### PR TITLE
Allow passing provisioning options through to bkr_info

### DIFF
--- a/docs/source/examples/workspace/topologies/bkr-new.yml
+++ b/docs/source/examples/workspace/topologies/bkr-new.yml
@@ -5,7 +5,6 @@ resource_groups:
     resource_group_type: beaker
     resource_definitions:
       - role: bkr_server
-        whiteboard: Provisioned with linchpin
         job_group: ci-ops-central
         recipesets:
           - distro: RHEL-6.5
@@ -17,10 +16,21 @@ resource_groups:
               - tag: device
                 op: "="
                 type: "network"
+              - tag: hostname
+                op: "like"
+                value: "%.subdomain.example.tld"
             count: 1
       - role: bkr_server
-        whiteboard: Provisioned with linchpin
         job_group: ci-ops-central
+        # option to set job whiteboard message
+        whiteboard: Provisioned with linchpin
+        # options to configure amount of time spent polling beaker:
+        # 60 attempts with 30 seconds wait time between them,
+        # provisioning timeout is roughly 1800 seconds
+        max_attempts: 60
+        attempt_wait_time: 30
+        # option to set cancellation message if linchpin cancels provisioning
+        cancel_message: Job cancelled on account of rain
         recipesets:
           - distro: RHEL-6.5
             arch: x86_64

--- a/docs/source/examples/workspace/topologies/bkr-new.yml
+++ b/docs/source/examples/workspace/topologies/bkr-new.yml
@@ -6,6 +6,15 @@ resource_groups:
     resource_definitions:
       - role: bkr_server
         job_group: ci-ops-central
+        # option to set job whiteboard message
+        whiteboard: Provisioned with linchpin
+        # options to configure amount of time spent polling beaker:
+        # 60 attempts with 60 seconds wait time between them,
+        # provisioning timeout is roughly 3600 seconds
+        max_attempts: 60
+        attempt_wait_time: 60
+        # option to set cancellation message if linchpin cancels provisioning
+        cancel_message: Job cancelled on account of rain
         recipesets:
           - distro: RHEL-6.5
             arch: x86_64
@@ -16,21 +25,9 @@ resource_groups:
               - tag: device
                 op: "="
                 type: "network"
-              - tag: hostname
-                op: "like"
-                value: "%.subdomain.example.tld"
             count: 1
       - role: bkr_server
         job_group: ci-ops-central
-        # option to set job whiteboard message
-        whiteboard: Provisioned with linchpin
-        # options to configure amount of time spent polling beaker:
-        # 60 attempts with 30 seconds wait time between them,
-        # provisioning timeout is roughly 1800 seconds
-        max_attempts: 60
-        attempt_wait_time: 30
-        # option to set cancellation message if linchpin cancels provisioning
-        cancel_message: Job cancelled on account of rain
         recipesets:
           - distro: RHEL-6.5
             arch: x86_64

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -259,6 +259,11 @@ class LinchpinAPI(object):
                                                  'Provisioned with LinchPin')
             res_defs['job_group'] = res_grp.pop('job_group')
             res_defs['recipesets'] = res_grp.pop('recipesets')
+            res_defs['cancel_message'] = res_grp.pop('cancel_message',
+                                                     'Canceled by LinchPin')
+            res_defs['max_attempts'] = res_grp.pop('max_attempts', 60)
+            res_defs['attempt_wait_time'] = res_grp.pop('attempt_wait_time',
+                                                        60)
             res_grp['resource_definitions'] = [res_defs]
 
             return res_grp

--- a/linchpin/provision/library/bkr_info.py
+++ b/linchpin/provision/library/bkr_info.py
@@ -112,10 +112,12 @@ def main():
     beaker = BeakerTargets(mod.params)
     try:
         if len(beaker.ids) > 1:
