### PR TITLE
CLI Error Handling

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -10,8 +10,9 @@ from distutils import dir_util
 from jinja2 import Environment, PackageLoader
 
 from linchpin.cli import LinchpinCli
-from linchpin.cli.context import LinchpinCliContext
 from linchpin.version import __version__
+from linchpin.exceptions import *
+from linchpin.cli.context import LinchpinCliContext
 
 
 pass_context = click.make_pass_decorator(LinchpinCliContext, ensure=True)
@@ -49,6 +50,38 @@ class LinchpinAliases(click.Group):
 
         rv = click.Group.get_command(self, ctx, cmd)
         return rv
+
+
+def _handle_results(ctx, results):
+    """
+    Handle results from the Ansible API. Either as a return value (retval)
+    when running with the ansible console enabled, or as a list of TaskResult
+    objects, and a return value.
+
+    If a target fails along the way, this method immediately exits with the
+    appropriate return value (retval). If the ansible console is disabled, an
+    error message will be printed before exiting.
+
+    :param results:
+        The dictionary of results for each target.
+    """
+
+    retval = 0
+
+    for k,v in results.iteritems():
+        if not isinstance(v, int):
+            trs, retval = v
+
+            if retval and trs is not None:
+                trs.reverse()
+                tr = trs[0]
+                msg = tr._check_key('msg')
+                ctx.log_state("{0} failed with error '{1}'".format(
+                                                        tr._task,
+                                                        msg))
+                sys.exit(retval)
+        else:
+            if v: sys.exit(v)
 
 
 @click.command(cls=LinchpinAliases,
@@ -112,22 +145,29 @@ def init(ctx):
 
     pf_w_path = os.path.realpath('{0}/{1}'.format(ws, pf))
 
-    src = ctx.cfgs['init']['source']
+    src = ctx.get_cfg('init', 'source', 'templates/')
     src_w_path = os.path.realpath('{0}/{1}'.format(ctx.lib_path, src))
 
     src_pf = os.path.realpath('{0}.lp_example'.format(pf_w_path))
 
-    if os.path.exists(pf_w_path):
-        if not click.confirm(
-            '{0} already exists, overwrite it?'.format(pf_w_path),
-            default=False):
-            sys.exit(0)
+    try:
 
-    dir_util.copy_tree(src_w_path, ws, verbose=1)
-    os.rename(src_pf, pf_w_path)
+        if os.path.exists(pf_w_path):
+            if not click.confirm(
+                '{0} already exists, overwrite it?'.format(pf_w_path),
+                default=False):
+                sys.exit(0)
 
-    ctx.log_state('{0} and file structure created at {1}'.format(
-        ctx.pinfile, ctx.workspace))
+        dir_util.copy_tree(src_w_path, ws, verbose=1)
+        os.rename(src_pf, pf_w_path)
+
+        ctx.log_state('{0} and file structure created at {1}'.format(
+            ctx.pinfile, ctx.workspace))
+
+    except Exception as e:
+        ctx.log_state('Error: {0}'.format(e))
+        sys.exit(1)
+
 
 
 @runcli.command()
@@ -145,7 +185,7 @@ def up(ctx, pinfile, targets):
     :param pinfile:
         path to pinfile (Default: ctx.workspace)
 
-    :param targets
+    :param targets:
         Provision ONLY the listed target(s). If omitted, ALL targets in the
         appropriate PinFile will be provisioned.
     """
@@ -156,11 +196,19 @@ def up(ctx, pinfile, targets):
     pf_w_path = '{0}/{1}'.format(ctx.workspace, pinfile)
 
     if not os.path.exists(pf_w_path):
-        return ctx.log_state('{0} not found in provided workspace: '
+        ctx.log_state('{0} not found in provided workspace: '
             '{1}'.format(pinfile, ctx.workspace))
+        sys.exit(1)
 
     lpcli = LinchpinCli(ctx)
-    lpcli.lp_up(pf_w_path, targets)
+    try:
+        results = lpcli.lp_up(pf_w_path, targets)
+
+        _handle_results(ctx, results)
+
+    except LinchpinError as e:
+        ctx.log_state(e)
+        sys.exit(1)
 
 
 @runcli.command()
@@ -195,7 +243,7 @@ def destroy(ctx, pinfile, targets):
 
     :param targets:
         Destroy ONLY the listed target(s). If omitted, ALL targets in the
-        appropriate Pinfile will be destroyed.
+        appropriate PinFile will be destroyed.
 
     """
 
@@ -209,7 +257,14 @@ def destroy(ctx, pinfile, targets):
             '{1}'.format(pinfile, ctx.workspace))
 
     lpcli = LinchpinCli(ctx)
-    lpcli.lp_destroy(pf_w_path, targets)
+    try:
+        results = lpcli.lp_destroy(pf_w_path, targets)
+
+        _handle_results(ctx, results)
+
+    except LinchpinError as e:
+        ctx.log_state(e)
+        sys.exit(1)
 
 
 @runcli.command()

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -70,16 +70,18 @@ def _handle_results(ctx, results):
 
     for k,v in results.iteritems():
         if not isinstance(v, int):
