### PR TITLE
LinchPin Journal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 ansible.cfg
 *.swp
+.fuse*
 
 # generated files
 docs/build/

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -309,7 +309,7 @@ def fetch(ctx, fetch_type, remote, root):
 @click.option('-c', '--count', metavar='COUNT', default=1, required=False,
               help='(up to) number of records to return (default: 10)')
 @click.option('-f', '--fields', metavar='FIELDS', required=False,
-               help='List the fields to display')
+              help='List the fields to display')
 @pass_context
 def journal(ctx, targets, fields, count):
     """
@@ -328,7 +328,7 @@ def journal(ctx, targets, fields, count):
     all_fields = json.loads(lpcli.get_cfg('lp', 'rundb_schema')).keys()
 
     if not fields:
-        fields = ['action','uhash','rc']
+        fields = ['action', 'uhash', 'rc']
     else:
         fields = fields.split(',')
 
@@ -336,9 +336,10 @@ def journal(ctx, targets, fields, count):
 
     if invalid_fields:
         ctx.log_state('The following fields passed in are not valid: {0}'
-                     ' \nValid fields are {1}'.format(fields, all_fields))
+                      ' \nValid fields are {1}'.format(fields, all_fields))
         sys.exit(89)
 
+    no_records = []
     output = 'run_id\t'
 
     for f in fields:
@@ -351,20 +352,34 @@ def journal(ctx, targets, fields, count):
     try:
         journal = lpcli.lp_journal(targets=targets, fields=fields, count=count)
 
-        for target,values in journal.iteritems():
-            print('\nTarget: {0}'.format(target))
-            print(output)
+        for target, values in journal.iteritems():
+
             keys = values.keys()
-            keys.sort(reverse=True)
-            for run_id in keys:
-                if int(run_id) > 0:
-                    out = '{0:<7}\t'.format(run_id)
-                    for f in fields:
-                        out += '{0:>8}\t'.format(values[run_id][f])
+            if len(keys):
+                print('\nTarget: {0}'.format(target))
+                print(output)
+                keys.sort(reverse=True)
+                for run_id in keys:
+                    if int(run_id) > 0:
+                        out = '{0:<7}\t'.format(run_id)
+                        for f in fields:
+                            out += '{0:>8}\t'.format(values[run_id][f])
 
-                    print(out)
+                        print(out)
+            else:
+                no_records.append(target)
 
-        print('\n')
+        if no_records:
+            no_out = '\nNo records for targets:'
+
+            for rec in no_records:
+                no_out += ' {0}'.format(rec)
+
+            no_out += '\n'
+
+            print(no_out)
+
+
 
 
     except LinchpinError as e:

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -480,6 +480,8 @@ class LinchpinAPI(object):
 
         for target in targets:
 
+            results[target] = {}
+
             # initialize rundb table
             dateformat = self.get_cfg('logger',
                                       'dateformat',
@@ -594,7 +596,7 @@ class LinchpinAPI(object):
             # FIXME need to add rundb data for hooks results
 
             # invoke the appropriate action
-            return_code, results[target] = (
+            return_code, results[target]['task_results'] = (
                 self._invoke_playbook(action=action,
                                       console=ansible_console)
             )
@@ -617,6 +619,9 @@ class LinchpinAPI(object):
             end = time.strftime(dateformat)
             rundb.update_record(target, rundb_id, 'end', end)
             rundb.update_record(target, rundb_id, 'rc', return_code)
+
+            run_data = rundb.get_record(target, action=action, run_id=rundb_id)
+            results[target]['rundb_data'] = {rundb_id: run_data[0]}
 
         return (return_code, results)
 

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -99,7 +99,7 @@ class LinchpinAPI(object):
         (default: None)
         """
 
-        return self.ctx.get_evar(key, default)
+        return self.ctx.get_evar(key=key, default=default)
 
 
     def set_evar(self, key, value):
@@ -340,6 +340,22 @@ class LinchpinAPI(object):
         fetch_class.fetch_files()
 
         fetch_class.copy_files()
+
+
+    def lp_journal(self, targets=[], fields=None, count=None):
+
+        rundb = self.setup_rundb()
+
+        journal = {}
+
+        if not len(targets):
+            targets = rundb.get_tables()
+
+
+        for target in targets:
+            journal[target] = rundb.get_records(table=target, count=count)
+
+        return journal
 
 
     def find_topology(self, topology):

--- a/linchpin/rundb/__init__.py
+++ b/linchpin/rundb/__init__.py
@@ -18,6 +18,14 @@ class RunDB(object):
         return self.driver.get_record(table, run_id=run_id)
 
     @abstractmethod
+    def get_records(self, table=[], count=10):
+        return self.driver.get_records(table=table, count=count)
+
+    @abstractmethod
+    def get_tables(self):
+        return self.driver.get_tables()
+
+    @abstractmethod
     def remove_record(self, table, key, value):
         return self.driver.remove_record(table, key, value)
 

--- a/linchpin/rundb/basedb.py
+++ b/linchpin/rundb/basedb.py
@@ -29,6 +29,12 @@ class BaseDB(RunDB):
     def get_record(self, table, action='up', run_id=None):
         return self.driver.get_record(table, run_id=run_id)
 
+    def get_records(self, table=[], count=10):
+        return self.driver.get_records(table=table, count=count)
+
+    def get_tables(self):
+        return self.driver.get_tables()
+
     def remove_record(self, table, key, value):
         return self.driver.remove_record(table, key, value)
 

--- a/linchpin/rundb/tinyrundb.py
+++ b/linchpin/rundb/tinyrundb.py
@@ -28,6 +28,7 @@ class TinyRunDB(BaseDB):
                          storage=CachingMiddleware(JSONStorage),
                          default_table=self.default_table)
 
+
     def __str__(self):
         if self.conn_str:
             return "{0} at {2}".format(self.name, self.conn_str)
@@ -50,6 +51,7 @@ class TinyRunDB(BaseDB):
         t = self.db.table(name=table)
         return t.insert(self.schema)
 
+
     @usedb
     def update_record(self, table, run_id, key, value):
         t = self.db.table(name=table)
@@ -71,6 +73,30 @@ class TinyRunDB(BaseDB):
                 return (record, int(rid))
 
         return (None, 0)
+
+
+    @usedb
+    def get_records(self, table, count=10):
+
+        records = {}
+        t = self.db.table(name=table)
+        start = len(t)
+        end = start - count
+
+        for i in xrange(start, end, -1):
+            records[i] = t.get(doc_id=i)
+
+        return records
+
+
+    @usedb
+    def get_tables(self):
+
+        tables = self.db.tables()
+        tables.remove(self.default_table)
+
+        return tables
+
 
     def remove_record(self, table, key, value):
         pass

--- a/linchpin/rundb/tinyrundb.py
+++ b/linchpin/rundb/tinyrundb.py
@@ -79,12 +79,13 @@ class TinyRunDB(BaseDB):
     def get_records(self, table, count=10):
 
         records = {}
-        t = self.db.table(name=table)
-        start = len(t)
-        end = start - count
+        if table in self.db.tables():
+            t = self.db.table(name=table)
+            start = len(t)
+            end = start - count
 
-        for i in xrange(start, end, -1):
-            records[i] = t.get(doc_id=i)
+            for i in xrange(start, end, -1):
+                records[i] = t.get(doc_id=i)
 
         return records
 


### PR DESCRIPTION
Linchpin journal provides a bit of data about the previous runs using runDB. This allows a user to see the last X number of components for a specific target. If target data doesn't exist in the runDB, `linchpin journal` will report no data.