### PR TITLE
Move to v1.0.4

### DIFF
--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -48,10 +48,6 @@ class LinchpinAPI(object):
         if not self.workspace:
             self.workspace = os.path.realpath(os.path.curdir)
 
-        # create localhost file in workspace for user if it doesn't exist
-        if not os.path.exists('{0}/localhost'.format(self.workspace)):
-            with open('{0}/localhost'.format(self.workspace), 'w') as f:
-                f.write('localhost\n')
 
 
 
@@ -214,7 +210,7 @@ class LinchpinAPI(object):
         self.set_evar('topology_name', topology_name)
 
 
-    def run_playbook(self, pinfile, targets='all', playbook='up'):
+    def run_playbook(self, pinfile, targets=[], playbook='up'):
         """
         This function takes a list of targets, and executes the given
         playbook (provison, destroy, etc.) for each provided target.
@@ -277,6 +273,10 @@ class LinchpinAPI(object):
         else:
             raise LinchpinError("One or more invalid targets found")
 
+        # create localhost file in workspace for user if it doesn't exist
+        if not os.path.exists('{0}/localhost'.format(self.workspace)):
+            with open('{0}/localhost'.format(self.workspace), 'w') as f:
+                f.write('localhost\n')
 
         for target in targets:
             self.set_evar('topology', self.find_topology(
@@ -302,6 +302,7 @@ class LinchpinAPI(object):
 
             if 'pre' in self.pb_hooks:
                 self.hook_state = '{0}{1}'.format('pre', playbook)
+
 
             # invoke the appropriate playbook
             return_code, results[target] = (

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -48,6 +48,12 @@ class LinchpinAPI(object):
         if not self.workspace:
             self.workspace = os.path.realpath(os.path.curdir)
 
+        # create localhost file in workspace for user if it doesn't exist
+        if not os.path.exists('{0}/localhost'.format(self.workspace)):
+            with open('{0}/localhost'.format(self.workspace), 'w') as f:
+                f.write('localhost\n')
+
+
 
     def get_cfg(self, section=None, key=None, default=None):
         """

--- a/linchpin/tests/api/test_init_pass.py
+++ b/linchpin/tests/api/test_init_pass.py
@@ -205,22 +205,25 @@ def test_get_evar_item():
 #    lpc.load_config()
 #    lpa = LinchpinAPI(lpc)
 
+
 @with_setup(setup_lp_api)
 def test_run_playbook():
 
     pf_w_path = '{0}/{1}'.format(lpc.workspace, pinfile)
     return_code, results = lpa.run_playbook(pf_w_path, targets=[provider])
 
+    failed = False
     for res in results[provider]:
         name = res._task.get_name()
-        failed = False
         if res.is_failed():
             failed = True
 
     assert not failed
 
+
 @with_setup(setup_lp_fetch_env)
 def test_fetch_local():
+
     src_path = os.path.join(mockpath, 'fetch/ws1')
     src_uri = 'file://{0}'.format(src_path)
     lpa.lp_fetch(src_uri, 'workspace', None)
@@ -233,18 +236,20 @@ def test_fetch_local():
     shutil.rmtree(os.path.join(os.path.expanduser('~'), '.cache/linchpin/'))
     assert_list_equal(src_list, dest_list)
 
+
 @with_setup(setup_lp_fetch_env)
 def test_fetch_git():
     src_url = 'https://github.com/agharibi/SampleLinchpinDirectory.git'
     lpa.lp_fetch(src_url, 'topologies', 'ws1')
 
-    src_list = ['topologies']
+    src_list = ['topologies', 'localhost']
     dest_list = os.listdir(lpc.workspace)
 
     shutil.rmtree(lpc.workspace)
     shutil.rmtree(os.path.join(os.path.expanduser('~'), '.cache/linchpin/'))
 
     assert_list_equal(src_list, dest_list)
+
 
 @with_setup(setup_lp_fetch_env)
 def test_fetch_cache():

