### PR TITLE
Optional uhash

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -78,7 +78,7 @@ class LinchpinAPI(object):
         Configures the run database parameters, sets them into extra_vars
         """
 
-        rundb_conn_default = '~/.config/linchpin/rundb-::mac::.json'
+        rundb_conn_default = '{0}/.rundb/rundb-::mac::.json'.format(self.workspace)
         rundb_conn = self.get_cfg(section='lp',
                                   key='rundb_conn',
                                   default=rundb_conn_default)

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -70,6 +70,7 @@ class LinchpinAPI(object):
         self.set_evar('lp_path', lp_path)
         self.set_evar('pb_path', self.pb_path)
         self.set_evar('from_api', True)
+        self.set_evar('enable_uhash', self.get_evar('enable_uhash', False))
         self.workspace = self.get_evar('workspace')
 
 

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -78,10 +78,10 @@ class LinchpinAPI(object):
         Configures the run database parameters, sets them into extra_vars
         """
 
-        rundb_conn_default = '{0}/.rundb/rundb-::mac::.json'.format(self.workspace)
+        rundb_conn_def = '{0}/.rundb/rundb-::mac::.json'.format(self.workspace)
         rundb_conn = self.get_cfg(section='lp',
                                   key='rundb_conn',
-                                  default=rundb_conn_default)
+                                  default=rundb_conn_def)
         rundb_type = self.get_cfg(section='lp',
                                   key='rundb_type',
                                   default='TinyRunDB')

--- a/linchpin/hooks/__init__.py
+++ b/linchpin/hooks/__init__.py
@@ -120,7 +120,7 @@ class LinchpinHooks(object):
         inv_folder = self.api.get_evar('inventories_folder')
         topo_name = topo_data.get('topology_name')
         uhash = self.api.get_evar('uhash')
