### PR TITLE
Update to 1.5.1.1

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -91,7 +91,7 @@ any resources used.
 config/Dockerfiles/JenkinsfileStageTrigger
 ++++++++++++++++++++++++++++++++++++++++++
 
-This is a declaritive pipeline script that watches linchpin's github repo for
+This is a declarative pipeline script that watches linchpin's github repo for
 any PR's that need testing.  If the changeset includes changes to a target's 
 Dockerfile it will rebuild the container and use that version of the container
 for testing.  If you add a new target you will also need to update the tagmap
@@ -104,7 +104,7 @@ replace <TARGET> with the actual target name.
 config/Dockerfiles/JenkinsfileStageMerge
 ++++++++++++++++++++++++++++++++++++++++
 
-This is a declaritive pipeline script that watches linchpin's github repo for
+This is a declarative pipeline script that watches linchpin's github repo for
 any PR's that have the comment '[merge]'.  If found it will look for any 
 containers that have a tag from this PR and promote them to stable.  Finally it will
 merge the PR.  No need to modify this file when a new target is added.

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
 __short_version__ = '1.5.1'
-__version__ = '1.5.1'
+__version__ = '1.5.1.1'


### PR DESCRIPTION
Interim version for beaker fix at request of ci-central-qe. 

* The `__short_version__` variable will stay at 1.5.1 since documentation will get updated in v1.5.2, not here.
* Fixed spelling errors in config/README.rst