### PR TITLE
Rework credentials (general) / inventory generation (openstack)

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -122,14 +122,11 @@ def runcli(ctx, config, workspace, verbose, version, creds_path):
         ctx.workspace = os.getenv('PWD')
 
     if creds_path is not None:
-        ctx.creds_path = os.path.realpath(os.path.expanduser(creds_path))
-    else:
-        ctx.creds_path = str(None)
+        ctx.set_evar('creds_path', os.path.realpath(os.path.expanduser(creds_path)))
 
     ctx.log_debug("ctx.workspace: {0}".format(ctx.workspace))
-    ctx.log_debug("ctx.creds_path: {0}".format(ctx.creds_path))
 
-    ctx.pinfile = ctx.cfgs['init']['pinfile']
+    ctx.pinfile = ctx.get_cfg('init', 'pinfile', default='PinFile')
 
 
 @runcli.command('init', short_help='Initializes a linchpin project.')

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -213,8 +213,6 @@ class LinchpinAPI(object):
         if self.ctx.cfgs.get('ansible'):
             ansible_console = ast.literal_eval(self.ctx.cfgs['ansible'].get('console', 'False'))
 
-        self.set_evar('creds_path', self.ctx.creds_path)
-
         if not ansible_console:
             ansible_console = self.ctx.verbose
 

--- a/linchpin/api/context.py
+++ b/linchpin/api/context.py
@@ -40,7 +40,6 @@ class LinchpinContext(object):
         self.lib_path = os.path.realpath(os.path.join(lib_path, os.pardir))
 
         self.workspace = os.path.realpath(os.path.curdir)
-        self.creds_path = None
 
 
     def load_config(self, lpconfig=None):

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -690,7 +690,19 @@
                                 {"$ref": "#/definitions/os_sg"}
                              ]
                     }
-                }
+                },
+                "credentials": {
+                    "description":"contains credentials associated to this resource",
+                    "type":"object",
+                     "properties": {
+                         "auth_type": {
+                           "type": "string"
+                         },
+                         "name": {
+                           "type": "string"
+                         }
+                     }
+                 }
             },
             "required":["resource_group_name","resource_group_type","resource_definitions"],
             "additionalProperties": true
@@ -717,6 +729,21 @@
                                 {"$ref": "#/definitions/aws_sg"}
                             ]
                     }
+                },
+                "credentials": {
+                    "description":"contains credentials associated to this resource",
+                    "type":"object",
+                    "properties": {
+                        "profile": {
+                          "type": "string"
+                        },
+                        "auth_type": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                    }
                 }
             },
             "required":["resource_group_name","resource_group_type","resource_definitions"],
@@ -739,6 +766,18 @@
                             [
                                 {"$ref": "#/definitions/gcloud_gce"}
                             ]
+                    }
+                },
+                "credentials": {
+                    "description":"contains credentials associated to this resource",
+                    "type":"object",
+                    "properties": {
+                        "auth_type": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
                     }
                 }
             },
@@ -765,7 +804,7 @@
                     }
                 },
                 "credentials": {
-                    "description":"contains creds file associated to this resource",
+                    "description":"contains credentials associated to this resource",
                     "type":"string"
                 }
             },
@@ -815,6 +854,10 @@
                                 {"$ref": "#/definitions/rax_server"}
                             ]
                     }
+                },
+                "credentials":{
+                    "description":"contains credentials associated with this resource",
+                    "type":"string"
                 }
             },
             "required":["resource_group_name","resource_group_type","resource_definitions"],

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -698,7 +698,7 @@
                          "auth_type": {
                            "type": "string"
                          },
-                         "name": {
+                         "filename": {
                            "type": "string"
                          }
                      }

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -740,7 +740,7 @@
                         "auth_type": {
                           "type": "string"
                         },
-                        "name": {
+                        "filename": {
                           "type": "string"
                         }
                     }
@@ -775,7 +775,7 @@
                         "auth_type": {
                           "type": "string"
                         },
-                        "name": {
+                        "filename": {
                           "type": "string"
                         }
                     }