-            mod.warn('Using multiple resource_definition for beaker resources'
-                     ' in topology is unsupported. Only the provisioning'
-                     ' parameters from the first resource_definition will be'
-                     ' used.')
+            mod.warn('When using multiple resource_definitions for beaker '
+                     'resources, only the provisioning parameters '
+                     '(max_attempts, attempt_wait_time) from the first '
+                     'resource_definition will be used. Consider using a '
+                     'single resource_definition with multiple recipes or '
+                     'recipesets instead.')
         results = beaker.get_system_statuses()
         mod.exit_json(hosts=results, changed=True)
     except Exception as ex:

--- a/linchpin/provision/library/bkr_info.py
+++ b/linchpin/provision/library/bkr_info.py
@@ -3,7 +3,6 @@ import os
 
 from time import sleep
 from sys import stderr
-from json import dumps
 import xml.etree.ElementTree as eT
 from ansible.module_utils.basic import AnsibleModule
 
@@ -12,32 +11,28 @@ from bkr.common.hub import HubProxy
 from bkr.common.pyconfig import PyConfigParser
 
 
-BEAKER_CONF = \
-    (os.environ.get('BEAKER_CONF', '/etc/beaker/client.conf'))
-WAIT_TIME = 60
+BEAKER_CONF = os.environ.get('BEAKER_CONF', '/etc/beaker/client.conf')
+
+
+def _jprefix(job_ids):
+    return ["J:" + _id for _id in job_ids]
 
 
 class BeakerTargets(object):
-    def __init__(self, params={}, logger=None):
-        self.__dict__ = params.copy()
+    def __init__(self, params, logger=None):
+        # params from AnsibleModule argument_spec below
+        self.ids = params['ids']
+        provision_params = params['provision_params']
+
+        # Set wait methods from provision params, with reasonable defaults
+        self.wait_time = provision_params.get('attempt_wait_time', 60)
+        self.max_attempts = provision_params.get('max_attempts', 60)
+
+        # set up beaker connection
         self.conf = PyConfigParser()
         default_config = os.path.expanduser(BEAKER_CONF)
         self.conf.load_from_file(default_config)
         self.hub = HubProxy(logger=logger, conf=self.conf)
-
-    def _get_url(self, bkr_id):
-        """
-        Constructs the Beaker URL for the job related to the provided Beaker
-        ID. That ID should be all numeric, unless the structure of Beaker
-        changes in the future. If that's the case, then the ID should be
-        appropriately URL encoded to be appended to the end of a URL properly.
-        """
-        base = self.conf.get('HUB_URL', '')
-        if base == '':
-            raise Exception("Unable to construct URL")
-        if base[-1] != '/':
-            base += '/'
-        return base + 'jobs/' + bkr_id
 
     def get_system_statuses(self):
         """
@@ -45,44 +40,45 @@ class BeakerTargets(object):
         hostname once the jobs have reached their defined status.
         """
         attempts = 0
-        pass_count = 0
-        all_count = len(self.ids)
         while attempts < self.max_attempts:
-            job_results = self._check_jobs(self.ids)
+            job_results, all_count = self._check_jobs()
             pass_count = 0
             for resource in job_results['resources']:
                 result = resource['result']
                 status = resource['status']
                 print >> stderr, "status: %s, result: %s" % (status, result)
                 if status not in ['Cancelled', 'Aborted']:
-                    if (result == 'Pass' or
-                       (result == 'Warn' and self.skip_no_system)):
+                    if result == 'Pass':
                         pass_count += 1
                     elif result in ['Fail', 'Warn', 'Panic', 'Completed']:
                         raise Exception("System failed with state"
                                         " '{0}'".format(result))
                 elif status == 'Aborted':
-                    if result == 'Warn' and self.skip_no_system:
-                        pass_count += 1
-                    else:
-                        raise Exception("System aborted")
+                    raise Exception("System aborted")
                 elif status == 'Cancelled':
                     raise Exception("System canceled")
             attempts += 1
             if pass_count == all_count:
                 return job_results['resources']
-            sleep(WAIT_TIME)
-        raise Exception("{0} system(s) never completed in {1}"
-                        " polling attempts. {2}".format(all_count - pass_count,
-                                                        attempts,
-                                                        dumps(job_results)))
+            sleep(self.wait_time)
 
