### PR TITLE
Miscellaneous Fixes and Updates, v1.5.0-rc1 release

### DIFF
--- a/Dockerfiles/centos6/Dockerfile
+++ b/Dockerfiles/centos6/Dockerfile
@@ -6,13 +6,34 @@ ENV HOME=/root
 WORKDIR $HOME
 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+
 RUN yum -y install python-pip ansible curl gcc python-devel openssl-devel \
-                   libvirt-daemon-driver-* libvirt-daemon libvirt-daemon-kvm \
-                   qemu-kvm libvirt-daemon-config-network libvirt-python \
-                   libvirt-devel libxml2-devel libxslt-devel file openssh \
-                   mkisofs libvirt-client virt-install net-tools && yum clean all
+                   qemu-kvm libxml2-devel libxslt-devel file openssh \
+                   python-jinja2-26 mkisofs libvirt-client libffi-devel
+
+# install Libvirt deps
+RUN yum -y install libvirt libvirt-devel libvirt-client libvirt-python \
+                   virt-install net-tools qemu-kvm libvirt-python \
+                   libguestfs-tools policycoreutils-python bridge-utils
+
+RUN echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
+
 RUN pip install -U pip
 RUN pip install -U setuptools
+
+# Per https://github.com/ansible/ansible/issues/276#issuecomment-54228436
+# to fix the error:
+# AttributeError: 'module' object has no attribute 'HAVE_DECL_MPZ_POWM_SEC'
+RUN pip uninstall -y pycrypto
+RUN yum -y remove python-crypto
+RUN yum -y install python-crypto python-paramiko
+
+# fix python-six missing
+RUN yum -y remove python-six python-requests python-urllib3
+RUN yum -y install cloud-init
+RUN pip install six requests urllib3 PyOpenSSL --force --upgrade
+
+RUN yum clean all
 
 COPY linchpin-install.sh $HOME/
 COPY linchpin-test.sh $HOME/
@@ -20,7 +41,8 @@ COPY pip_install.sh $HOME/
 COPY centos6/start_libvirtd.sh $HOME/
 
 RUN $HOME/pip_install.sh
-RUN mkdir -p $HOME/.config
+#RUN mkdir -p $HOME/.config
+
 
 # /wordir should include the source code of linchpin
 VOLUME [ "/workdir" ]

--- a/Dockerfiles/centos6/Dockerfile
+++ b/Dockerfiles/centos6/Dockerfile
@@ -8,13 +8,14 @@ WORKDIR $HOME
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 
 RUN yum -y install python-pip ansible curl gcc python-devel openssl-devel \
-                   qemu-kvm libxml2-devel libxslt-devel file openssh \
-                   python-jinja2-26 mkisofs libvirt-client libffi-devel
+                   libxml2-devel libxslt-devel file openssh \
+                   python-jinja2-26libffi-devel
 
 # install Libvirt deps
 RUN yum -y install libvirt libvirt-devel libvirt-client libvirt-python \
-                   virt-install net-tools qemu-kvm libvirt-python \
-                   libguestfs-tools policycoreutils-python bridge-utils
+                   qemu-kvm virt-install net-tools qemu-kvm libvirt-python \
+                   mkisofs libvirt-client libguestfs-tools \
+                   policycoreutils-python bridge-utils
 
 RUN echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
 