--- a/linchpin/linchpin.conf
+++ b/linchpin/linchpin.conf
@@ -23,7 +23,6 @@ async = False
 async_timeout = 1000
 output = True
 check_mode = False
-creds_path = None
 # default paths in playbooks
 #
 # lp_path = <src_dir>/linchpin

--- a/linchpin/linchpin.conf
+++ b/linchpin/linchpin.conf
@@ -47,9 +47,9 @@ default_schemas_path = {{ lp_path }}/defaults/%(schemas_folder)s
 default_topologies_path = {{ lp_path }}/defaults/%(topologies_folder)s
 default_layouts_path = {{ lp_path }}/defaults/%(layouts_folder)s
 
-# outputs
-default_resources_path = {{ lp_path }}/defaults/%(resources_folder)s # formerly outputs
-inventory_dir = {{ lp_path }}/defaults/%(inventories_folder)s
+# resources, formerly outputs
+default_resources_path = {{ lp_path }}/defaults/%(resources_folder)s
+default_inventories_path = {{ lp_path }}/defaults/%(inventories_folder)s
 
 # default_schema interpolates the default_schemas_path from above
 schema_v3 = %(default_schemas_path)s/schema_v3.json

--- a/linchpin/provision/InventoryFilters/GenericInventory.py
+++ b/linchpin/provision/InventoryFilters/GenericInventory.py
@@ -46,7 +46,7 @@ class GenericInventory(InventoryFilter):
     def get_hosts_by_count(self, host_dict, count):
         """
         currently this function gets all the ips/hostname according to the
-        order in which inventories are specified , later can be modified
+        order in which inventories are specified. later can be modified
         to work with user input
         """
         all_hosts = []
@@ -75,3 +75,4 @@ class GenericInventory(InventoryFilter):
         output = StringIO.StringIO()
         self.config.write(output)
         return output.getvalue()
+

--- a/linchpin/provision/InventoryFilters/OpenstackInventory.py
+++ b/linchpin/provision/InventoryFilters/OpenstackInventory.py
@@ -17,11 +17,12 @@ class OpenstackInventory(InventoryFilter):
     def get_host_ips(self, topo):
         host_public_ips = []
         for group in topo['os_server_res']:
-            if isinstance(group['openstack'], list):
-                for server in group['openstack']:
+            grp = group.get('openstack', [])
+            if isinstance(grp, list):
+                for server in grp:
                     host_public_ips.append(str(server['accessIPv4']))
-            if isinstance(group['openstack'], dict):
-                host_public_ips.append(str(group['openstack']['accessIPv4']))
+            if isinstance(grp, dict):
+                host_public_ips.append(str(grp['accessIPv4']))
         return host_public_ips
 
     def get_inventory(self, topo, layout):

--- a/linchpin/provision/library/auth_driver.py
+++ b/linchpin/provision/library/auth_driver.py
@@ -30,7 +30,7 @@ options:
     description:
       defaults to file type. 
     required: true