-        uhash_enabled = self.api.get_evar('enable_uhash')
+        uhash_enabled = self.api.get_evar('enable_uhash', False)
         ext = self.api.get_cfg('extensions', 'inventory')
 
         inv_file = '{0}/{1}/{2}{3}'.format(workspace,

--- a/linchpin/hooks/__init__.py
+++ b/linchpin/hooks/__init__.py
@@ -120,13 +120,19 @@ class LinchpinHooks(object):
         inv_folder = self.api.get_evar('inventories_folder')
         topo_name = topo_data.get('topology_name')
         uhash = self.api.get_evar('uhash')
+        uhash_enabled = self.api.get_evar('enable_uhash')
         ext = self.api.get_cfg('extensions', 'inventory')
 
-        inv_file = '{0}/{1}/{2}-{3}{4}'.format(workspace,
-                                               inv_folder,
-                                               topo_name,
-                                               uhash,
-                                               ext)
+        inv_file = '{0}/{1}/{2}{3}'.format(workspace,
+                                           inv_folder,
+                                           topo_name,
+                                           ext)
+        if uhash_enabled:
+            inv_file = '{0}/{1}/{2}-{3}{4}'.format(workspace,
+                                                   inv_folder,
+                                                   topo_name,
+                                                   uhash,
+                                                   ext)
 
         self.api.target_data['extra_vars'] = {}
         self.api.target_data['extra_vars']['inventory_dir'] = inv_folder

--- a/linchpin/linchpin.conf
+++ b/linchpin/linchpin.conf
@@ -46,6 +46,11 @@ _async = False
 async_timeout = 1000
 default_ssh_key_path = ~/.ssh
 
+
+# the uhash value will still exist, but will not be added to
+# instances or the inventory_path
+enable_uhash = False
+
 # default paths in playbooks
 #
 # lp_path = <src_dir>/linchpin

--- a/linchpin/linchpin.conf
+++ b/linchpin/linchpin.conf
@@ -22,8 +22,8 @@ module_folder = library
 # rundb_conn is the location of the run database.
 # A common reason to move it is to use the rundb centrally across
 # the entire system, or in a central db on a shared filesystem.
-# Default: {{ workspace }}/.rundb/rundb.json
-#rundb_conn = %(default_config_path)s/rundb/rundb-::mac::.json
+# System-wide RunDB: rundb_conn = %(default_config_path)s/rundb-::mac::.json
+# Default: rundb_conn = {{ workspace }}/.rundb/rundb-::mac::.json
 #
 rundb_type = TinyRunDB
 rundb_conn_type = file

--- a/linchpin/linchpin.conf
+++ b/linchpin/linchpin.conf
@@ -24,7 +24,7 @@ module_folder = library
 # the entire system, or in a central db on a shared filesystem.
 # System-wide RunDB: rundb_conn = %(default_config_path)s/rundb-::mac::.json
 # Default: rundb_conn = {{ workspace }}/.rundb/rundb-::mac::.json
-#
+
 rundb_type = TinyRunDB
 rundb_conn_type = file
 rundb_schema = {"action": "",
@@ -46,10 +46,9 @@ _async = False
 async_timeout = 1000
 default_ssh_key_path = ~/.ssh
 
-
 # the uhash value will still exist, but will not be added to
 # instances or the inventory_path
-enable_uhash = False
+# enable_uhash = False
 
 # default paths in playbooks
 #

--- a/linchpin/provision/roles/dummy/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/dummy/tasks/provision_res_defs.yml
@@ -1,11 +1,12 @@
 ---
 - name: "Get the resource name"
   set_fact:
-    resource_name: "{{ res_def['name'] }}"
+    dummy_name: "{{ res_def['name'] }}"
 
 - name: "Assign dummy name using uhash value"
   set_fact:
-    dummy_name: "{{ resource_name + '-' + uhash }}"
+    dummy_name: "{{ dummy_name + '-' + uhash }}"
+  when: enable_uhash == True
 
 - name: "Provision dummy resources by looping on count"
   dummy:
@@ -21,4 +22,3 @@
 - name: "Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_dummy: "{{ topology_outputs_dummy + tmp }}"
-

--- a/linchpin/provision/roles/dummy/tasks/teardown_res_defs.yml
+++ b/linchpin/provision/roles/dummy/tasks/teardown_res_defs.yml
@@ -1,11 +1,12 @@
 ---
 - name: "Get the resource name"
   set_fact:
-    resource_name: "{{ res_def['res_name'] | default(res_def['name']) }}"
+    dummy_name: "{{ res_def['name'] }}"
 
 - name: "Assign dummy name using uhash value"
   set_fact:
-    dummy_name: "{{ resource_name + '-' + uhash }}"
+    dummy_name: "{{ dummy_name + '-' + uhash }}"
+  when: enable_uhash == True
 
 - name: "Teardown dummy resources by looping on count"
   dummy:

--- a/linchpin/provision/roles/gcloud/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/gcloud/tasks/provision_res_defs.yml
@@ -16,12 +16,12 @@
 
 - name: "Get the resource name"
   set_fact:
-    rsrc_name: "{{ res_def['res_name'] | default(res_def['name']) }}"
+    gce_resource_name: "{{ res_def['name'] }}"
 
 - name: "Create name using uhash value"
   set_fact:
-    gce_resource_name: "{{ rsrc_name + '-' + uhash }}"
+    gce_resource_name: "{{ gce_resource_name + '-' + uhash }}"
+  when: enable_uhash == True
 
-#- name: "Register resource count"
 - name: "provision resource type : {{ res_def['role'] }}"
   include: "provision_{{ res_def['role'] }}.yml"

--- a/linchpin/provision/roles/inventory_gen/tasks/main.yml
+++ b/linchpin/provision/roles/inventory_gen/tasks/main.yml
@@ -13,6 +13,13 @@
   set_fact:
     inventory_path: "{{ inventory_path | default( workspace +'/'+inventories_folder+'/'+
     topology_name.replace(' ', '_').lower() ) + '-' + uhash }}.inventory"
