### PR TITLE
Run destroy action even if no RunDB records are found

### DIFF
--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -8,8 +8,8 @@ aws_ec2
 
 AWS Instances can be provisioned using this resource.
 
-* :docs1.5:`Topology Example <workspace/topologies/os-server-new.yml>`
-* `aws_ec2 module <http://docs.ansible.com/ansible/latest/os_server_module.html>`_
+* :docs1.5:`Topology Example <workspace/topologies/aws-ec2-new.yml>`
+* `aws_ec2 module <http://docs.ansible.com/ansible/latest/ec2_module.html>`_
 
 aws_ec2_key
 -----------

--- a/docs/source/examples/workspace/linchpin.conf
+++ b/docs/source/examples/workspace/linchpin.conf
@@ -190,7 +190,7 @@ generate_resources = False
 #enable = True
 
 # Full path to the location of the linchpin log file
-file = %(default_config_path)s/linchpin.log
+file = ~/.config/linchpin/linchpin.log
 
 # Log format used. See https://docs.python.org/2/howto/logging-cookbook.html
 #format = %%(levelname)s %%(asctime)s %%(message)s

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -455,7 +455,6 @@ class LinchpinAPI(object):
                                                      run_id=run_id)
 
                 if data:
-                    self.set_evar('orig_run_id', orig_run_id)
                     uhash = data.get('uhash')
                     self.ctx.log_debug("using data from"
                                        " run_id: {0}".format(run_id))
@@ -500,6 +499,7 @@ class LinchpinAPI(object):
             rundb.update_record(target, rundb_id, 'start', start)
             rundb.update_record(target, rundb_id, 'action', action)
 
+            self.set_evar('orig_run_id', orig_run_id)
             self.set_evar('rundb_id', rundb_id)
             self.set_evar('uhash', uhash)
 

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -441,12 +441,14 @@ class LinchpinAPI(object):
             # generate a new rundb_id
             # (don't confuse it with an already existing run_id)
             rundb_id = rundb.init_table(target)
+            orig_run_id = rundb_id
 
-            if action == 'up' and not run_id:
+            if not run_id:
                 uh = hashlib.new(self.rundb_hash,
                                  ':'.join([target, str(rundb_id), start]))
                 uhash = uh.hexdigest()[-4:]
-            elif action == 'destroy' or run_id:
+
+            if action == 'destroy' or run_id:
                 # look for the action='up' records to destroy
                 data, orig_run_id = rundb.get_record(target,
                                                      action='up',
@@ -457,38 +459,38 @@ class LinchpinAPI(object):
                     uhash = data.get('uhash')
                     self.ctx.log_debug("using data from"
                                        " run_id: {0}".format(run_id))
-                else:
-                    # add data to the current record so it doesn't cause
-                    # inconsistent results
-                    rundb.update_record(target,
-                                        rundb_id,
-                                        'action',
-                                        action)
-                    rundb.update_record(target,
-                                        rundb_id,
-                                        'rc',
-                                        8)
-                    if not uhash:
-                        uh = hashlib.new(self.rundb_hash,
-                                         ':'.join([target,
-                                                   str(rundb_id),
-                                                   start]))
-                        uhash = uh.hexdigest()[-4:]
-                        rundb.update_record(target,
-                                            rundb_id,
-                                            'uhash',
-                                            uhash)
-
-
-                    raise LinchpinError("Attempting to perform '{0}' action on"
-                                        " target: '{1}' failed. No records"
-                                        " available.".format(action, target))
-            else:
+#                else:
+#                    # add data to the current record so it doesn't cause
+#                    # inconsistent results
+#                    rundb.update_record(target,
+#                                        rundb_id,
+#                                        'action',
+#                                        action)
+#                    rundb.update_record(target,
+#                                        rundb_id,
+#                                        'rc',
+#                                        8)
+#                    if not uhash:
+#                        uh = hashlib.new(self.rundb_hash,
+#                                         ':'.join([target,
+#                                                   str(rundb_id),
+#                                                   start]))
+#                        uhash = uh.hexdigest()[-4:]
+#                        rundb.update_record(target,
+#                                            rundb_id,
+#                                            'uhash',
+#                                            uhash)
+#
+#
+#                    raise LinchpinError("Attempting to perform '{0}' action on"
+#                                        " target: '{1}' failed. No records"
+#                                        " available.".format(action, target))
+            elif action not in ['up', 'destroy']:
                 # it doesn't appear this code will will execute,
                 # but if it does...
                 raise LinchpinError("Attempting '{0}' action on"
-                                    " target: '{1}' failed. No records"
-                                    " available.".format(action, target))
+                                    " target: '{1}' failed. Not an"
+                                    " action.".format(action, target))
 
 
             self.ctx.log_debug('rundb_id: {0}'.format(rundb_id))