-      
+
 author: Samvaran Kashyap Rallabandi -
 '''
 
@@ -58,8 +58,10 @@ class ConfigDict(ConfigParser.ConfigParser):
             d[k].pop('__name__', None)
         return d
 
+
 def list_files(path):
     return glob.glob(path+"/*.*")
+
 
 def parse_file(filename):
     cred_str = open(filename, "r").read()
@@ -79,7 +81,9 @@ def parse_file(filename):
                 module.fail_json(msg= "Error  {0} ".format(str(e)))
     return out
 
+
 def get_cred(name, creds_path):
+
     paths = creds_path.split(";")
     files = []
     for path in paths:
@@ -88,8 +92,12 @@ def get_cred(name, creds_path):
             if name == filename.split("/")[-1].split(".")[0]:
                 out = parse_file(filename)
                 return out, path
+
     module.fail_json(msg= "Error: Credential not found")
+
+
 def main():
+
     global module
     module = AnsibleModule(
     argument_spec={

--- a/linchpin/provision/library/auth_driver.py
+++ b/linchpin/provision/library/auth_driver.py
@@ -43,6 +43,7 @@ import shlex
 import tempfile
 import yaml
 import glob
+
 try:
     import configparser as ConfigParser
 except ImportError:
@@ -57,10 +58,6 @@ class ConfigDict(ConfigParser.ConfigParser):
             d[k] = dict(self._defaults, **d[k])
             d[k].pop('__name__', None)
         return d
-
-
-def list_files(path):
-    return glob.glob(path+"/*.*")
 
 
 def parse_file(filename):
@@ -84,13 +81,14 @@ def parse_file(filename):
 
 def get_cred(name, creds_path):
 
-    paths = creds_path.split(";")
+    paths = creds_path.split(os.path.pathsep)
     files = []
     for path in paths:
-        files = list_files(path)
-        for filename in files:
-            if name == filename.split("/")[-1].split('.')[0]:
-                out = parse_file(filename)
+        path = os.path.realpath(os.path.expanduser(path))
+        for filename in os.listdir(path):
+            if name == os.path.splitext(filename)[0]:
+                full_file_path = '{0}/{1}'.format(path, filename)
+                out = parse_file(full_file_path)
                 return out, path
 
     module.fail_json(msg= "Error: Credential not found")

--- a/linchpin/provision/library/auth_driver.py
+++ b/linchpin/provision/library/auth_driver.py
@@ -89,7 +89,7 @@ def get_cred(name, creds_path):
     for path in paths:
         files = list_files(path)
         for filename in files:
-            if name == filename.split("/")[-1].split(".")[0]:
+            if name == filename.split("/")[-1].split('.')[0]:
                 out = parse_file(filename)
                 return out, path
 
@@ -101,19 +101,19 @@ def main():
     global module
     module = AnsibleModule(
     argument_spec={
-            'name':     {'required': True, 'aliases': ['name']},
-            'cred_type':     {'required': False, 'aliases': ['credential_type']},
+            'filename': {'required': True, 'aliases': ['name']},
+            'cred_type': {'required': False, 'aliases': ['credential_type']},
             'cred_path': {'required': True, 'aliases': ['credential_store']},
             'driver': {'required': True, 'aliases': ['driver_type']},
         },
         required_one_of=[],
         supports_check_mode=True
     )
-    name = module.params["name"]
+    filename = module.params["filename"]
     cred_type = module.params["cred_type"]
     cred_path = module.params["cred_path"]
     driver_type = module.params["driver"]
-    output, path = get_cred(name, cred_path)
+    output, path = get_cred(filename, cred_path)
     changed = True
     module.exit_json(changed=changed, output=output, params=module.params, path=path)
 

--- a/linchpin/provision/library/auth_driver.py
+++ b/linchpin/provision/library/auth_driver.py
@@ -79,14 +79,14 @@ def parse_file(filename):
     return out
 
 
-def get_cred(name, creds_path):
+def get_cred(fname, creds_path):
 
     paths = creds_path.split(os.path.pathsep)
     files = []
     for path in paths:
         path = os.path.realpath(os.path.expanduser(path))
         for filename in os.listdir(path):
-            if name == os.path.splitext(filename)[0]:
+            if fname == filename:
                 full_file_path = '{0}/{1}'.format(path, filename)
                 out = parse_file(full_file_path)
                 return out, path

--- a/linchpin/provision/roles/aws/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_resource_group.yml
@@ -12,7 +12,7 @@
 
 - name: "Get creds from auth driver"
   auth_driver:
-    name: "{{ res_grp['credentials']['name']  }}"
+    filename: "{{ res_grp['credentials']['filename']  }}"
     cred_type: "aws"
     cred_path: "{{ creds_path }}"
     driver: "file"

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -8,7 +8,7 @@
 
 - name: "Get creds from auth driver"
   auth_driver:
-    name: "{{ res_grp['credentials']['name']  }}"
+    filename: "{{ res_grp['credentials']['filename']  }}"
     cred_type: "aws"
     cred_path: "{{ creds_path }}"
     driver: "file"

--- a/linchpin/provision/roles/common/tasks/load_evars_from_ini.yml
+++ b/linchpin/provision/roles/common/tasks/load_evars_from_ini.yml
@@ -68,9 +68,9 @@
   when: workspace is defined
 
 
-#- name: evars_tmp
+#- name: evars_ini
 #  debug:
-#    var: evars_tmp
+#    var: evars_ini
 
 #- fail:
 #    msg: "stopping execution for now"

--- a/linchpin/provision/roles/gcloud/tasks/provision_gcloud_gce.yml
+++ b/linchpin/provision/roles/gcloud/tasks/provision_gcloud_gce.yml
@@ -27,7 +27,7 @@
     state: "{{ state }}"
     service_account_email: "{{ auth_var['output']['client_email'] }}"
     credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['filename'] }}"
-    project_id: "{{ auth_var['project_id'] }}"
+    project_id: "{{ auth_var['output']['project_id'] }}"
   register: res_def_output
   when: async
   async: "{{ async_timeout }}"

--- a/linchpin/provision/roles/gcloud/tasks/provision_gcloud_gce.yml
+++ b/linchpin/provision/roles/gcloud/tasks/provision_gcloud_gce.yml
@@ -7,7 +7,7 @@
     image: "{{ res_def['image']  }}"
     state: "{{ state }}"
     service_account_email: "{{ auth_var['output']['client_email'] }}"
-    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['filename'] }}.json"
+    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['filename'] }}"
     project_id: "{{ auth_var['output']['project_id'] }}"
   register: res_def_output
   when: not async
@@ -26,8 +26,8 @@
     image: "{{ res_def['image']  }}"
     state: "{{ state }}"
     service_account_email: "{{ auth_var['output']['client_email'] }}"
-    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['filename'] }}.json"
-    project_id: "{{ auth_var['output']['project_id'] }}"
+    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['filename'] }}"
+    project_id: "{{ auth_var['project_id'] }}"
   register: res_def_output
   when: async
   async: "{{ async_timeout }}"

--- a/linchpin/provision/roles/gcloud/tasks/provision_gcloud_gce.yml
+++ b/linchpin/provision/roles/gcloud/tasks/provision_gcloud_gce.yml
@@ -7,7 +7,7 @@
     image: "{{ res_def['image']  }}"
     state: "{{ state }}"
     service_account_email: "{{ auth_var['output']['client_email'] }}"
-    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['name'] }}.json"
+    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['filename'] }}.json"
     project_id: "{{ auth_var['output']['project_id'] }}"
   register: res_def_output
   when: not async
@@ -26,7 +26,7 @@
     image: "{{ res_def['image']  }}"
     state: "{{ state }}"
     service_account_email: "{{ auth_var['output']['client_email'] }}"
-    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['name'] }}.json"
+    credentials_file: "{{ auth_var['path'] }}/{{ auth_var['params']['filename'] }}.json"
     project_id: "{{ auth_var['output']['project_id'] }}"
   register: res_def_output
   when: async

--- a/linchpin/provision/roles/gcloud/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/gcloud/tasks/provision_resource_group.yml
@@ -12,7 +12,7 @@
 
 - name: "Get creds from auth driver"
   auth_driver:
-    name: "{{ res_grp['credentials']['name']  }}"
+    filename: "{{ res_grp['credentials']['filename']  }}"
     cred_type: "gcloud"
     cred_path: "{{ creds_path }}"
     driver: "file"

--- a/linchpin/provision/roles/gcloud/vars/ex_gcloud_creds.yml
+++ b/linchpin/provision/roles/gcloud/vars/ex_gcloud_creds.yml
@@ -1,4 +1,0 @@
---- # gcloud credentials example
-service_account_email: "XXXXXXXXXXXXXXX.iam.gserviceaccount.com" 
-project_id: "XXXXXXXXXXXXXX" 
-credentials_file: "absolute_path_to_json_file"

--- a/linchpin/provision/roles/inventory_gen/tasks/main.yml
+++ b/linchpin/provision/roles/inventory_gen/tasks/main.yml
@@ -25,11 +25,15 @@
   set_fact:
     inventory_layout: "{{ layout_file | default( default_layouts_path+'/'+'openshift-3node-cluster.yml') | ordered_yaml }}"
 
-- name: "Updating inventory_file with the absolute path"
+- name: "Updating inventory_path with the absolute path"
   set_fact:
-    inventory_file: "{{ inventory_file | default( inventory_dir+'/'+outputs.topology_name ) }}"
+    inventory_path: "{{ inventory_path | default( default_inventories_path+'/'+outputs.topology_name ) }}.inventory"
+
+#- name: inventory_layout
+#  debug:
+#    var: inventory_layout
 
 - name: "Generate Generic Inventory"
   template:
     src: "templates/generic_inventory_formatter.j2"
-    dest: "{{ inventory_file }}"
+    dest: "{{ inventory_path }}"

--- a/linchpin/provision/roles/openstack/tasks/main.yml
+++ b/linchpin/provision/roles/openstack/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 # This playbook will initiate provisioning for the openstack resources groups.
-- name: "DEBUG:: Openstack resource group list"
-  debug:
-    msg: "Currently Provisioning/Deprovisioning the resources under list os_res_grps {{ os_res_grps }}"
+#- name: "DEBUG:: Openstack resource group list"
+#  debug:
+#    msg: "Currently Provisioning/Deprovisioning the resources under list os_res_grps {{ os_res_grps }}"
 
 - name: "declaring output vars"
   set_fact:

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -1,20 +1,20 @@
-- name: "provision/deprovision os_server resources by looping on count"
+- name: "provisioning os_server resources with provided auth"
   os_server2:
     state: "{{ state }}"
-    auth: "{{ auth_var | default(omit) }}"
+    auth: "{{ auth_var }}"
     name: "{{ res_grp_name }}_{{ res_def['res_name'] | default(res_def['name']) }}"
     image: "{{ res_def['image'] }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
     flavor: "{{ res_def['flavor'] }}"
-    nics:  "{{ res_def['networks'] | os_net }}"
+    nics:  "{{ res_def['networks'] | default(omit) | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
-  when: not async and auth_var['changed'] == true
+  when: not async and auth_var is defined
   register: res_def_output
 
-- name: "provision/deprovision os_server resources by looping on count"
+- name: "provisioning os_server resources"
   os_server2:
     state: "{{ state }}"
     name: "{{ res_grp_name }}_{{ res_def['res_name'] | default(res_def['name']) }}"
@@ -26,7 +26,7 @@
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
-  when: not async and auth_var['changed'] == false
+  when: not async and auth_var is not defined
   register: res_def_output
 
 - name: "Append outputitem to topology_outputs"

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -22,7 +22,7 @@
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
     flavor: "{{ res_def['flavor'] }}"
-    nics:  "{{ res_def['networks'] | os_net }}"
+    nics:  "{{ res_def['networks'] | default(omit) | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     count: "{{ res_def['count'] }}"

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -11,8 +11,13 @@
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
-  when: not async and auth_var is defined
   register: res_def_output
+  when: not async and auth_var is defined
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_server: "{{ topology_outputs_os_server + [res_def_output] }}"
+  when: not async and auth_var is defined
 
 - name: "provisioning os_server resources"
   os_server2:
@@ -26,13 +31,13 @@
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
-  when: not async and auth_var is not defined
   register: res_def_output
+  when: not async and auth_var is not defined
 
 - name: "Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server + [res_def_output] }}"
-  when: not async
+  when: not async and auth_var is not defined
 
 - name: "provision/deprovision os_server resources by looping on count"
   os_server2:
@@ -50,7 +55,12 @@
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output
-  when: async and auth_var['changed'] == true
+  when: async and auth_var is defined
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_server: "{{ topology_outputs_os_server + [res_def_output] }}"
+  when: not async and auth_var is defined
 
 - name: "provision/deprovision os_server resources by looping on count"
   os_server2:
@@ -67,8 +77,7 @@
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output
-  when: async and auth_var['changed'] == false 
-
+  when: async and auth_var is not defined
 
 # following tasks saves the async job details
 - name: "Async:: save the job id"

--- a/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -5,28 +5,29 @@
 
 - name: "set default_cred_profile when res_grp[credentials] is undefined"
   set_fact:
-    cred_profile: "{{ cred_profile | default({}) | combine({ cred: 'default' }) }}"
-  with_items:
-    - 'name'
-    - 'profile'
-  loop_control:
-    loop_var: cred
+    cred_profile: 'default'
   when: res_grp['credentials'] is not defined
+
+- name: "set default_cred_profile when res_grp[credentials] is undefined"
+  set_fact:
+    cred_name: 'default'
+  when: res_grp['credentials'] is not defined
+
+- name: "set cred_profile when res_grp[credentials] is defined"
+  set_fact:
+    cred_profile: "{{ res_grp['credentials']['profile'] }}"
+  when: res_grp['credentials'] is defined
 
 - name: "set default_cred_profile when res_grp[credentials] is defined"
   set_fact:
-    cred_profile: "{{ res_grp['credentials']['name'] }}"
+    cred_name: "{{ res_grp['credentials']['name'] }}"
   when: res_grp['credentials'] is defined
-
-- name: cred_profile
-  debug:
-    var: cred_profile
 
 - name: "Get creds from auth driver"
   auth_driver:
-    name: "{{ cred_profile['name'] }}"
+    filename: "{{ cred_name }}" # don't include the .yaml
     cred_type: "openstack"
-    cred_path: "{{ creds_path | default('/tmp/clouds.yaml') }}"
+    cred_path: "{{ creds_path | default('~/.config/openstack/') }}"
     driver: "file"
   register: auth_var
   ignore_errors: true

--- a/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -6,9 +6,15 @@
   set_fact:
     auth_var: ""
 
+- name: "set cred profile to default"
+  set_fact:
+    cred_profile: "default"
+
 - name: "set cred profile"
   set_fact:
     cred_profile: "{{ res_grp['credentials']['profile'] | default('default') }}"
+  when: res_grp['credentials'] is defined
+
 
 - name: "Get creds from auth driver"
   auth_driver:
@@ -18,11 +24,13 @@
     driver: "file"
   register: auth_var
   ignore_errors: true
+  when: cred_profile != 'default'
 
 - name: "set auth_var "
   set_fact:
     auth_var: "{{ auth_var['output']['clouds'][cred_profile]['auth'] | default(omit) }}"
   ignore_errors: true
+  when: cred_profile != 'default'
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}

--- a/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -10,7 +10,7 @@
 
 - name: "set default_cred_profile when res_grp[credentials] is undefined"
   set_fact:
-    cred_name: 'default'
+    cred_filename: 'clouds.yaml'
   when: res_grp['credentials'] is not defined
 
 - name: "set cred_profile when res_grp[credentials] is defined"
@@ -18,14 +18,14 @@
     cred_profile: "{{ res_grp['credentials']['profile'] }}"
   when: res_grp['credentials'] is defined
 
-- name: "set default_cred_profile when res_grp[credentials] is defined"
+- name: "set default_cred_filename when res_grp[credentials] is defined"
   set_fact:
-    cred_name: "{{ res_grp['credentials']['name'] }}"
+    cred_filename: "{{ res_grp['credentials']['filename'] }}"
   when: res_grp['credentials'] is defined
 
 - name: "Get creds from auth driver"
   auth_driver:
-    filename: "{{ cred_name }}" # don't include the .yaml
+    filename: "{{ cred_filename }}" # don't include the .yaml
     cred_type: "openstack"
     cred_path: "{{ creds_path | default('~/.config/openstack/') }}"
     driver: "file"

--- a/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -1,36 +1,40 @@
-- name: "DEBUG:: provisioning resource group {{ res_grp }}"
-  debug:
-    msg: "The current server obj is {{ res_grp }} "
-
+---
 - name: "Unset the authvar from previous run"
   set_fact:
     auth_var: ""
 
-- name: "set cred profile to default"
+- name: "set default_cred_profile when res_grp[credentials] is undefined"
   set_fact:
-    cred_profile: "default"
+    cred_profile: "{{ cred_profile | default({}) | combine({ cred: 'default' }) }}"
+  with_items:
+    - 'name'
+    - 'profile'
+  loop_control:
+    loop_var: cred
+  when: res_grp['credentials'] is not defined
 
-- name: "set cred profile"
+- name: "set default_cred_profile when res_grp[credentials] is defined"
   set_fact:
-    cred_profile: "{{ res_grp['credentials']['profile'] | default('default') }}"
+    cred_profile: "{{ res_grp['credentials']['name'] }}"
   when: res_grp['credentials'] is defined
 
+- name: cred_profile
+  debug:
+    var: cred_profile
 
 - name: "Get creds from auth driver"
   auth_driver:
-    name: "{{ res_grp['credentials']['name']  }}"
+    name: "{{ cred_profile['name'] }}"
     cred_type: "openstack"
-    cred_path: "{{ creds_path }}"
+    cred_path: "{{ creds_path | default('/tmp/clouds.yaml') }}"
     driver: "file"
   register: auth_var
   ignore_errors: true
-  when: cred_profile != 'default'
 
-- name: "set auth_var "
+- name: "set auth_var"
   set_fact:
-    auth_var: "{{ auth_var['output']['clouds'][cred_profile]['auth'] | default(omit) }}"
+    auth_var: "{{ auth_var['output']['clouds'][cred_profile]['auth'] }}"
   ignore_errors: true
-  when: cred_profile != 'default'
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}

--- a/linchpin/provision/roles/output_writer/tasks/main.yml
+++ b/linchpin/provision/roles/output_writer/tasks/main.yml
@@ -31,9 +31,9 @@
   when: not async
   ignore_errors: yes
 
-- name: "DEBUG:: topology_outputs"
-  debug:
-    msg: "{{ topology_outputs }}"
+#- name: "DEBUG:: topology_outputs"
+#  debug:
+#    msg: "{{ topology_outputs }}"
 
 - name: "Generate outputs when async is false"
   template:

--- a/linchpin/provision/roles/output_writer/tasks/update_os_server_outputs.yml
+++ b/linchpin/provision/roles/output_writer/tasks/update_os_server_outputs.yml
@@ -1,7 +1,7 @@
 - name: "register var for async_outputs_os_server"
   set_fact:
-    async_outputs_os_server: [] 
-  
+    async_outputs_os_server: []
+
 - name: "Wait on jobs"
   include: wait_on_os_server.yml
   vars:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pyopenssl
 boto>=2.40.0
 apache-libcloud>=0.20.1
 jsonschema>=2.5.1
-shade>=1.8.0
+shade>=1.8.0,!=1.21.0
 click
 tabulate
 camel


### PR DESCRIPTION
Fixes #274 
Fixes #275 

For openstack specifically, the default location for clouds.yaml to live is ~/.config/openstack/. A topology would be expressed in this way.

```
---
topology_name: os-test
resource_groups:
  -
    resource_group_name: lp-test
    resource_group_type: openstack
    resource_definitions:
      - name: resource
        type: os_server
        flavor: m1.small
        image: rhel-7.2-server-x86_64-released
        count: 1
        keypair: ci-factory
        networks:
          - atomic-e2e-jenkins-test
        fip_pool: 10.8.172.0/22
    credentials:
      filename: clouds.yaml
      profile: ci-osp
```
The clouds.yaml (with --creds-path or not) would look something like so.

```
---
clouds:
  default:
    auth:
      auth_url: http://dashboard.centralci.eng.rdu2.redhat.com:5000/v2.0/
      project_name: atomic-e2e-jenkins
      username: <redacted>
      password: <redacted>
  ci-osp:
    auth:
      auth_url: http://dashboard.centralci.eng.rdu2.redhat.com:5000/v2.0/
      project_name: atomic-e2e-jenkins-test
      username: <redacted>
      password: <redacted>
```

Since credentials management is now controlled at the API/CLI level, I mistakenly thought the credentials data didn't need to be there. However, because we still need to possibly pass a profile or some other data indicating which credentials will be used, I reverted it to allow the data to be handled properly. 

One adjustment was made to handle this scenario, which was to set the profile to default if no credentials were passed. Since it's now optional, default will be searched if no other value is passed.