### PR TITLE
Release of v1.0.3

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -95,7 +95,7 @@ def _handle_results(ctx, results, return_code):
               help='Enable verbose output')
 @click.option('--version', is_flag=True,
               help='Prints the version and exits')
-@click.option('--creds-path', type=click.Path(), envvar='LP_CREDS',
+@click.option('--creds-path', type=click.Path(), envvar='CREDS_PATH',
               help='Use the specified credentials path if CREDS_PATH'
                    'environment variable is not set')
 @pass_context

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,3 +1,2 @@
-__short_version__ = '1.0.2'
-__release_version__ = ''
-__version__ = '1.0.2'
+__short_version__ = '1.0.3'
+__version__ = '1.0.3'


### PR DESCRIPTION
I think we're ready to release another bugfix version 1.0.3.

Included are the following updates:

* remove gce2 module and use the standard module from ansible
* requirements.txt to use Ansible >= 2.3.1 (this means we can package it for Fedora)
* remove other requirements from requirements.txt that are not necessary
* improved documentation around clouds.yaml and --creds-path
* CLI exits with proper exit codes (with tests to verify)
* linchpin fetch (download local/remote workspaces)
* flake8 testing
* ovirt support with docs!
* linchpin.conf supports overriding specific sections from previous config
* os_server module updated to handle multiple provisioning properly
* remove cruft from api framework
* upgrade setuptools and pip in tests
* move lp_init into api and cli to work together
* workspace set and get methods
* other miscellany