--- a/Dockerfiles/linchpin-test.sh
+++ b/Dockerfiles/linchpin-test.sh
@@ -4,9 +4,9 @@ DRIVER=$1
 
 function clean_up {
     set +e
-    linchpin -v down $DRIVER
+    linchpin -v destroy $DRIVER
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM
 
-pushd /workdir/Dockerfiles/lp_test_workspace
+pushd /workdir/docs/source/examples/workspace
 linchpin -v up $DRIVER

--- a/Dockerfiles/run_tests.sh
+++ b/Dockerfiles/run_tests.sh
@@ -5,13 +5,15 @@ shift
 TARGETS=$*
 DRIVERS="dummy duffy libvirt"
 
-# Pull latest example topolgies
-if [ -d "lp_test_workspace" ]; then
-    pushd lp_test_workspace && git pull
-    popd
-else
-    git clone https://github.com/herlo/lp_test_workspace.git
-fi
+# NOTE: this is replaced by workdir/docs/source/examples/workspace
+# in the linchpin repo
+# Pull latest example topologies
+#if [ -d "lp_test_workspace" ]; then
+#    pushd lp_test_workspace && git pull
+#    popd
+#else
+#    git clone https://github.com/herlo/lp_test_workspace.git
+#fi
 
 # Pull down duffy-ansible-module
 if [ -d "duffy-ansible-module" ]; then

--- a/docs/source/centos6_install.rst
+++ b/docs/source/centos6_install.rst
@@ -1,0 +1,111 @@
+Installing LinchPin on CentOS 6
+===============================
+
+Installing LinchPin on CentOS 6 is a bit of a special snowflake. Because
+of the age of the distribution, and the newness of the libraries used by
+LinchPin, system packages and python packages will conflict.
+
+.. note:: It's possible this document could be used to install RHEL6 packages
+   as well. Please consult the Red Hat documentation.
+
+Follow this document very carefully, completing each section in order. It's
+imperative to a working LinchPin installation.
+
+System Packages
+---------------
+
+Install the EPEL RPM.
+
+.. code-block:: bash
+
+    $ sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+
+Follow this up with the LinchPin dependencies. This shouldn't differ from the
+standard :doc:`installation`.
+
+.. code-block:: bash
+
+    $ sudo yum install python-pip python-virtualenv libffi-devel \
+    openssl-devel libyaml-devel gmp-devel libselinux-python make \
+    gcc redhat-rpm-config libxml2-python libxslt-python
+
+Next install some additional dependencies used for installing LinchPin via the
+python pip package manager.
+
+.. code-block:: bash
+
+    $ sudo yum install gcc python-devel libxslt-devel \
+    python-jinja2-26 libffi-devel
+
+Pip Packages
+------------
+
+Because pip and setuptools from RPM are too old, update them.
+
+.. note:: Using ``--force`` is required because otherwise other tools depend
+   on a newer setuptools
+
+.. code-block:: bash
+
+    $ pip install pip setuptools --force --upgrade
+
+So far this has been rather simple. This next part is critical. To address
+`AttributeError: 'module' object has no attribute 'HAVE_DECL_MPZ_POWM_SEC
+<https://github.com/ansible/ansible/issues/276#issuecomment-54228436>`_,
+perform the following tasks in order.
+
+.. code-block:: bash
+
+    $ sudo pip uninstall pycrypto
+    $ sudo yum install python-crypto python-paramiko
+
+This removes the python-crypto RPM and pycrypto pip package, then puts the
+older python-crypto RPM back. In a minute, we'll update that to a newer version.
+
+When removing the above packages, it removed a few other dependencies. Add them
+back here.
+
+.. code-block:: bash
+
+    $ sudo yum remove python-six python-requests python-urllib3
+    $ sudo pip uninstall -y urllib3
+    $ sudo yum install cloud-init
+    $ sudo pip install six requests urllib3 PyOpenSSL --force --upgrade
+
+Installing LinchPin
+-------------------
+
+Now it is time to install LinchPin.
+
+.. code-block:: bash
+
+    $ sudo pip install linchpin
+
+Alternatively install from source.
+
+.. code-block:: bash
+
+    $ sudo yum install git
+    $ git clone git://github.com/CentOS-PaaS-SIG/linchpin.git
+    $ cd linchpin
+    $ sudo pip install .
+
+At this point, the ``linchpin`` command should work.
+
+.. code-block:: bash
+
+    $ linchpin --version
+    linchpin version 1.5.0
+
+Installation Script
+-------------------
+
+To make this easier, a script has been written which implements the above
+steps. In can be run from the scripts directory in a linchpin git checkout.
+
+:code1.5:`centos6_install.sh <scripts/centos6_install.sh>`
+
+.. seealso::
+
+    :doc:`providers`
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -353,7 +353,7 @@ extlinks = {
     'docs1.5': (
     'https://raw.githubusercontent.com/herlo/linchpin/docs1.5/docs/source/examples/%s', ''),
     'code1.5': (
-    'https://raw.githubusercontent.com/herlo/linchpin/docs1.5/linchpin/%s', ''),
+    'https://raw.githubusercontent.com/herlo/linchpin/docs1.5/%s', ''),
     'dirs1.5': (
     'https://github.com/herlo/linchpin/tree/docs1.5/docs/source/examples/%s', ''),
 }

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2,7 +2,7 @@ General Configuration
 ---------------------
 
 Managing LinchPin requires a few configuration files. Beyond