-            trs, retval = v
+            trs = v
 
-            if retval and trs is not None:
+            if trs is not None:
                 trs.reverse()
                 tr = trs[0]
-                msg = tr._check_key('msg')
-                ctx.log_state("{0} failed with error '{1}'".format(
-                                                        tr._task,
-                                                        msg))
-                sys.exit(retval)
+                if tr.is_failed():
+                    msg = tr._check_key('msg')
+                    ctx.log_state("Target '{0}': {1} failed with error '{2}'".format(
+                                                            k,
+                                                            tr._task,
+                                                            msg))
+                    sys.exit(retval)
         else:
             if v: sys.exit(v)
 
@@ -261,6 +263,9 @@ def destroy(ctx, pinfile, targets):
         results = lpcli.lp_destroy(pf_w_path, targets)
 
         _handle_results(ctx, results)
+
+        for target in targets:
+            ctx.log_state('Target {0} is destroyed'.format(target))
 
     except LinchpinError as e:
         ctx.log_state(e)

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -200,11 +200,19 @@ class LinchpinAPI(object):
                                             self.get_evar('resources_folder',
                                                     default='resources')))
 
-        self.set_evar('inventory_dir', '{0}/{1}'.format(
+        # playbooks still use this var, keep it here
+        self.set_evar('default_inventories_path', '{0}/{1}'.format(
                                         self.ctx.workspace,
                                         self.get_evar('inventories_folder',
                                                 default='inventories')))
+
+        # add this because of magic_var evaluation in ansible
+        self.set_evar('inventory_dir', self.get_evar(
+                                        'default_inventories_path',
+                                        default='inventories'))
+
         self.set_evar('state', 'present')
+
 
         if playbook == 'destroy':
             self.set_evar('state', 'absent')
@@ -218,7 +226,7 @@ class LinchpinAPI(object):
         elif len(targets) == 0:
             targets = set(pf.keys()).difference()
         else:
-            raise  LinchpinError("One or more Invalid targets found")
+            raise LinchpinError("One or more Invalid targets found")
 
 
         for target in targets:
@@ -372,7 +380,7 @@ class LinchpinAPI(object):
                               variable_manager=variable_manager,
                               host_list=[])
         passwords = {}
-        utils.VERBOSITY = 4
+        #utils.VERBOSITY = 4
 
         Options = namedtuple('Options', ['listtags',
                                          'listtasks',
@@ -409,7 +417,7 @@ class LinchpinAPI(object):
                           become=False,
                           become_method='sudo',
                           become_user='root',
-                          verbosity=utils.VERBOSITY,
+                          verbosity=0,
                           check=False)
 
         pbex = PlaybookExecutor(playbooks=[playbook_path],
@@ -424,6 +432,8 @@ class LinchpinAPI(object):
             pbex._tqm._stdout_callback = cb
             return_code = pbex.run()
             results = cb.results
+
+            return results, return_code
         else:
             results = pbex.run()
 

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -142,6 +142,7 @@ class LinchpinAPI(object):
 
         self._hook_observers.append(callback)
 
+
     def set_magic_vars(self):
         """
         Function inbuilt to set magic vars for ansible context
@@ -225,6 +226,7 @@ class LinchpinAPI(object):
                                                         target, playbook))
             self.set_evar('topology', self.find_topology(
                     pf[target]["topology"]))
+
             if 'layout' in pf[target]:
                 self.set_evar('layout_file', (
                     '{0}/{1}/{2}'.format(self.ctx.workspace,
@@ -347,7 +349,7 @@ class LinchpinAPI(object):
         if topology in topos:
             return os.path.realpath('{0}/{1}'.format(topo_path, topology))
 
-        return None
+        raise LinchpinError('Topology {0} not found in workspace'.format(topology))
 
 
     def _invoke_playbook(self, playbook='up', console=True):

--- a/linchpin/provision/roles/common/tasks/main.yml
+++ b/linchpin/provision/roles/common/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: "load ini evars from linchpin.conf"
   include: load_evars_from_ini.yml
   when: from_api is not defined
- 
+
 - name: "if topology_file is passed, set topology to its value"
   set_fact:
     topology: "{{ topology_file }}"

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,3 +1,3 @@
 __short_version__ = '1.0.0'
-__release_version__ = 'b1'
-__version__ = '1.0.0b1'
+__release_version__ = 'b2'
+__version__ = '1.0.0b2'


### PR DESCRIPTION
Fixes #254 and #159 

The `lp_up()` and `lp_destroy` methods now throw exceptions when invalid data is passed. This allows the command-line interface to catch these exceptions and process them appropriately, usually with a `sys.exit(1)`.

If an error occurs during a playbook run, the return value is passed back from Ansible and assigned to `retval`. The CLI calls sys.exit(retval) appropriately in the `_handle_results` method.