### PR TITLE
AWS VPC and docs fixes (#484)

### DIFF
--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -50,13 +50,18 @@ AWS Security Groups can be provisioned using this resource.
 Additional Dependencies
 -----------------------
 
-No additional dependencies are required for the Openstack Provider.
+No additional dependencies are required for the AWS Provider.
 
 Credentials Management
 ----------------------
 
 AWS provides several ways to provide credentials. LinchPin supports
-some of these methods for passing credentials for use with openstack resources.
+some of these methods for passing credentials for use with AWS resources.
+
+One method to provide AWS credentials that can be loaded by LinchPin is to use
+the INI format that the `AWS CLI tool
+<https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html>`_
+uses.
 
 Environment Variables
 `````````````````````

--- a/linchpin/provision/roles/aws/files/schema.json
+++ b/linchpin/provision/roles/aws/files/schema.json
@@ -16,7 +16,8 @@
                     "image": { "type": "string", "required": false },
                     "count": { "type": "integer", "required": false },
                     "keypair": { "type": "string", "required": false },
-                    "security_group": { "type": "string", "required": false }
+                    "security_group": { "type": "string", "required": false },
+                    "vpc_subnet_id": { "type": "string", "required": false }
                 }
             },
             {

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -58,7 +58,7 @@
   when: res_item.0['role'] == "aws_ec2"
   with_nested:
     - "{{ resource_definitions }}"
-    - "{{ topo_output_resources['aws_ec2'] }}"
+    - "{{ topo_output_resources['aws_ec2_res'] }}"
     - ["{{ res_grp['resource_group_name']  }}"]
   loop_control:
     loop_var: res_item


### PR DESCRIPTION
* Fixed references in AWS docs from OpenStack -> AWS

* Added a way to set up credentials in the AWS docs

* Added 'vpc_subnet_id' to topology schema for VPC to resolve VPC issues
(#484)

* Fixed an attribute name used for teardown of AWS resources (#484)