-:code1.5:`linchpin.conf`, there are a few other configurations that are
+:code1.5:`linchpin.conf <linchpin/linchpin.conf>`, there are a few other configurations that are
 checked . When running linchpin, four different locations are checked for
 linchpin.conf files. Files are checked in the following order:
 
@@ -11,7 +11,7 @@ linchpin.conf files. Files are checked in the following order:
 #. :file:`~/.config/linchpin/linchpin.conf`
 #. :file:`path/to/workspace/linchpin.conf`
 
-The linchpin configuration parser supports overriding and extension of
+The LinchPin configuration parser supports overriding and extension of
 configurations. Therefore, the existing configuration files are read.
 If linchpin finds the same configuration section header in more than one file,
 the header that was parsed more recently will provide the configuration for that

--- a/docs/source/examples/workspace/PinFile.complex.yml
+++ b/docs/source/examples/workspace/PinFile.complex.yml
@@ -137,5 +137,6 @@ libvirt-centos6:
 #bkr:
 #  topology: bkr.yml
 #
-#duffy:
-#  topology: duffy.yml
+duffy:
+  topology: duffy.yml
+  layout: duffy.yml

--- a/docs/source/examples/workspace/layouts/duffy.yml
+++ b/docs/source/examples/workspace/layouts/duffy.yml
@@ -1,0 +1,10 @@
+---
+inventory_layout:
+  vars:
+    hostname: __IP__
+  hosts:
+    example-node:
+      count: 1
+      host_groups:
+        - example
+

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -69,7 +69,7 @@ The following is a list of terms used throughout the LinchPin documentation.
     inventories_folder
         *(Default: inventories)*
 
-        A configuration entry in :code1.5:`linchpin.conf` which stores the relative location
+        A configuration entry in :code1.5:`linchpin.conf <linchpin/linchpin.conf>` which stores the relative location
         where inventories are stored.
 
     linchpin_config

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Currently, LinchPin can be run from any machine with Python 2.6+ (Python 3.x is currently experimental), and requires Ansible 2.3.1 or newer. 
+Currently, LinchPin can be run from any machine with Python 2.6+ (Python 3.x is currently experimental), and requires Ansible 2.3.1 or newer.
 
 .. note:: Some providers have additional dependencies. Additional software requirements can be found in the :doc:`providers` documentation.
 
@@ -27,15 +27,23 @@ As LinchPin is heavily dependent on Ansible 2.3.1 or newer, this is a core requi
 * libxml2-python
 * libxslt-python
 
-For Fedora/CentOS/RHEL the following packages should be installed
+For CentOS or RHEL the following packages should be installed:
 
 .. code-block:: bash
 
-    $ sudo yum install python-virtualenv libffi-devel \
+    $ sudo yum install python-pip python-virtualenv libffi-devel \
     openssl-devel libyaml-devel gmp-devel libselinux-python make \
     gcc redhat-rpm-config libxml2-python libxslt-python
 
