### PR TITLE
AWS EC2 provider networking and inventory generation fixes

### DIFF
--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -9,7 +9,23 @@ aws_ec2
 AWS Instances can be provisioned using this resource.
 
 * :docs1.5:`Topology Example <workspace/topologies/aws-ec2-new.yml>`
+* :docs1.5:`Topology Example w/ VPC <workspace/topologies/aws-ec2-vpc.yml>`
 * `aws_ec2 module <http://docs.ansible.com/ansible/latest/ec2_module.html>`_
+
+EC2 Inventory Generation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If an instance has a public IP attached, its hostname in public DNS, if
+available, will be provided in the generated Ansible inventory file, and if not
+the public IP address will be provided.
+
+For instances which have a private IP address for VPC usage, the private IP
+address will be provided since private EC2 DNS hostnames (e.g.
+**ip-10-0-0-1.ec2.internal**) will not typically be resolvable outside of AWS.
+
+For instances with both a public and private IP address, the public address is
+always provided instead of the private address, so as to avoid duplicate runs
+of Ansible on the same host via the generated inventory file.
 
 aws_ec2_key
 -----------
@@ -64,12 +80,12 @@ the INI format that the `AWS CLI tool
 uses.
 
 Environment Variables
-`````````````````````
+~~~~~~~~~~~~~~~~~~~~~
 
 LinchPin honors the AWS environment variables
 
 Provisioning
-````````````
+~~~~~~~~~~~~
 
 Provisioning with credentials uses the ``--creds-path`` option.
 

--- a/docs/source/examples/workspace/topologies/aws-ec2-vpc.yml
+++ b/docs/source/examples/workspace/topologies/aws-ec2-vpc.yml
@@ -1,0 +1,16 @@
+---
+topology_name: ec2-new-vpc
+resource_groups:
+  - resource_group_name: "aws"
+    resource_group_type: "aws"
+    resource_definitions:
+      - name: "webserver"
+        flavor: "t2.micro"
+        role: "aws_ec2"
+        region: "us-west-1"
+        image: "ami-11f8bb71"
+        security_group: "default"
+        count: 1
+        keypair: "herlo_key"
+        assign_public_ip: false
+        vpc_subnet_id: "subnet-29e1aa2c"

--- a/linchpin/provision/roles/aws/files/schema.json
+++ b/linchpin/provision/roles/aws/files/schema.json
@@ -17,7 +17,8 @@
                     "count": { "type": "integer", "required": false },
                     "keypair": { "type": "string", "required": false },
                     "security_group": { "type": "string", "required": false },
-                    "vpc_subnet_id": { "type": "string", "required": false }
+                    "vpc_subnet_id": { "type": "string", "required": false },
+                    "assign_public_ip": { "type": "boolean", "required": false }
                 }
             },
             {


### PR DESCRIPTION
* Added 'assign_public_ip' to schema and EC2 topology example (#489)

* Added 'vpc_subnet_id' to EC2 topology example

* Fixed AWS EC2 inventory file generation, added support for public vs
private instances for the inventory, and updated sphinx docs with an
explanation of how the inventory files are generated (#490)

* Fixed a formatting warning from the sphinx 'make html' command for the
Environment Variables and Provisioning section of the AWS sphinx docs.