+  when: enable_uhash == True
+
+- name: "Updating inventory_path with the absolute path"
+  set_fact:
+    inventory_path: "{{ inventory_path | default( workspace +'/'+inventories_folder+'/'+
+    topology_name.replace(' ', '_').lower() ) }}.inventory"
+  when: enable_uhash == False
 
 - name: "Generate Generic Inventory"
   template:

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -31,6 +31,7 @@
                     "boot_from_volume": { "type": "boolean", "required": false },
                     "volume_size": { "type": "string", "required": false },
                     "boot_volume": { "type": "string", "required": false },
+                    "remote_user": { "type": "string", "required": false },
                     "cloud_config": { "required": false },
                     "networks": {
                         "type": "list",

--- a/linchpin/provision/roles/libvirt/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_res_defs.yml
@@ -17,11 +17,12 @@
 
 - name: "Set the resource node name"
   set_fact:
-    rsrc_name: "{{ res_def['res_name'] | default(res_def['name']) }}"
+    libvirt_resource_name: "{{ res_def['name'] }}"
 
 - name: "Create name using uhash value"
   set_fact:
-    libvirt_resource_name: "{{ rsrc_name + '-' + uhash }}"
+    libvirt_resource_name: "{{ libvirt_resource_name + '-' + uhash }}"
+  when: enable_uhash == True
 
 - name: "provision libvirt node"
   include: provision_libvirt_node.yml

--- a/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml
@@ -11,11 +11,12 @@
 
 - name: "Get the resource name"
   set_fact:
-    rsrc_name: "{{ res_def['res_name'] | default(res_def['name']) }}"
+    os_resource_name: "{{ res_def['name'] }}"
 
 - name: "Create name using uhash value"
   set_fact:
-    os_resource_name: "{{ rsrc_name + '-' + uhash + '-' }}"
+    os_resource_name: "{{ os_resource_name + '-' + uhash + '-' }}"
+  when: enable_uhash == True
 
 - name: "provision/teardown resources }}"
   include: "provision_{{ res_def['role'] }}.yml"

--- a/linchpin/tests/mockdata/dummy/conf/linchpin.conf
+++ b/linchpin/tests/mockdata/dummy/conf/linchpin.conf
@@ -19,8 +19,13 @@ module_folder = library
 
 # rundb tracks provisioning transactions
 # If you add a new one, rundb/drivers.py needs to be updated to match
+# rundb_conn is the location of the run database.
+# A common reason to move it is to use the rundb centrally across
+# the entire system, or in a central db on a shared filesystem.
+# System-wide RunDB: rundb_conn = %(default_config_path)s/rundb-::mac::.json
+# Default: rundb_conn = {{ workspace }}/.rundb/rundb-::mac::.json
+
 rundb_type = TinyRunDB
-rundb_conn = %(default_config_path)s/rundb-::mac::.json
 rundb_conn_type = file
 rundb_schema = {"action": "",
                 "inputs": [],
@@ -41,6 +46,10 @@ _async = False
 async_timeout = 1000
 output = True
 default_ssh_key_path = ~/.ssh
+
+# the uhash value will still exist, but will not be added to
+# instances or the inventory_path
+enable_uhash = True
 
 # default paths in playbooks
 #


### PR DESCRIPTION
Fixes #433 - Moves the rundb into the workspace. The default location is `<workspace>/.rundb/rundb-<macidvalue>.json`

Fixes #434 - Addresses the default value for `enable_uhash`, which is False. Those who wish to have the uhash enabled must turn this on in their configuration file. 

It passes the test [here](https://gitlab.cee.redhat.com/ci-ops/cinch-docs-internal#create-a-jenkins-master-in-openstack-with-vagrant-for-developmenttesting) provided by @robled.