-.. note:: Fedora will present an output suggesting the use of `dnf` as a replacement for yum.
+.. attention:: CentOS 6 (and likely RHEL 6) require special care during installation. See :doc:`centos6_install` for more detail.
+
+For Fedora 26+ the following packages should be installed:
+
+.. code-block:: bash
+
+    $ sudo dnf install python-virtualenv libffi-devel \
+    openssl-devel libyaml-devel gmp-devel libselinux-python make \
+    gcc redhat-rpm-config libxml2-python libxslt-python
 
 .. _installing_linchpin:
 

--- a/docs/source/intro_config.rst
+++ b/docs/source/intro_config.rst
@@ -3,14 +3,14 @@ Configuration File
 
 .. contents:: Topics
 
-Below is full coverage of each of the sections of the values available in :code1.5:`linchpin.conf`.
+Below is full coverage of each of the sections of the values available in :code1.5:`linchpin.conf <linchpin/linchpin.conf>`.
 
 Getting the most current configuration
 --------------------------------------
 
 If you are installing LinchPin from a package manager (pip or RPM), the latest linchpin.conf is already included in the library.
 
-An example :code1.5:`linchpin.conf` is available on Github.
+An example :code1.5:`linchpin.conf <linchpin/linchpin.conf>` is available on Github.
 
 For in-depth details of all the options, see the :doc:`Configuration Reference <configuration>` document.
 

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -70,6 +70,7 @@ class LinchpinAPI(object):
         self.set_evar('lp_path', lp_path)
         self.set_evar('pb_path', self.pb_path)
         self.set_evar('from_api', True)
+        self.workspace = self.get_evar('workspace')
 
 
     def setup_rundb(self):

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -623,10 +623,12 @@ class LinchpinAPI(object):
                 module_paths.append('{0}/{1}/'.format(path, module_folder))
 
             extra_vars = self.get_evar()
+            inventory_src = '{0}/localhost'.format(self.workspace)
 
             return_code, res = ansible_runner(playbook_path,
                                               module_paths,
                                               extra_vars,
+                                              inventory_src=inventory_src,
                                               console=console)
 
             if res:

--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -3,11 +3,20 @@ import sys
 import ansible
 from collections import namedtuple
 from contextlib import contextmanager
-from callbacks import PlaybookCallback
-from ansible.parsing.dataloader import DataLoader
-from ansible.executor.playbook_executor import PlaybookExecutor
 
 ansible24 = float(ansible.__version__[0:3]) >= 2.4
+
+# CentOS 6 EPEL provides an alternate Jinja2 package
+# Ansible uses Jinja2 here
+try:
+    from callbacks import PlaybookCallback
+    from ansible.parsing.dataloader import DataLoader
+    from ansible.executor.playbook_executor import PlaybookExecutor
+except ImportError:
+    sys.path.insert(0, '/usr/lib/python2.6/site-packages/Jinja2-2.6-py2.6.egg')
+    from callbacks import PlaybookCallback
+    from ansible.parsing.dataloader import DataLoader
+    from ansible.executor.playbook_executor import PlaybookExecutor
 
 if ansible24:
     from ansible.vars.manager import VariableManager

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -132,12 +132,16 @@ class LinchpinCli(LinchpinAPI):
                                         'default_pinfile',
                                         default='PinFile')
 
-        pf_w_path = os.path.abspath(os.path.expanduser(self.pinfile))
+        pf_w_path = os.path.realpath(os.path.expanduser(self.pinfile))
 
+        # Ensure a PinFile path will exist
         if not os.path.exists(pf_w_path) and exists:
             pf_w_path = '{0}/{1}'.format(self.workspace, self.pinfile)
-            self.ctx.log_state('{0} not found in provided workspace: '
-                               '{1}'.format(self.pinfile, self.workspace))
+
+        # If the PinFile doesn't exist, raise an error
+        if not os.path.exists(pf_w_path) and exists:
+            raise LinchpinError('{0} not found. Please check that it'
+                                ' exists and try again'.format(pf_w_path))
 
         return pf_w_path
 

--- a/linchpin/context.py
+++ b/linchpin/context.py
@@ -3,6 +3,9 @@
 import os
 import logging
 
