### PR TITLE
Minor Beaker fixes

### DIFF
--- a/docs/source/examples/workspace/PinFile.jenkins.j2
+++ b/docs/source/examples/workspace/PinFile.jenkins.j2
@@ -1,5 +1,5 @@
 jenkins-slave:
-  topology: jenkins-slave.yml
+  topology: jenkins-slave.j2
   layout: jenkins-slave.yml
   {% if hooks %}
   hooks:

--- a/docs/source/examples/workspace/topologies/jenkins-slave.j2
+++ b/docs/source/examples/workspace/topologies/jenkins-slave.j2
@@ -5,7 +5,7 @@ resource_groups:
   resource_group_type: beaker
   resource_definitions:
   - role: bkr_server
-    job_group: multiarch-qe
+    job_group: "{{ job_group }}"
     whiteboard: "{{ arch }} slave for multiarch testing"
     recipesets:
     - distro: RHEL-7.4

--- a/linchpin/provision/beaker.yml
+++ b/linchpin/provision/beaker.yml
@@ -26,4 +26,4 @@
     - role: 'inventory_gen'
       when:
         - state == 'present'
-        - layout_file is defined or layout is defined
+        - layout_data is defined

--- a/linchpin/provision/roles/beaker/files/schema.json
+++ b/linchpin/provision/roles/beaker/files/schema.json
@@ -10,7 +10,7 @@
                     "allowed": ["bkr_server"]
                 },
                 "whiteboard": { "type": "string", "required": true },
-                "job_group": { "type": "string", "required": true },
+                "job_group": { "type": "string", "required": false },
                 "recipesets": {
                     "type": "list",
                     "schema": {


### PR DESCRIPTION
Since the Beaker ansible job allows the job_group to be blank, adjusting the schema to match.

Fixed an issue reported by @scoheb around beaker inventory generation. The inventory_gen role had an outdated when statement. This is now updated and should address the issue.