### PR TITLE
Fixes #263/#267: linchpin destroy after 1.0 upgrade

### DIFF
--- a/docs/source/release/RELEASE_1_0_0.rst
+++ b/docs/source/release/RELEASE_1_0_0.rst
@@ -10,7 +10,7 @@ Enhancements
 
 - Beaker provisioner
 
-- Convert from lincnpin_config.yml to linchpin.conf
+- Convert from linchpin_config.yml to linchpin.conf
   - Add tooling to load configurations from linchpin.conf
 
 - LinchPin Context to manage environment

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -473,7 +473,8 @@ class LinchpinAPI(object):
             return return_code, results
         else:
             # the console only returns a return_code
-            return pbex.run()
+            return_code = pbex.run()
+            return return_code, None
 
 
 #    def lp_topo_list(self, upstream=None):


### PR DESCRIPTION
Linchpin now handles the return from _invoke_linchpin correctly by providing
a tuple for both ansible.console cases.