### PR TITLE
Provide for booting openstack from volume

### DIFF
--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -61,9 +61,18 @@
                 },
                 "userdata": {
                     "type": "string"
+                },
+                "boot_from_volume": {
+                    "type": "boolean"
+                },
+                "volume_size": {
+                    "type": "number"
+                },
+                "boot_volume": {
+                    "type": "string"
                 }
             },
-            "required":["flavor","type","image","count","keypair"]
+            "required":["flavor","type","count","keypair"]
         },
         "dummy": {
             "type" : "object",

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -3,7 +3,7 @@
     state: "{{ state }}"
     auth: "{{ auth_var }}"
     name: "{{ res_grp_name }}_{{ res_def['res_name'] | default(res_def['name']) }}"
-    image: "{{ res_def['image'] }}"
+    image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
     flavor: "{{ res_def['flavor'] }}"
@@ -12,6 +12,10 @@
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     userdata: "{{ res_def['userdata'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
+    boot_from_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    volume_size: "{{ res_def['volume_size'] | default(omit) }}"
+    boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
   register: res_def_output
   when: not async and auth_var is defined
 
@@ -24,7 +28,7 @@
   os_server2:
     state: "{{ state }}"
     name: "{{ res_grp_name }}_{{ res_def['res_name'] | default(res_def['name']) }}"
-    image: "{{ res_def['image'] }}"
+    image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
     flavor: "{{ res_def['flavor'] }}"
@@ -33,6 +37,10 @@
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     userdata: "{{ res_def['userdata'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
+    boot_from_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    volume_size: "{{ res_def['volume_size'] | default(omit) }}"
+    boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
   register: res_def_output
   when: not async and auth_var is not defined
 
@@ -46,7 +54,7 @@
     state: "{{ state }}"
     auth: "{{ auth_var | provide_default(omit) }}"
     name: "{{ res_grp_name }}_{{ res_def['res_name'] | default(res_def['name']) }}"
-    image: "{{ res_def['image'] }}"
+    image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
     flavor: "{{ res_def['flavor'] }}"
@@ -55,6 +63,10 @@
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     userdata: "{{ res_def['userdata'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
+    boot_from_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    volume_size: "{{ res_def['volume_size'] | default(omit) }}"
+    boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output
@@ -69,7 +81,7 @@
   os_server2:
     state: "{{ state }}"
     name: "{{ res_grp_name }}_{{ res_def['res_name'] | default(res_def['name']) }}"
-    image: "{{ res_def['image'] }}"
+    image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
     flavor: "{{ res_def['flavor'] }}"
@@ -78,6 +90,10 @@
     security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     userdata: "{{ res_def['userdata'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
+    boot_from_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
+    volume_size: "{{ res_def['volume_size'] | default(omit) }}"
+    boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output


### PR DESCRIPTION
Allows user to specify a specific volume to boot from, which will remain
intact after instance shut down. This volume must be pre-created and
already be flagged as a bootable volume

Allows user to request a new volume be automatically created on boot,
which will then be auto-terminated when the instance is shut down

Lacks the ability to check required/excluded options from schema. That
checking is handled by the Ansible module