### PR TITLE
Clean up schemas

### DIFF
--- a/linchpin/defaults/schemas/schema_v3.json
+++ b/linchpin/defaults/schemas/schema_v3.json
@@ -60,10 +60,10 @@
                 "keypair": {
                     "type":"string"
                 },
-		            "fip_pool": {
-		                "type":"string"
-		            },
-		            "security_groups": {
+                    "fip_pool": {
+                        "type":"string"
+                    },
+                    "security_groups": {
                     "type":"string"
                 }
             },
@@ -644,17 +644,17 @@
                     "description":"contains creds file associated to this resource",
                     "type":"string"
                 },
-		"credentials": {
-	            "type": "object",
-		    "properties":{
-		        "name": {
-			  "type": "string"
-			},
-			"auth_type": {
-			  "type": "string"
-			}
-		    }
-		}
+                "credentials": {
+                    "type": "object",
+                    "properties":{
+                        "name": {
+                      "type": "string"
+                    },
+                    "auth_type": {
+                      "type": "string"
+                    }
+                }
+            }
             },
             "required":["resource_group_name","res_group_type","res_defs"],
             "additionalProperties": true

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -52,10 +52,10 @@
                 "keypair": {
                     "type":"string"
                 },
-		            "fip_pool": {
-		                "type":"string"
-		            },
-		            "security_groups": {
+                    "fip_pool": {
+                        "type":"string"
+                    },
+                    "security_groups": {
                     "type":"string"
                 }
             },
@@ -690,24 +690,9 @@
                                 {"$ref": "#/definitions/os_sg"}
                              ]
                     }
-                },
-                "credentials": {
-                    "description":"contains creds file associated to this resource",
-                    "type":"object",
-		    "properties": {
-	                "profile": {
-			  "type": "string"
-			},
-		        "auth_type": {
-		          "type": "string"
-			},
-			"name": {
-			  "type": "string"
-			}
-		    }
                 }
             },
-            "required":["resource_group_name","resource_group_type","resource_definitions","credentials"],
+            "required":["resource_group_name","resource_group_type","resource_definitions"],
             "additionalProperties": true
         },
         "aws": {
@@ -732,24 +717,9 @@
                                 {"$ref": "#/definitions/aws_sg"}
                             ]
                     }
-                },
-                "credentials": {
-                    "description":"contains creds file associated to this resource",
-		    "type":"object",
-                    "properties": {
-                        "profile": {
-                          "type": "string"
-                        },
-                        "auth_type": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                    }
                 }
             },
-            "required":["resource_group_name","resource_group_type","resource_definitions","credentials"],
+            "required":["resource_group_name","resource_group_type","resource_definitions"],
             "additionalProperties": true
         },
         "gcloud": {
@@ -770,21 +740,9 @@
                                 {"$ref": "#/definitions/gcloud_gce"}
                             ]
                     }
-                },
-                "credentials": {
-                    "description":"contains creds file associated to this resource",
-                    "type":"object",
-		    "properties": {
-                        "auth_type": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                    }
                 }
             },
-            "required":["resource_group_name","resource_group_type","resource_definitions","credentials"],
+            "required":["resource_group_name","resource_group_type","resource_definitions"],
             "additionalProperties": true
         },
         "duffy": {
@@ -834,10 +792,6 @@
                             {"$ref": "#/definitions/libvirt_network"}
                         ]
                     }
-                },
-                "assoc_creds": {
-                    "description":"contains creds file associated to this resource",
-                    "type":"string"
                 }
             },
             "required":["resource_group_name","resource_group_type","resource_definitions"],
@@ -861,13 +815,9 @@
                                 {"$ref": "#/definitions/rax_server"}
                             ]
                     }
-                },
-                "credentials": {
-                    "description":"contains creds file associated to this resource",
-                    "type":"string"
                 }
             },
-            "required":["resource_group_name","resource_group_type","resource_definitions","credentials"],
+            "required":["resource_group_name","resource_group_type","resource_definitions"],
             "additionalProperties": true
         }
     }

--- a/scripts/create_pypi_package.sh
+++ b/scripts/create_pypi_package.sh
@@ -15,6 +15,7 @@ if [ $# -lt 1 ]; then
 fi
 
 PROMPT=1
+LP_PATH=${1}
 
 PKG_TYPES="sdist bdist_wheel"
 SETUP_CMD="python setup.py"
@@ -24,11 +25,16 @@ UPLOAD_CMD="${PKG_TYPES} upload"
 
 # find extraneous files and remove them
 CRUFTIES=('coverage.xml' 'linchpin.log')
+CRUFTY_DIRS=('linchpin.egg-info' 'build' 'dist' 'docs/build' 'provision/outputs')
 
 echo "REMOVING CRUFTY FILES"
 
 for CRUFT in "${CRUFTIES[@]}"; do
-    find -name "${CRUFT}" -delete
+    find ${LP_PATH} -name "${CRUFT}" -delete
+done
+
+for CRUFT_DIR in "${CRUFTY_DIRS[@]}"; do
+    rm -rf ${LP_PATH}/${CRUFT_DIR}
 done
 
 CLEAN="${SETUP_CMD} ${CLEAN_CMD}"


### PR DESCRIPTION
Fixes #267 

Addresses the credentials compatibility in schema_v4. Since LinchPin has moved away from managing credentials in the topology, and moved it back to the provider's preferred way (with minor exception eg. duffy), credentials is no longer needed in most cases.

If a user would like to use credentials and store them in a central place, the `--creds-path` option can be passed on the command-line.