### PR TITLE
CLI now exits with non-zero exit code on failure

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -46,7 +46,7 @@ class LinchpinAliases(click.Group):
         return rv
 
 
-def _handle_results(ctx, results):
+def _handle_results(ctx, results, return_code):
     """
     Handle results from the Ansible API. Either as a return value (retval)
     when running with the ansible console enabled, or as a list of TaskResult
@@ -60,7 +60,6 @@ def _handle_results(ctx, results):
         The dictionary of results for each target.
     """
 
-    retval = 0
 
     for k, v in results.iteritems():
         if not isinstance(v, int):
@@ -73,10 +72,8 @@ def _handle_results(ctx, results):
                     msg = tr._check_key('msg')
                     ctx.log_state("Target '{0}': {1} failed with"
                                   " error '{2}'".format(k, tr._task, msg))
-                    sys.exit(retval)
-        else:
-            if v:
-                sys.exit(v)
+
+    sys.exit(return_code)
 
 
 @click.group(cls=LinchpinAliases,
@@ -170,9 +167,9 @@ def up(ctx, targets):
     pf_w_path = _get_pinfile_path()
 
     try:
-        results = lpcli.lp_up(pf_w_path, targets)
+        return_code, results = lpcli.lp_up(pf_w_path, targets)
 
-        _handle_results(ctx, results)
+        _handle_results(ctx, results, return_code)
 
     except LinchpinError as e:
         ctx.log_state(e)
@@ -214,9 +211,9 @@ def destroy(ctx, targets):
     pf_w_path = _get_pinfile_path()
 
     try:
-        results = lpcli.lp_destroy(pf_w_path, targets)
+        return_code, results = lpcli.lp_destroy(pf_w_path, targets)
 
-        _handle_results(ctx, results)
+        _handle_results(ctx, results, return_code)
 
     except LinchpinError as e:
         ctx.log_state(e)

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -46,7 +46,7 @@ class LinchpinAliases(click.Group):
         return rv
 
 
-def _handle_results(ctx, results, return_code):
+def _handle_results(ctx, results, return_code=1):
     """
     Handle results from the Ansible API. Either as a return value (retval)
     when running with the ansible console enabled, or as a list of TaskResult
@@ -60,7 +60,6 @@ def _handle_results(ctx, results, return_code):
         The dictionary of results for each target.
     """
 
-
     for k, v in results.iteritems():
         if not isinstance(v, int):
             trs = v
@@ -72,8 +71,12 @@ def _handle_results(ctx, results, return_code):
                     msg = tr._check_key('msg')
                     ctx.log_state("Target '{0}': {1} failed with"
                                   " error '{2}'".format(k, tr._task, msg))
-
-    sys.exit(return_code)
+                    sys.exit(return_code)
+            elif return_code:
+                sys.exit(return_code)
+        else:
+            if v:
+                sys.exit(v)
 
 
 @click.group(cls=LinchpinAliases,

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -46,7 +46,7 @@ class LinchpinAliases(click.Group):
         return rv
 
 
-def _handle_results(ctx, results, return_code=1):
+def _handle_results(ctx, results, return_code):
     """
     Handle results from the Ansible API. Either as a return value (retval)
     when running with the ansible console enabled, or as a list of TaskResult

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -338,7 +338,7 @@ class LinchpinAPI(object):
             if 'post' in self.pb_hooks:
                 self.hook_state = '{0}{1}'.format('post', playbook)
 
-        return return_code, results
+        return (return_code, results)
 
 
     def lp_rise(self, pinfile, targets='all'):

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -338,7 +338,7 @@ class LinchpinAPI(object):
             if 'post' in self.pb_hooks:
                 self.hook_state = '{0}{1}'.format('post', playbook)
 
-        return results
+        return return_code, results
 
 
     def lp_rise(self, pinfile, targets='all'):

--- a/linchpin/tests/api/test_init_pass.py
+++ b/linchpin/tests/api/test_init_pass.py
@@ -209,7 +209,7 @@ def test_get_evar_item():
 def test_run_playbook():
 
     pf_w_path = '{0}/{1}'.format(lpc.workspace, pinfile)
-    results = lpa.run_playbook(pf_w_path, targets=[provider])
+    return_code, results = lpa.run_playbook(pf_w_path, targets=[provider])
 
     for res in results[provider]:
         name = res._task.get_name()


### PR DESCRIPTION
This is a patch to issue #306.
I changed return value of run_playbook to a tuple which includes a 'results' dict and return_code to pass into _handle_results().  _handle_results() then calls the sys.exit() with the return_code argument.