+        # max attempts exceeded, cancel jobs and fail
+        for job_id in _jprefix(self.ids):
+            self.hub.taskactions.stop(job_id, 'cancel',
+                                      'Provision request timed out')
+        # Fail with error msg, include results from last attempt to include
+        # in topology outputs even if provisioning failed so a destroy still
+        # cancels jobs
+        msg = ("{0} system(s) never completed in {1} polling attempts, jobs "
+               "have been cancelled: {2}".format(
+                   all_count - pass_count, attempts, ','.join(self.ids)))
+        raise Exception(msg, job_results['resources'])
 
-    def _check_jobs(self, ids):
+    def _check_jobs(self):
         """
             Get state of a job in Beaker
         """
-        jobs = ["J:" + _id for _id in ids]
+        jobs = _jprefix(self.ids)
         results = {}
         resources = []
         bkrcmd = BeakerCommand('BeakerCommand')
@@ -91,9 +87,7 @@ class BeakerTargets(object):
             myxml = self.hub.taskactions.to_xml(task)
             myxml = myxml.encode('utf8')
             root = eT.fromstring(myxml)
-            # TODO: Using getiterator() since its backward compatible
-            # with Python 2.6
-            # This is deprectated in 2.7 and we should be using iter()
+            # Using getiterator() since its backward compatible with py26
             for job in root.getiterator('job'):
                 results.update({'job_id': job.get('id'),
                                 'results': job.get('result')})
@@ -107,21 +101,27 @@ class BeakerTargets(object):
                                   'result': recipe.get('result'),
                                   'id': recipe.get('job_id')})
                 results.update({'resources': resources})
-        return results
+        return results, len(resources)
 
 
 def main():
     mod = AnsibleModule(argument_spec={
-        'ids': {'type': 'list'},
-        'skip_no_system': {'type': 'bool', 'default': False},
-        'max_attempts': {'type': 'int', 'default': 60}
+        'ids': {'type': 'dict'},
+        'provision_params': {'type': 'dict'},
     })
     beaker = BeakerTargets(mod.params)
     try:
+        if len(beaker.ids) > 1:
+            mod.warn('Using multiple resource_definition for beaker resources'
+                     ' in topology is unsupported. Only the provisioning'
+                     ' parameters from the first resource_definition will be'
+                     ' used.')
         results = beaker.get_system_statuses()
-        mod.exit_json(hosts=results, changed=True, success=True)
+        mod.exit_json(hosts=results, changed=True)
     except Exception as ex:
-        mod.fail_json(msg=str(ex))
+        msg, results = ex.args
+        mod.warn(msg)
+        mod.fail_json(msg=msg, hosts=results, changed=True)
 
 
 # import module snippets

--- a/linchpin/provision/roles/beaker/files/schema.json
+++ b/linchpin/provision/roles/beaker/files/schema.json
@@ -11,6 +11,9 @@
                 },
                 "whiteboard": { "type": "string", "required": true },
                 "job_group": { "type": "string", "required": false },
