### PR TITLE
Make a default path for credentials

### DIFF
--- a/linchpin/cli/context.py
+++ b/linchpin/cli/context.py
@@ -58,7 +58,7 @@ class LinchpinCliContext(LinchpinContext):
           * $PWD/linchpin.conf
           * ~/.linchpin.conf
           * /etc/linchpin.conf
-          * linchpin/library/path/linchpin.conf
+          * /linchpin/library/path/linchpin.conf
 
         Alternatively, a full path to the linchpin configuration file
         can be passed.

--- a/linchpin/linchpin.conf
+++ b/linchpin/linchpin.conf
@@ -55,6 +55,9 @@ default_inventories_path = {{ lp_path }}/defaults/%(inventories_folder)s
 schema_v3 = %(default_schemas_path)s/schema_v3.json
 schema_v4 = %(default_schemas_path)s/schema_v4.json
 
+# default credentials data, this path doesn't automatically exist
+default_credentials_path = ~/.config/linchpin
+
 #keystore_path: "{{ playbook_dir }}/../keystore"
 
 
@@ -102,7 +105,7 @@ console = False
 
 [states]
 # in future each state will carry a comma seperated substates
-preup = preup  
+preup = preup
 predestroy = predestroy
 postup = postup
 postdestroy = postdestroy

--- a/linchpin/provision/roles/aws/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_resource_group.yml
@@ -14,7 +14,7 @@
   auth_driver:
     filename: "{{ res_grp['credentials']['filename']  }}"
     cred_type: "aws"
-    cred_path: "{{ creds_path }}"
+    cred_path: "{{ creds_path | default(default_credentials_path) }}"
     driver: "file"
   register: auth_var
   ignore_errors: true

--- a/linchpin/provision/roles/common/tasks/load_evars_from_ini.yml
+++ b/linchpin/provision/roles/common/tasks/load_evars_from_ini.yml
@@ -47,6 +47,7 @@
     default_layouts_path: "{{ lookup('ini', 'default_layouts_path section=evars file={{ lpconfig }}') }}"
     default_resources_path: "{{ lookup('ini', 'default_resources_path section=evars file={{ lpconfig }}') }}"
     default_inventories_path: "{{ lookup('ini', 'default_inventories_path section=evars file={{ lpconfig }}') }}"
+    default_credentials_path: "{{ lookup('ini', 'default_credentials_path section=evars file={{ lpconfig }}') }}"
   when: workspace is not defined
 
 - name: set remaining evars from linchpin.conf

--- a/linchpin/provision/roles/gcloud/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/gcloud/tasks/provision_resource_group.yml
@@ -14,7 +14,7 @@
   auth_driver:
     filename: "{{ res_grp['credentials']['filename']  }}"
     cred_type: "gcloud"
-    cred_path: "{{ creds_path }}"
+    cred_path: "{{ creds_path | default(default_credentials_path) }}"
     driver: "file"
   register: auth_var
   ignore_errors: true

--- a/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -27,7 +27,7 @@
   auth_driver:
     filename: "{{ cred_filename }}" # don't include the .yaml
     cred_type: "openstack"
-    cred_path: "{{ creds_path | default('~/.config/openstack/') }}"
+    cred_path: "{{ creds_path | default(default_credentials_path) }}"
     driver: "file"
   register: auth_var
   ignore_errors: true


### PR DESCRIPTION
Fixes #279 

Updated linchpin.conf to have a 'default_credentials_path'
Updated the openstack/aws/gcloud drivers to use 'default_credentials path'
if 'creds_path' isn't provided
Updated load_evars_from_ini to include 'default_credentials_path' in
case ansible-playbook method is used