### PR TITLE
Add taskparam support to beaker schema

### DIFF
--- a/linchpin/provision/roles/beaker/files/schema.json
+++ b/linchpin/provision/roles/beaker/files/schema.json
@@ -23,6 +23,11 @@
                                 "distro": { "type": "string", "required": true },
                                 "arch": { "type": "string", "required": false },
                                 "variant": { "type": "string", "required": false },
+                                "taskparam": {
+                                    "type": "list",
+                                    "required": false,
+                                    "schema": { "type": "string", "required": true }
+                                },
                                 "keyvalue": {
                                     "type": "list",
                                     "required": false,


### PR DESCRIPTION
Turns out that bkr_server already had support for task params, we just
need to allow it in recipes; all other machinery is in place.

To add a custom reservesys time, add this to a recipe inside recipesets,
in the same place as things like hostrequires, distro, etc.
```yaml
        taskparam:
          - RESERVETIME=7200
```

Value is in seconds, so this is a 2-hour reservation.

closes: https://github.com/CentOS-PaaS-SIG/linchpin/issues/380