### PR TITLE
Allow ansible-playbook to destroy using rundb

### DIFF
--- a/linchpin/provision/library/rundb.py
+++ b/linchpin/provision/library/rundb.py
@@ -157,7 +157,8 @@ def main():
                         if key in record:
                             output = record.get(key)
                         else:
-                            msg = "key '{0}' was not found in record".format(key)
+                            msg = "key '{0}' was not found in"
+                            " record".format(key)
                             module.fail_json(msg=msg)
                 else:
                     msg = "The 'key' value must be passed"

--- a/linchpin/provision/library/rundb.py
+++ b/linchpin/provision/library/rundb.py
@@ -140,20 +140,31 @@ def main():
                     module.fail_json(msg=msg)
 
             if op == "get":
-                if run_id and key:
-                    runid = int(run_id)
-                    record = rundb.get_record(table,
-                                              action=action,
-                                              run_id=runid)[0]
+                if key:
+                    runid = None
+                    if run_id:
+                        runid = int(run_id)
+                    if key == 'run_id':
+                        output = rundb.get_record(table,
+                                                  action=action,
+                                                  run_id=runid)[1]
 
-                    if key in record:
-                        output = record.get(key)
                     else:
-                        msg = "key '{0}' was not found in record".format(key)
-                        module.fail_json(msg=msg)
+                        record = rundb.get_record(table,
+                                                  action=action,
+                                                  run_id=runid)[0]
+
+                        if key in record:
+                            output = record.get(key)
+                        else:
+                            msg = "key '{0}' was not found in record".format(key)
+                            module.fail_json(msg=msg)
+                else:
+                    msg = "The 'key' value must be passed"
+                    module.fail_json(msg=msg)
 
         else:
-            msg = ("Module 'action' required".format(action))
+            msg = "Module 'action' required"
             module.fail_json(msg=msg)
 
         if output:

--- a/linchpin/provision/roles/common/tasks/initialize_rundb.yml
+++ b/linchpin/provision/roles/common/tasks/initialize_rundb.yml
@@ -5,13 +5,19 @@
 
 # the PinFile isn't technically used in an ansible-playbook run,
 # so we'll say this is an 'ansible-playbook' target
-- name: set PinFile target
+- name: "set PinFile target"
   set_fact:
     target: ansible-playbook
 
-- name: set rundb_connect value
+- name: "set rundb_connect value"
   set_fact:
     rundb_conn: "{{ rundb_conn | regex_replace('::mac::', macid_output.stdout) }}"
+  when: rundb_conn_type == "file"
+
+- name: "ensure rundb path exists if type is file"
+  file:
+    state: directory
+    path: "{{ rundb_conn | dirname }}"
   when: rundb_conn_type == "file"
 
 - name: "initialize rundb"
@@ -62,10 +68,33 @@
       uh: "{{ [target,rundb_id,start_time] | join(':') | hash('sha256') }}"
   when: state == "present"
 
-- name: "get uhash with last 4 of uh var"
+- name: "get uhash from last 4 of full hash"
   set_fact:
     uhash: "{{ uh[-4:] }}"
   when: state == "present"
+
+- name: "get last run_id to destroy"
+  rundb:
+    conn_str: "{{ rundb_conn }}"
+    operation: get
+    table: "{{ target }}"
+    key: run_id
+  register: orig_run_id
+  when: state == "absent"
+
+- name: "get last uhash to destroy"
+  rundb:
+    conn_str: "{{ rundb_conn }}"
+    operation: get
+    table: "{{ target }}"
+    key: uhash
+  register: uhash
+  when: state == "absent"
+
+- name: "get uhash from last 4 of full hash"
+  set_fact:
+    uhash: "{{ uhash.output }}"
+  when: state == "absent"
 
 - name: "set unique-ish hash into rundb"
   rundb:


### PR DESCRIPTION
When running linchpin with ansible-playbook for debugging purposes, it could not run destroy actions because the uhash, and orig_run_id needed to be looked up. Additionally, if the rundb_conn_type value was file, the path is now created if it doesn't exist.