### PR TITLE
Fix the inventory and resources default filenames

### DIFF
--- a/linchpin/provision/roles/aws/tasks/main.yml
+++ b/linchpin/provision/roles/aws/tasks/main.yml
@@ -22,5 +22,6 @@
   include: teardown_resource_group.yml res_grp={{ item.0 }} topo_output_file={{ item.1 }}
   with_nested:
     - "{{ aws_res_grps }}"
-    - ["{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"]
+    - ["{{ resources_file | default( default_resources_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"]
   when: state == "absent"

--- a/linchpin/provision/roles/beaker/tasks/main.yml
+++ b/linchpin/provision/roles/beaker/tasks/main.yml
@@ -14,5 +14,6 @@
   include: teardown_resource_group.yml res_grp={{ item.0 }} topo_output_file={{ item.1 }}
   with_nested:
     - "{{ bkr_res_grps }}"
-    - ["{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"]
+    - ["{{ resources_file | default( default_resources_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"]
   when: state == "absent"

--- a/linchpin/provision/roles/duffy/tasks/main.yml
+++ b/linchpin/provision/roles/duffy/tasks/main.yml
@@ -18,5 +18,6 @@
   include: teardown_resource_group.yml res_grp={{ item.0 }} topo_output_file={{ item.1 }}
   with_nested:
     - "{{ duffy_res_grps }}"
-    - ["{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"]
+    - ["{{ resources_file | default( default_resources_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"]
   when: state == "absent"

--- a/linchpin/provision/roles/dummy/tasks/main.yml
+++ b/linchpin/provision/roles/dummy/tasks/main.yml
@@ -18,5 +18,6 @@
   include: teardown_resource_group.yml res_grp={{ item.0 }} topo_output_file={{ item.1 }}
   with_nested:
     - "{{ dummy_res_grps }}"
-    - ["{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"]
+    - ["{{ resources_file | default( default_resources_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"]
   when: state == "absent"

--- a/linchpin/provision/roles/inventory_gen/tasks/main.yml
+++ b/linchpin/provision/roles/inventory_gen/tasks/main.yml
@@ -5,7 +5,8 @@
 #    msg: "{{ layout_file }}"
 #  when: state == "present"
 
-- include_vars: "{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"
+- include_vars: "{{ resources_file | default( default_resources_path+'/'+
+outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"
 
 - name: "Updating topology_outputs"
   set_fact:
@@ -23,11 +24,13 @@
 # parse inventory generation files here : can be overridden by extravar layout_file currently defaulted to openshift-3node-cluster.yml
 - name: "Parse inventory layout as a ordered dict"
   set_fact:
-    inventory_layout: "{{ layout_file | default( default_layouts_path+'/'+'openshift-3node-cluster.yml') | ordered_yaml }}"
+    inventory_layout: "{{ layout_file | default( default_layouts_path+'/'+
+    'openshift-3node-cluster.yml') | ordered_yaml }}"
 
 - name: "Updating inventory_path with the absolute path"
   set_fact:
-    inventory_path: "{{ inventory_path | default( default_inventories_path+'/'+outputs.topology_name ) }}.inventory"
+    inventory_path: "{{ inventory_path | default( default_inventories_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower() ) }}.inventory"
 
 #- name: inventory_layout
 #  debug:

--- a/linchpin/provision/roles/output_writer/tasks/main.yml
+++ b/linchpin/provision/roles/output_writer/tasks/main.yml
@@ -38,7 +38,8 @@
 - name: "Generate outputs when async is false"
   template:
     src: "../templates/output_formatter.j2"
-    dest: "{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"
+    dest: "{{ resources_file | default( default_resources_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"
   when: state == "present" and not async and output
 
 # pretty much the same when we use async== false , seperated the task for probable customizations in future
@@ -96,10 +97,12 @@
 - name: "Generate outputs when async is true"
   template:
     src: "../templates/output_formatter.j2"
-    dest: "{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"
+    dest: "{{ resources_file | default( default_resources_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"
   when: state == "present" and async and output
 
 - name: "set name of the resources_file for inventory generation"
   set_fact:
-    resources_file:  "{{ resources_file | default( default_resources_path+'/'+outputs.topology_name+'.output' ) }}"
+    resources_file:  "{{ resources_file | default( default_resources_path+'/'+
+    outputs.topology_name.replace(' ', '_').lower()+'.output' ) }}"
   when: state == "present"


### PR DESCRIPTION
This commit helps avoid invalid filenames for inventory and resources
output files. The default filename standard uses the topology_name value
(defined inside the topology) file to set the filename. If a user sets
their topology name as the following 'Provision cloud resources'. Their
output file would be 'Provision cloud resources.output', etc. This
patch replaces all spaces with underscores and makes the filename
lowercase.