+from linchpin.exceptions import LinchpinError
+from linchpin.version import __version__
+
 # FIXME: remove this later when not using python2.6
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -12,8 +15,6 @@ try:
 except ImportError:
     import ConfigParser as ConfigParser
 
-from linchpin.exceptions import LinchpinError
-from linchpin.version import __version__
 
 
 class LinchpinContext(object):

--- a/linchpin/context.py
+++ b/linchpin/context.py
@@ -3,6 +3,10 @@
 import os
 import logging
 
+# FIXME: remove this later when not using python2.6
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
 try:
     import configparser as ConfigParser
 except ImportError:

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -265,18 +265,6 @@ def up(ctx, targets, run_id):
         sys.exit(1)
 
 
-#@runcli.command()
-#@click.argument('targets', metavar='TARGET', required=False, nargs=-1)
-#@pass_context
-#def rise(ctx, targets):
-#    """
-#    DEPRECATED. Use 'up'
-#
-#    """
-#
-#    pass
-
-
 @runcli.command()
 @click.argument('targets', metavar='TARGET', required=False,
                 nargs=-1)
@@ -299,27 +287,6 @@ def destroy(ctx, targets, run_id):
     except LinchpinError as e:
         ctx.log_state(e)
         sys.exit(1)
-
-
-#@runcli.command()
-#@click.argument('targets', metavar='TARGET', required=False,
-#                nargs=-1)
-#@pass_context
-#def drop(ctx, targets):
-#    """
-#    DEPRECATED. Use 'destroy'.
-#
-#    There are now two functions, `destroy` and `down` which perform node
-#    teardown. The `destroy` functionality is the default, and if drop is
-#    used, will be called.
-#
-#    The `down` functionality is currently unimplemented, but will shutdown
-#    and preserve instances. This feature will only work on providers that
-#    support this option.
-#
-#    """
-#
-#    pass
 
 
 @runcli.command()

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -150,7 +150,7 @@ def _handle_results(ctx, results, return_code):
     sys.exit(return_code)
 
 