--- a/linchpin/tests/api/test_init_pass.py
+++ b/linchpin/tests/api/test_init_pass.py
@@ -213,10 +213,12 @@ def test_run_playbook():
     return_code, results = lpa.run_playbook(pf_w_path, targets=[provider])
 
     failed = False
-    for res in results[provider]:
-        name = res._task.get_name()
-        if res.is_failed():
-            failed = True
+    if return_code:
+        failed = True
+        for res in results[provider]:
+            name = res._task.get_name()
+            if res.is_failed():
+                print('name: {}'.format(name))
 
     assert not failed
 
@@ -239,10 +241,11 @@ def test_fetch_local():
 
 @with_setup(setup_lp_fetch_env)
 def test_fetch_git():
+
     src_url = 'https://github.com/agharibi/SampleLinchpinDirectory.git'
     lpa.lp_fetch(src_url, 'topologies', 'ws1')
 
-    src_list = ['topologies', 'localhost']
+    src_list = ['topologies']
     dest_list = os.listdir(lpc.workspace)
 
     shutil.rmtree(lpc.workspace)
@@ -253,6 +256,7 @@ def test_fetch_git():
 
 @with_setup(setup_lp_fetch_env)
 def test_fetch_cache():
+
     src_url = 'https://github.com/agharibi/SampleLinchpinDirectory.git'
     lpa.lp_fetch(src_url, 'topologies', 'ws1')
     lpa.lp_fetch(src_url, 'topologies', 'ws1')

--- a/linchpin/tests/mockdata/contextdata.py
+++ b/linchpin/tests/mockdata/contextdata.py
@@ -80,8 +80,10 @@ class ContextData(object):
         self.cfg_data['logger']['file'] = self.logfile
 
         self.evars = self.cfg_data.get('evars', {})
-    
+
+
     def load_new_config(self, provider='dummy'):
+
         self.cfg_data = {}
 
         expanded_path = None
@@ -100,7 +102,7 @@ class ContextData(object):
                 existing_paths.append(expanded_path)
 
         if len(existing_paths) == 0:
-            raise Linchpinerror('Configuration file not foud in'
+            raise LinchpinError('Configuration file not foud in'
                                 ' path: {0}'.format(CONFIG_PATH))
         try:
             for path in existing_paths:
@@ -122,7 +124,7 @@ class ContextData(object):
         except ConfigParser.InterpolationSyntaxError as e:
             raise LinchpinError('Unable to parse configuration file properly:'
                             '{0}'.format(e))
-    
+
         # override logger file
         self.cfg_data['logger']['file'] = self.logfile
 

--- a/linchpin/tests/mockdata/dummy/fetch/ws1/localhost
+++ b/linchpin/tests/mockdata/dummy/fetch/ws1/localhost
@@ -1,0 +1,1 @@
+localhost

--- a/linchpin/tests/mockdata/dummy/fetch/ws2/localhost
+++ b/linchpin/tests/mockdata/dummy/fetch/ws2/localhost
@@ -1,0 +1,1 @@
+localhost

--- a/linchpin/tests/mockdata/dummy/localhost
+++ b/linchpin/tests/mockdata/dummy/localhost
@@ -1,0 +1,1 @@
+localhost

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
-__short_version__ = '1.0.3'
-__version__ = '1.0.3'
+__short_version__ = '1.0.4'
+__version__ = '1.0.4'


### PR DESCRIPTION
This release contains the following:

* Fixed invalid syntax in bkr_server.py introduced by flake8 cleanup
* users can add their own custom inventory variables to the hosts
* Updated schema to support tags in gcloud_gce provisioning
* CODE_OF_CONDUCT.md file now in root of repository
* Libvirt copy_img_src updated stat to use mimetype
* Added optional note about mkvirtualenv in installation document
* Restructured the imports, added ansible runner for ansible 2.4
* Added a Testing section to the CONTRIBUTING document
* Create a localhost file in workspace to accommodate ansible 2.4 warnings

