### PR TITLE
Fixed failure when workspace != cwd

### DIFF
--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -668,8 +668,10 @@ class LinchpinAPI(object):
                                                                action,
                                                                'site.yml'))
         extra_var = self.get_evar()
+        inventory_src = '{0}/localhost'.format(self.workspace)
 
         return ansible_runner(playbook_path,
                               module_path,
                               extra_var,
+                              inventory_src=inventory_src,
                               console=console)


### PR DESCRIPTION
When using the linchpin API where the workspace != CWD, the provisioning step would fail with the error:

`    [WARNING]: Unable to parse .../localhost as an inventory source.`

This is because the call to ansible_runner in the file **linchpin/aspi/__init__.py** (line 672) was relying on the default inventory_src ('localhost') instead of providing the explicit path. This change adds the inventory_src parameter as a path that matches the localhost path identified/created in lines 501-503 of the **__init__.py** file.