### PR TITLE
Updates to beaker provisioner related to #278

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ This documentation covers the current released version of LinchPin (|version|). 
    installation
    getting_started
    configuration
+   topologies
    community
    libdocs
    releases

--- a/docs/source/topologies_beaker.rst
+++ b/docs/source/topologies_beaker.rst
@@ -16,7 +16,7 @@ Beaker Server
     resource_groups:
       - resource_group_name: test1
         res_group_type: beaker
-        job_group: ci-ops-central
+        job_group: your-beaker-group
         whiteboard: Arbitrary Job whiteboard string
         recipesets:
           - distro: RHEL-6.5
@@ -40,9 +40,12 @@ Beaker Server
 Requiring Specific Hosts
 ````````````````````````
 
-By default, any host available to the named ``job_group`` can be selected for use in a given job.
+By default, any host available to your beaker user can be selected for use in a given job.
 If a specific host, or hosts, is desired, ``hostrequires`` filters can be used to refine the hosts
 selected for use in a given job.
+
+Force a Specific Host
+^^^^^^^^^^^^^^^^^^^^^
 
 The reservation of a specific hostname can be done with the ``force`` keyword nested within a
 recipeset's ``hostrequires`` mapping. Additional filtering,
@@ -53,19 +56,20 @@ any other filters.
 For example::
 
     hostrequires:
-      - force: beaker.machine.hostname
+      force: beaker.machine.hostname
 
-Beaker supports globbing via the "like" operator::
+Select from a named System Pool
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Beaker also supports provisioning from a named system pool::
 
     hostrequires:
-      - tag: hostname
-        op: like
-        value: beaker-%.machine.hostname
+      - tag: pool
+        op: "="
+        value: system-pool-name
 
-This glob will match hostnames like ``beaker-01.machine.hostname``, allowing you to select from
-a subset of machines available in the given job group. This acts like any other "hostrequires"
-filter, so it can be combined with those filters to futher ensure that only nodes with required
-cababilities are selected for a job (unlike when ``force`` is used).
+This filter will automatically select a system from the named system pool, but unlike the ``force``
+keyword additional filters will also be applied.
 
 .. note::
 

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -190,29 +190,33 @@
                                      "type": "array"
                                  },
                                  "hostrequires": {
-                                     "type": "array",
-                                     "items": {
-                                         "oneOf": [
-                                             {
-                                                 "type": "object",
-                                                 "properties": {
-                                                     "force": {
-                                                         "type": "string"
-                                                     }
-                                                 },
-                                                 "required": ["force"]
+                                     "oneOf": [
+                                         {
+                                             "type": "array",
+                                              "items": {
+                                                  "allOf": [
+                                                      {
+                                                          "type": "object",
+                                                          "properties": {
+                                                              "tag": {
+                                                                  "type": "string"
+                                                              }
+                                                          },
+                                                          "required": ["tag"]
+                                                      }
+                                                 ]
+                                              }
+                                         },
+                                         {
+                                             "type": "object",
+                                             "properties": {
+                                                 "force": {
+                                                     "type": "string"
+                                                 }
                                              },
-                                             {
-                                                 "type": "object",
-                                                 "properties": {
-                                                     "tag": {
-                                                         "type": "string"
-                                                     }
-                                                 },
-                                                 "required": ["tag"]
-                                             }
-                                          ]
-                                     }
+                                             "required": ["force"]
+                                         }
+                                     ]
                                  },
                                  "bkr_data": {
                                     "type": "object"
@@ -229,7 +233,7 @@
                      }
                  }
              },
-             "required": ["job_group", "recipesets"]
+             "required": ["recipesets"]
          },
         "gcloud_gce": {
             "type" : "object",

--- a/linchpin/provision/library/bkr_server.py
+++ b/linchpin/provision/library/bkr_server.py
@@ -239,7 +239,7 @@ def main():
     module = AnsibleModule(argument_spec={
         'whiteboard': {'required': False, 'type': 'str'},
         'recipesets': {'required': True, 'type': 'list'},
-        'job_group': {'required': True, 'type': 'str'},
+        'job_group': {'default': '', 'type': 'str'},
         'state': {'default': 'present', 'choices': ['present', 'absent']},
         'cancel_message': {'default': 'Job canceled by Ansible'}
     })
@@ -250,11 +250,14 @@ def main():
     for recipeset in params.recipesets:
         for x in range(0, recipeset['count']):
             if params.state == 'present':
+                extra_params = {}
+                if params.job_group:
+                    extra_params['job_group'] = params.job_group
                 # Make provision
-                job_id = factory.provision(debug=True, wait=True,\
-                                           recipesets=[recipeset],\
-                                           job_group=params.job_group,
-                                           whiteboard=params.whiteboard)
+                job_id = factory.provision(debug=True, wait=True,
+                                           recipesets=[recipeset],
+                                           whiteboard=params.whiteboard,
+                                           **extra_params)
                 job_ids.extend(job_id)
             else:
                 factory.cancel_jobs(recipeset['ids'], params.cancel_message)

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -5,7 +5,7 @@
     whiteboard: "{{ res.whiteboard | default('Provisioned with linchpin') }}"
     recipesets: "{{ res.recipesets }}"
     state: present
-    job_group: "{{ res.job_group }}"
+    job_group: "{{ res.job_group | default('') }}"
   with_items: "{{ bkr_res_grps }}"
   loop_control:
     loop_var: res

--- a/linchpin/provision/roles/beaker/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/teardown_resource_group.yml
@@ -42,5 +42,4 @@
   bkr_server:
     recipesets: "[ {{ combined }} ]"
     state: absent
-    job_group: "{{ res_grp['job_group'] }}"
-
+    job_group: "{{ res_grp['job_group'] | default('') }}"


### PR DESCRIPTION
- Update docs and v4 schema to match how I actually intended the stuff
  to work, as evidenced by the lack of changes to the related bkr_server
  logic.
- job_group is no longer a required field when provisioning in beaker.
  This was most likely used to get the non-default beaker behavior of
  automatic provisioning from a system pool related to a job group
  before beaker version 20. This behavior should be explicitly requested
  via the "pool" hostrequires tag.
- Added the example topologies to the toplevel index. We've been
  building them into the docs but not exposing them to users. If this
  was intentional, I'll pull it out.

fixes #278