+                "cancel_message": { "type": "string", "required": false },
+                "max_attempts": { "type": "integer", "required": false },
+                "attempt_wait_time": { "type": "integer", "required": false },
                 "recipesets": {
                     "type": "list",
                     "schema": {

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -36,10 +36,7 @@
       provision_params: "{{ bkr.results[0].provision_params }}"
     register: _topology_outputs_beaker_server
 
-  - name: "append beaker outputs"
+  - name: "extract beaker outputs"
     set_fact:
-      topology_outputs_beaker_server: "{{ topology_outputs_beaker_server + bkr_item.hosts }}"
-    with_items: "{{ _topology_outputs_beaker_server.results }}"
-    loop_control:
-      loop_var: bkr_item
+      topology_outputs_beaker_server: "{{ _topology_outputs_beaker_server.hosts }}"
   when: state == 'present'

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -1,48 +1,45 @@
 ---
 - name: "provision beaker systems"
   bkr_server:
-    whiteboard: "{{ res.whiteboard | default('Provisioned with linchpin') }}"
     recipesets: "{{ res.recipesets }}"
     state: present
-    job_group: "{{ res.job_group | default('') }}"
+    # these values have defaults set in the bkr_server module
+    # if omitted, or they are not required
+    whiteboard: "{{ res.whiteboard | default(omit) }}"
+    job_group: "{{ res.job_group | default(omit) }}"
+    cancel_message: "{{ res.cancel_message | default(omit) }}"
+    max_attempts: "{{ res.max_attempts | default(omit) }}"
+    attempt_wait_time: "{{ attempt_wait_time | default(omit) }}"
   with_items: "{{ res_defs['resource_definitions'] }}"
+  # loop over res_defs even though there should be only one for beaker
   loop_control:
     loop_var: res
   register: bkr
 
-- name: set blank bkr_id_values list
-  set_fact:
-    bkr_id_values: []
+- block:
+  # stash job ids and urls for printing
+  - name: set bkr_id_values
+    set_fact:
+      bkr_id_values: "{{ bkr_id_values | default({}) | combine(result['ids']) }}"
+    with_items: "{{ bkr.results }}"
+    loop_control:
+      loop_var: result
+
+  - name: print beaker job ids and URLs
+    debug:
+      var: bkr_id_values
+
+  - name: "fetch beaker details"
+    bkr_info:
+      ids: "{{ bkr_id_values }}"
+      # pull provision params from the first (should be only) result
+      provision_params: "{{ bkr.results[0].provision_params }}"
+    register: _topology_outputs_beaker_server
+
+  - name: "append beaker outputs"
+    set_fact:
+      topology_outputs_beaker_server: "{{ topology_outputs_beaker_server + bkr_item.hosts }}"
+    with_items: "{{ _topology_outputs_beaker_server.results }}"
+    loop_control:
+      loop_var: bkr_item
   when: state == 'present'
-
-# per PR #180, print out beaker job ids
-- name: set bkr_id_values
-  set_fact:
-    bkr_id_values: "{{ bkr_id_values + result['ids'] }}"
-  with_items: "{{ bkr.results }}"
-  loop_control:
-    loop_var: result
-  when: state == 'present'
-
-# per PR #180, print out beaker job ids
-- name: print bkr_id_values
-  debug:
-    var: bkr_id_values
-
-- name: "fetch beaker details"
-  bkr_info:
-    ids: "{{ result['ids'] }}"
-  with_items: "{{ bkr.results }}"
-  loop_control:
-    loop_var: result
-  when: state == 'present'
-  register: _topology_outputs_beaker_server
-
-- name: "append beaker outputs"
-  set_fact:
-    topology_outputs_beaker_server: "{{ topology_outputs_beaker_server + bkr_item.hosts }}"
-  with_items: "{{ _topology_outputs_beaker_server.results }}"
-  loop_control:
-    loop_var: bkr_item
-  when: state == 'present'
-


### PR DESCRIPTION
Previously, the bkr_server would receive all provisioning options and
then pass only job IDs through to bkr_server for monitoring, which made
it impossible to pass those options through. It's useful to be able to
pass those through, as that allows for changing things like how long
bkr_info will wait for a provisioning request to succeed or fail.

This also includes a variety of quality of life fixes:

---
closes #424
CentOS-PaaS-SIG#424

Being able to specify `max_attempts` and `attempt_wait_time` in the
topology allows you to effectively specify the timeout, where `timeout =
max_attempts * attempt_wait_time`.

---
closes #399
CentOS-PaaS-SIG#399

In addition to the job IDs, job URLs are now also printed out in the
course of provisioning. This debug print happens between the bkr_server
provisioning step and the bkr_info monitoring step, so users can monitor
or alter the job in beaker should they choose to do so.

---
closes #394
CentOS-PaaS-SIG#394

When bkr_info exceeds its `max_attempts` and times out, it issues a
job-cancel for the job being monitored in beaker, freeing up resources
that may have been provisioned during the request.