### PR TITLE
Added support for attaching volumes to provisioned instances.

### DIFF
--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -15,6 +15,47 @@ Openstack instances can be provisioned using this resource.
    the variables used are identical to the Ansible os_server module, except for
    adding a ``count`` option.
 
+Topology Schema
+~~~~~~~~~~~~~~
+
+Within Linchpin, the :term:`os_server` :term:`resource_definition` has more options
+than what are shown in the examples above. For each :term:`os_server` definition, the
+following options are available.
+
++------------------+------------+----------+------------------- +----------------+
+| Parameter        | required   | type     | ansible value     | comments       |
++==================+============+==========+===================+================+
+| name             | true       | string   | name              |                |
++------------------+------------+----------+-------------------+----------------+
+| flavor           | true       | string   | flavor            |                |
++------------------+------------+----------+-------------------+----------------+
+| image            | true       | string   | image             |                |
++------------------+------------+----------+-------------------+----------------+
+| region           | false      | string   | region            |                |
++------------------+------------+----------+-------------------+----------------+
+| count            | false      | integer  | count             |                |
++------------------+------------+----------+-------------------+----------------+
+| keypair          | false      | string   | key_name          |                |
++------------------+------------+----------+-------------------+----------------+
+| security_groups  | false      | string   | security_groups   |                |
++------------------+------------+----------+-------------------+----------------+
+| fip_pool         | false      | string   | floating_ip_pools |                |
++------------------+------------+----------+-------------------+----------------+
+| nics             | false      | string   | networks          |                |
++------------------+------------+----------+-------------------+----------------+
+| userdata         | false      | string   | userdata          |                |
++------------------+------------+----------+-------------------+----------------+
+| volumes          | false      | list     | volumes           |                |
++------------------+------------+----------+-------------------+----------------+
+| boot_from_volume | false      | string   | boot_from_volume  |                |
++------------------+------------+----------+-------------------+----------------+
+| terminate_volume | false      | string   | terminate_volume  |                |
++------------------+------------+----------+-------------------+----------------+
+| volume_size      | false      | string   | volume_size       |                |
++------------------+------------+----------+-------------------+----------------+
+| boot_volume      | false      | string   | boot_volume       |                |
++------------------+------------+----------+-------------------+----------------+
+
 os_obj
 ------
 

--- a/linchpin/provision/roles/openstack/files/schema.json
+++ b/linchpin/provision/roles/openstack/files/schema.json
@@ -19,6 +19,11 @@
                         "required": false,
                         "schema": { "type": "string", "required": true }
                     },
+		    "volumes": {
+                        "type": "list",
+                        "required": false,
+                        "schema": { "type": "string", "required": true }
+                    },
                     "keypair": { "type": "string", "required": true },
                     "security_groups": { "type": "string", "required": false },
                     "fip_pool": { "type": "string", "required": false },

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -21,6 +21,7 @@
     terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
     volume_size: "{{ res_def['volume_size'] | default(omit) }}"
     boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
+    volumes: "{{ res_def['volumes'] | default(omit) }}"
   register: res_def_output
   when: not async and auth_var is defined
 
@@ -46,6 +47,7 @@
     terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
     volume_size: "{{ res_def['volume_size'] | default(omit) }}"
     boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
+    volumes: "{{ res_def['volumes'] | default(omit) }}"
   register: res_def_output
   when: not async and auth_var is not defined
 
@@ -72,6 +74,7 @@
     terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
     volume_size: "{{ res_def['volume_size'] | default(omit) }}"
     boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
+    volumes: "{{ res_def['volumes'] | default(omit) }}"
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output
@@ -99,6 +102,7 @@
     terminate_volume: "{{ res_def['boot_from_volume'] | default(omit) }}"
     volume_size: "{{ res_def['volume_size'] | default(omit) }}"
     boot_volume: "{{ res_def['boot_volume'] | default(omit) }}"
+    volumes: "{{ res_def['volumes'] | default(omit) }}"
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output


### PR DESCRIPTION
Updated the schema.json and playbooks for OpenStack to support list of pre-provisioned volumes
names as a list of attachments to provisioned instances. No new changes were added to os_server2
module since attaching volumes is already supported.
fixes #479 