-@click.group(cls=DefaultGroup, default_if_no_args=True, default='halp',
+@click.group(cls=DefaultGroup, default_if_no_args=True, default='help',
              invoke_without_command=True,
              context_settings=CONTEXT_SETTINGS)
 @click.option('-c', '--config', type=click.Path(), envvar='LP_CONFIG',
@@ -211,9 +211,9 @@ def runcli(ctx, config, pinfile, template_data, output_pinfile,
     lpcli = LinchpinCli(ctx)
 
 
-@runcli.command('halp', short_help='Prints help')
+@runcli.command('help', short_help='Prints help')
 @click.pass_context
-def halp(ctx):
+def help(ctx):
     """
     Print help
     """
@@ -265,16 +265,16 @@ def up(ctx, targets, run_id):
         sys.exit(1)
 
 
-@runcli.command()
-@click.argument('targets', metavar='TARGET', required=False, nargs=-1)
-@pass_context
-def rise(ctx, targets):
-    """
-    DEPRECATED. Use 'up'
-
-    """
-
-    pass
+#@runcli.command()
+#@click.argument('targets', metavar='TARGET', required=False, nargs=-1)
+#@pass_context
+#def rise(ctx, targets):
+#    """
+#    DEPRECATED. Use 'up'
+#
+#    """
+#
+#    pass
 
 
 @runcli.command()
@@ -301,25 +301,25 @@ def destroy(ctx, targets, run_id):
         sys.exit(1)
 
 
-@runcli.command()
-@click.argument('targets', metavar='TARGET', required=False,
-                nargs=-1)
-@pass_context
-def drop(ctx, targets):
-    """
-    DEPRECATED. Use 'destroy'.
-
-    There are now two functions, `destroy` and `down` which perform node
-    teardown. The `destroy` functionality is the default, and if drop is
-    used, will be called.
-
-    The `down` functionality is currently unimplemented, but will shutdown
-    and preserve instances. This feature will only work on providers that
-    support this option.
-
-    """
-
-    pass
+#@runcli.command()
+#@click.argument('targets', metavar='TARGET', required=False,
+#                nargs=-1)
+#@pass_context
+#def drop(ctx, targets):
+#    """
+#    DEPRECATED. Use 'destroy'.
+#
+#    There are now two functions, `destroy` and `down` which perform node
+#    teardown. The `destroy` functionality is the default, and if drop is
+#    used, will be called.
+#
+#    The `down` functionality is currently unimplemented, but will shutdown
+#    and preserve instances. This feature will only work on providers that
+#    support this option.
+#
+#    """
+#
+#    pass
 
 
 @runcli.command()

--- a/linchpin/shell/click_default_group.py
+++ b/linchpin/shell/click_default_group.py
@@ -103,6 +103,13 @@ class DefaultGroup(click.Group):
         if not len(ctx.protected_args):
             ctx.protected_args.append(self.default_cmd_name)
 
+    def list_commands(self, ctx):
+        """
+        Provide a list of available commands. Anything deprecated should
+        not be listed
+        """
+
+        return ['init', 'up', 'destroy', 'fetch', 'journal']
 
     def get_command(self, ctx, cmd_name):
 

--- a/linchpin/utils/dataparser.py
+++ b/linchpin/utils/dataparser.py
@@ -4,13 +4,19 @@ import yaml
 import json
 import subprocess
 
-from jinja2 import BaseLoader
-from jinja2 import Environment
+# CentOS 6 EPEL provides an alternate Jinja2 package
+try:
+    from jinja2 import BaseLoader
+    from jinja2 import Environment
+except ImportError:
+    import sys
+    sys.path.insert(0, '/usr/lib/python2.6/site-packages/Jinja2-2.6-py2.6.egg')
+    from jinja2 import BaseLoader
+    from jinja2 import Environment
+
 
 from linchpin.exceptions import LinchpinError
 from linchpin.exceptions import ValidationError
-
-
 
 
 def dict_representer(dumper, data):

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
 __short_version__ = '1.5.0'
-__version__ = '1.5.0.pre1'
+__version__ = '1.5.0-rc1'

--- a/scripts/centos6_install.sh
+++ b/scripts/centos6_install.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+DISTRO=$(cat /etc/redhat-release | cut -f1 -d' ')
+
+if [ "${DISTRO}" == "CentOS" ] || [ "${DISTRO}" == "Red Hat" ]; then
+    if [ "${DISTRO}" == "CentOS" ]; then
+        VER=$(rpm -q --queryformat '%{VERSION}' centos-release)
+    else
+        VER=$(rpm -q --queryformat '%{RELEASE}' redhat-release-server | awk -F. '{print $1}')
+    fi
+
+    if [ "${VER}" != "6" ]; then
+        echo "Can only be run on CentOS 6 or Red Hat 6 systems"
+        exit 1
+    fi
+else
+    echo "Can only be run on CentOS 6 or Red Hat 6 systems"
+    exit 1
+fi
+
+SUDO=''
+
+if [ "$USER" != "root" ]; then
+    SUDO=$(which sudo)
+    echo "User is not root, using ${SUDO}"
+fi
+
+# Install the EPEL RPM.
+
+EPEL_PKG="epel-release"
+rpm -q ${EPEL_PKG} >  /dev/null
+RES=${?}
+if [ "${RES}" != "0" ]; then
+    ${SUDO} yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+    if [ "${?}" != 0 ]; then
+        exit 1
+    fi
+fi
+
+# Follow this up with the LinchPin dependencies.
+LP_PKGS="python-pip python-virtualenv libffi-devel openssl-devel libyaml-devel gmp-devel libselinux-python make gcc redhat-rpm-config libxml2-python libxslt-python"
+
+for pkg in ${LP_PKGS}; do
+    rpm -q ${pkg} > /dev/null
+    RES=${?}
+    if [ "${RES}" != "0" ]; then
+        ${SUDO} yum install -y ${pkg}
+        if [ "${?}" != 0 ]; then
+            exit 1
+        fi
+    fi
+done
+
+
+# install some additional dependencies used for installing LinchPin via the
+# python pip package manager.
+DEP_PKGS="gcc python-devel libxslt-devel python-jinja2-26 libffi-devel"
+
+for pkg in ${DEP_PKGS}; do
+    rpm -q ${pkg} > /dev/null
+    RES=${?}
+    if [ "${RES}" != "0" ]; then
+        ${SUDO} yum install -y ${pkg}
+        if [ "${?}" != 0 ]; then
+            exit 2
+        fi
+    fi
+done
+
+# Because pip and setuptools from RPM are too old, update them.
+# use --force because otherwise setuptools won't update
+${SUDO} pip install pip setuptools --force --upgrade
+
+# To address `AttributeError: 'module' object has no attribute 'HAVE_DECL_MPZ_POWM_SEC
+# <https://github.com/ansible/ansible/issues/276#issuecomment-54228436>`_,
+${SUDO} pip uninstall -y pycrypto
+
+CRYPTO_PKGS="python-crypto python-paramiko"
+
+for pkg in ${CRYPTO_PKGS}; do
+    rpm -q ${pkg} > /dev/null
+    RES=${?}
+    if [ "${RES}" != "0" ]; then
+        ${SUDO} yum install -y ${pkg}
+        if [ "${?}" != 0 ]; then
+            exit 3
+        fi
+    fi
+done
+
+# When removing the above packages, it removed a few other dependencies.
+# Add them back here.
+URL_PKGS="python-urllib3 python-six python-requests"
+
+for pkg in ${URL_PKGS}; do
+    rpm -q ${pkg} > /dev/null
+    RES=${?}
+    if [ "${RES}" == "0" ]; then
+        ${SUDO} yum remove -y ${pkg}
+        if [ "${?}" != 0 ]; then
+            exit 5
+        fi
+    fi
+done
+
+${SUDO} pip uninstall -y urllib3 six requests
+
+CLOUD_PKGS="cloud-init"
+for pkg in ${CLOUD_PKGS}; do
+    rpm -q ${pkg} > /dev/null
+    RES=${?}
+    if [ "${RES}" != "0" ]; then
+        ${SUDO} yum install -y ${pkg}
+        if [ "${?}" != 0 ]; then
+            exit 7
+        fi
+    fi
+done
+
+${SUDO} pip install six requests urllib3 PyOpenSSL --force --upgrade
+if [ "${?}" != 0 ]; then
+    exit 8
+fi
+
+echo
+echo
+echo "Dependencies installed. Install linchpin."
+echo "From pypi, run:"
+echo
+echo "sudo pip install linchpin"
+echo
+echo "or from source run:"
+echo
+echo "$ sudo yum install git"
+echo "$ git clone git://github.com/CentOS-PaaS-SIG/linchpin.git"
+echo "$ cd linchpin"
+echo "$ sudo pip install ."
+echo
+echo "Test it by running:"
+echo
+echo "linchpin --version"
+echo
+echo "The output should be something like:"
+echo
+echo "linchpin version 1.5.0"
+echo
+echo
+echo "Have a great day!"
+
+
+
+
+
+


### PR DESCRIPTION
Fixes in this PR include:
* CentOS 6 Dockerfile test was a bit wonky, so I updated it to work. Fixes #405 
* CentOS 6 also needed some adjustments with jinja2 templating. Addressed this here.
* Removed the python deprecation warnings for now. This is mostly due to CentOS 6 using python2.6.
* Added a bit to the centos6_install.rst document. This should help people install there. Plus, it has a script included that works.
* In the previous PR, the linchpin aliases were removed. I put them back into this one, even though they are likely not used.
* We're using a new workspace (which was actually included in the last PR), but this one fixes up the dummy target so that test will pass again. Also adjusted the linchpin down -> linchpin destroy in the Dockerfiles tests.

