### PR TITLE
bugfix: Added common inventory variables to the inventory layout

### DIFF
--- a/linchpin/provision/InventoryFilters/InventoryFilter.py
+++ b/linchpin/provision/InventoryFilters/InventoryFilter.py
@@ -103,5 +103,7 @@ class InventoryFilter(object):
                 host_string = item
                 for var in common_vars:
                     if common_vars[var] == "__IP__":
-                        host_string += " " + var + "=" + item + " "
+                        host_string += " " + var + "=" + item
+                    else:
+                        host_string += " " + var + "=" + common_vars[var]
                 self.config.set(group, host_string)


### PR DESCRIPTION
Currently layout accept only __IP__ magic var inside the vars
section of layout file . Now with this fix users can add their own
custom inventory variables to the hosts.