@@ -578,7 +580,7 @@ class LinchpinAPI(object):
             rundb.update_record(target, rundb_id, 'end', end)
             rundb.update_record(target, rundb_id, 'rc', return_code)
 
-            if action == 'destroy':
+            if action == 'destroy' and orig_run_id:
                 run_data = rundb.get_record(target,
                                             action=action,
                                             run_id=orig_run_id)

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -183,7 +183,7 @@ class LinchpinCli(LinchpinAPI):
             A tuple of targets to provision
 
         :param run_id:
-            An optional run_id if the task is idempotent or a destroy action
+            An optional run_id if the task is idempotent
         """
 
         pf_w_path = self._get_pinfile_path()

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -1,8 +1,4 @@
 ---
-- name: current res_grp
-  debug:
-    var: res_grp
-
 - name: "Set cred profile"
   set_fact:
     cred_profile: "{{ res_grp['credentials']['profile'] | default('default') }}"
@@ -24,7 +20,7 @@
   ignore_errors: true
   when: auth_var is defined
 
-- name: "Get topology output data"
+- name: "Get topology output data from RunDb"
   rundb:
     conn_str: "{{ rundb_conn }}"
     operation: get
@@ -32,10 +28,25 @@
     key: "outputs"
     run_id: "{{ orig_run_id }}"
   register: topo_output
+  when: not generate_resources
 
 - name: "set topo_output_resources fact"
   set_fact:
     topo_output_resources: "{{ topo_output.output[0]['resources'] }}"
+  when: not generate_resources
+
+- name: "Get topology output data from resources file"
+  output_parser:
+    output_file: "{{ default_resources_path + '/' +
+                 topo_data['topology_name'].replace(' ', '_').lower() + '.output' }}"
+  register: topo_output
+  when: generate_resources
+
+- name: "set topo_output_resources fact"
+  set_fact:
+    topo_output_resources: "{{ topo_output.output['content'] }}"
+  when: generate_resources
+
 
 # patch for role to type translation
 - name: "Add attribute role to res_grp resource_definitions"
@@ -47,7 +58,7 @@
   when: res_item.0['role'] == "aws_ec2"
   with_nested:
     - "{{ resource_definitions }}"
-    - "{{ topo_output_resources }}"
+    - "{{ topo_output_resources['aws_ec2'] }}"
     - ["{{ res_grp['resource_group_name']  }}"]
   loop_control:
     loop_var: res_item

--- a/linchpin/provision/roles/beaker/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/teardown_resource_group.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Get topology output data"
+- name: "Get topology output data from RunDB"
   rundb:
     conn_str: "{{ rundb_conn }}"
     operation: get
@@ -7,10 +7,24 @@
     key: "outputs"
     run_id: "{{ orig_run_id }}"
   register: topo_output
+  when: not generate_resources
 
 - name: "set topo_output_resources fact"
   set_fact:
     topo_output_resources: "{{ topo_output.output[0]['resources'] }}"
+  when: not generate_resources
+
+- name: "Get topology output data resources file"
+  output_parser:
+    output_file: "{{ default_resources_path + '/' +
+                 topo_data['topology_name'].replace(' ', '_').lower() + '.output' }}"
+  register: topo_output
+  when: generate_resources
+
+- name: "set topo_output_resources fact"
+  set_fact:
+    topo_output_resources: "{{ topo_output.output['content']['beaker_res'] }}"
+  when: generate_resources
 
 - name: "init job_ids"
   set_fact:


### PR DESCRIPTION
When running a destroy, use the existing topology for v1.0.x compatibility 