### PR TITLE
Allow Jinja2 templating to exist in separate files

### DIFF
--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -129,7 +129,7 @@ class LinchpinCli(LinchpinAPI):
             Whether the pinfile is supposed to already exist (default: True)
         """
 
-        pinfile = self.get_cfg('lp', 'default_pinfile')
+        pinfile = self.get_cfg('lp', 'default_pinfile', default='PinFile')
         if self.pinfile:
             pinfile = self.pinfile
 

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -190,7 +190,10 @@ class LinchpinCli(LinchpinAPI):
 
         if pf:
             provision_data = self._build(pf, pf_data)
-            print('provision_data: {}'.format(provision_data))
+
+            pf_outfile = self.get_cfg('tmp', 'output_pinfile')
+            if pf_outfile:
+                self.parser.write_json(provision_data, pf_outfile)
 
             return self._execute(provision_data,
                                  targets=targets,

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -112,7 +112,9 @@ def _handle_results(ctx, results, return_code):
 @click.option('-p', '--pinfile', envvar='PINFILE',
               help='Use a name for the PinFile different from'
                    ' the configuration.')
-@click.option('-d', '--template-data', metavar='template_data',
+@click.option('-d', '--template-data', metavar='TEMPLATE_DATA',
+              help='Write out PinFile to provided location')
+@click.option('-o', '--output-pinfile', metavar='OUTPUT_PINFILE',
               help='Template data passed to PinFile template')
 @click.option('-w', '--workspace', type=click.Path(), envvar='WORKSPACE',
               help='Use the specified workspace if the familiar Jenkins'
@@ -125,7 +127,7 @@ def _handle_results(ctx, results, return_code):
               help='Use the specified credentials path if CREDS_PATH'
                    'environment variable is not set')
 @pass_context
-def runcli(ctx, config, pinfile, template_data,
+def runcli(ctx, config, pinfile, template_data, output_pinfile,
            workspace, verbose, version, creds_path):
     """linchpin: hybrid cloud orchestration"""
 
@@ -138,6 +140,9 @@ def runcli(ctx, config, pinfile, template_data,
 
     # if the pinfile is a template, data will be passed here
     ctx.pf_data = template_data
+
+    if output_pinfile:
+        ctx.set_cfg('tmp', 'output_pinfile', output_pinfile)
 
     ctx.pinfile = None
     if pinfile:

--- a/linchpin/utils/dataparser.py
+++ b/linchpin/utils/dataparser.py
@@ -30,13 +30,13 @@ class DataParser(object):
         self._mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
 
 
-    def process(self, pf_w_path, data_w_path=None):
+    def process(self, file_w_path, data_w_path=None):
         """ Processes the PinFile and any data (if a template)
         using Jinja2. Returns json of PinFile, topology, layout,
-        and hooks data
+        and hooks.
 
-        :param pf_w_path:
-            Full path to the provided Pinfile
+        :param file_w_path:
+            Full path to the provided file to process
 
         :param targets:
             A tuple of targets to provision
@@ -45,8 +45,8 @@ class DataParser(object):
             An optional run_id if the task is idempotent or a destroy action
         """
 
-        with open(pf_w_path, 'r') as stream:
-            pinfile_data = stream.read()
+        with open(file_w_path, 'r') as stream:
+            file_data = stream.read()
 
             if data_w_path:
                 pf_data = data_w_path
@@ -56,10 +56,10 @@ class DataParser(object):
                 except Exception:
                     pass
 
-                pinfile_data = self.render(pinfile_data, pf_data)
-                return self.parse_json_yaml(pinfile_data)
+                file_data = self.render(file_data, pf_data)
+                return self.parse_json_yaml(file_data)
 
-        return self.load_pinfile(pf_w_path)
+        return self.load_pinfile(file_w_path)
 
 
     def render(self, template, context):
@@ -90,7 +90,10 @@ class DataParser(object):
         yaml.add_representer(dict, dict_representer)
         yaml.add_constructor(self._mapping_tag, dict_constructor)
 
-        data = yaml.load(data)
+        try:
+            data = yaml.load(data)
+        except Exception as e:
+            raise LinchpinError('YAML parsing error: {}'.format(e))
 
         if isinstance(data, dict):
             return data

--- a/linchpin/utils/dataparser.py
+++ b/linchpin/utils/dataparser.py
@@ -139,3 +139,8 @@ class DataParser(object):
                 raise LinchpinError(e)
 
         return pf
+
+    def write_json(self, provision_data, pf_outfile):
+
+        with open(pf_outfile, 'w') as outfile:
+            json.dump(provision_data, outfile, indent=4)

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
-__short_version__ = '1.2.0'
-__version__ = '1.2.0'
+__short_version__ = '1.5.0'
+__version__ = '1.5.0.pre1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=17.1
+setuptools>=35.0
 pyopenssl
 boto>=2.40.0
 apache-libcloud>=0.20.1

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,16 @@ setup(
     ''',
     extras_require={
         'krbV': ["python-krbV"],
-        'beaker': ['beaker-client>=23.3'],
+        'beaker': ['beaker-client>=23.3', 'python-krbV'],
         'docs': ["docutils", "sphinx", "sphinx_rtd_theme"],
         'tests': ["nose", "mock", "coverage", "flake8"],
         'libvirt': ["libvirt-python>=3.0.0", "lxml"],
     },
     zip_safe=False,
     packages=find_packages(),
-    include_package_data=True
-    # scripts=['scripts/linchpin_complete.sh']
+    include_package_data=True,
+    scripts=[
+        'scripts/install_libvirt_deps.sh',
+        'scripts/install_selinux_venv.sh'
+    ]
 )


### PR DESCRIPTION
@jaypoulz pointed out that while Jinja2 template processing was working in a single PinFile, it failed when including the topology or layout files. He suggested LinchPin process those files as well. This PR addresses processing those files as well. Each file gets processed independently using the template-data passed.

Additionally, this output can be written out to a file during to an action 'up' task.

Fixes #428 
Fixes #426 