### PR TITLE
Fixes before v1.5.2 release

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -707,8 +707,8 @@ class LinchpinAPI(object):
 
     def get_run_data(self, tx_id, fields, targets=()):
         """
-        Returns the RunDB for data from a specified field given either a run_id
-        or tx_id. The fields consist of the major sections in the RunDB (target
+        Returns the RunDB for data from a specified field given a tx_id.
+        The fields consist of the major sections in the RunDB (target
         view only). Those fields are action, start, end, inputs, outputs,
         uhash, and rc.
 

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -1,8 +1,4 @@
 ---
-#- name: auth_var
-#  debug:
-#    var: auth_var
-
 - name: "provision/teardown os_server resources with provided auth"
   os_server2:
     state: "{{ state }}"
@@ -11,6 +7,7 @@
     image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
+    timeout: 1200
     flavor: "{{ res_def['flavor'] }}"
     nics:  "{{ res_def['networks'] | default(omit) | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
@@ -37,6 +34,7 @@
     image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
+    timeout: 1200
     flavor: "{{ res_def['flavor'] }}"
     nics:  "{{ res_def['networks'] | default(omit) | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
@@ -64,6 +62,7 @@
     image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
+    timeout: 1200
     flavor: "{{ res_def['flavor'] }}"
     nics:  "{{ res_def['networks'] | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
@@ -92,6 +91,7 @@
     image: "{{ res_def['image'] | default(omit) }}"
     key_name: "{{ res_def['keypair'] }}"
     api_timeout: 99999
+    timeout: 1200
     flavor: "{{ res_def['flavor'] }}"
     nics:  "{{ res_def['networks'] | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
 __short_version__ = '1.5.2'
-__version__ = '1.5.2rc1'
+__version__ = '1.5.2'


### PR DESCRIPTION
Per an email with @beerparty, I've updated the os_server timeout to 1200 seconds (20 minutes) as a semi-mitigation. Fixed a small amount of documentation. Updated to v1.5.2 in preparation for release today.