### PR TITLE
remove redundancy when setting workspace

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -118,8 +118,6 @@ def runcli(ctx, config, workspace, verbose, version, creds_path):
 
     if workspace is not None:
         ctx.workspace = os.path.realpath(os.path.expanduser(workspace))
-    else:
-        ctx.workspace = os.getenv('PWD')
 
     if creds_path is not None:
         ctx.set_evar('creds_path', os.path.realpath(os.path.expanduser(creds_path)))


### PR DESCRIPTION
The workspace is set through the following order:
  1. by default, LinchpinContext class sets to current directory
  2. then if the environment variable WORKSPACE, it replaces the
     default
  3. last with most precedence, if the user sets the option -w or
     --workspace
There is no need to set the workspace to PWD in case the user has
not set the option or the environment variable because the class
already sets to os.path.curdir (step 1 above).