### PR TITLE
Split triggers into their own jobs

### DIFF
--- a/config/Dockerfiles/Jenkinsfile
+++ b/config/Dockerfiles/Jenkinsfile
@@ -47,15 +47,36 @@ properties(
         disableConcurrentBuilds(),
         parameters(
             [
-                string(defaultValue: 'develop', description: '', name: 'ghprbActualCommit'),
-                string(defaultValue: '', description: '', name: 'sha1'),
-                string(defaultValue: '', description: 'Pull Request Number', name: 'ghprbPullId'),
-                string(defaultValue: '', description: 'Pull Request Author username', name: 'ghprbPullAuthorLogin'),
-                string(defaultValue: 'stable', description: 'Tag for slave image', name: 'SLAVE_TAG'),
-                string(defaultValue: 'stable', description: 'Tag for fedora26 image', name: 'FEDORA26_TAG'),
-                string(defaultValue: 'stable', description: 'Tag for fedora27 image', name: 'FEDORA27_TAG'),
-                string(defaultValue: 'stable', description: 'Tag for centos6 image', name: 'CENTOS6_TAG'),
-                string(defaultValue: 'stable', description: 'Tag for centos7 image', name: 'CENTOS7_TAG')
+                string(defaultValue: 'develop',
+                       description: '',
+                       name: 'ghprbActualCommit'),
+                string(defaultValue: '',
+                       description: '',
+                       name: 'sha1'),
+                string(defaultValue: '',
+                       description: 'Pull Request Number',
+                       name: 'ghprbPullId'),
+                string(defaultValue: '',
+                       description: 'Pull Request Author username',
+                       name: 'ghprbPullAuthorLogin'),
+                string(defaultValue: '',
+                       description: 'Git Hub Repository',
+                       name: 'ghprbGhRepository'),
+                string(defaultValue: 'stable',
+                       description: 'Tag for slave image',
+                       name: 'SLAVE_TAG'),
+                string(defaultValue: 'stable',
+                       description: 'Tag for fedora26 image',
+                       name: 'FEDORA26_TAG'),
+                string(defaultValue: 'stable',
+                       description: 'Tag for fedora27 image',
+                       name: 'FEDORA27_TAG'),
+                string(defaultValue: 'stable',
+                       description: 'Tag for centos6 image',
+                       name: 'CENTOS6_TAG'),
+                string(defaultValue: 'stable',
+                       description: 'Tag for centos7 image',
+                       name: 'CENTOS7_TAG')
             ]
         ),
     ]
@@ -136,7 +157,7 @@ podTemplate(name: podName,
                         pipelineUtils.setDefaultEnvVars()
                         // Decorate our build
                         currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - PR: ${env.ghprbPullId} - Author: ${env.ghprbPullAuthorLogin}"
-                        if (env.ghprbActualCommit != null && env.ghprbActualCommit != "master") {
+                        if (env.ghprbActualCommit != null && env.ghprbActualCommit != "develop") {
                             currentBuild.description = "<a href=\"https://github.com/${env.ghprbGhRepository}/pull/${env.ghprbPullId}\">PR #${env.ghprbPullId} (${env.ghprbPullAuthorLogin})</a>"
                         }
                         // Gather some info about the node we are running on for diagnostics

--- a/config/Dockerfiles/JenkinsfileContainer
+++ b/config/Dockerfiles/JenkinsfileContainer
@@ -39,34 +39,32 @@ library identifier: "cico-pipeline-library@master",
 properties([
   buildDiscarder(logRotator(artifactNumToKeepStr: '20', numToKeepStr: '20')),
   [$class: 'GithubProjectProperty', displayName: '', projectUrlStr: 'https://github.com/CentOS-PaaS-SIG/linchpin/'],
-  [$class: 'org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty', triggers:[
+  parameters(
     [
-      $class: 'org.jenkinsci.plugins.ghprb.GhprbTrigger',
-      orgslist: 'CentOS-PaaS-SIG',
-      cron: 'H/5 * * * *',
-      triggerPhrase: '.*\\[test\\].*',
-      onlyTriggerPhrase: false,
-      useGitHubHooks: true,
-      permitAll: true,
-      autoCloseFailedPullRequests: false,
-      displayBuildErrorsOnDownstreamBuilds: true,
-      extensions: [
-        [
-          $class: 'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus',
-          commitStatusContext: 'Docker Build',
-          showMatrixStatus: false,
-          triggeredStatus: 'Starting job...',
-          startedStatus: 'Building...',
-        ]
-      ]
+      string(defaultValue: 'develop',
+             description: '',
+             name: 'ghprbActualCommit'),
+      string(defaultValue: '',
+             description: '',
+             name: 'sha1'),
+      string(defaultValue: '',
+             description: 'Pull Request Number',
+             name: 'ghprbPullId'),
+      string(defaultValue: '',
+             description: 'Pull Request Author username',
+             name: 'ghprbPullAuthorLogin'),
+      string(defaultValue: '',
+             description: 'Git Hub Repository',
+             name: 'ghprbGhRepository'),
     ]
-  ]]
+  ),
 ])
 
 pipeline {
     agent {
         kubernetes {
             cloud 'openshift'
+            serviceAccount 'jenkins'
             label 'stage-trigger-' + env.ghprbActualCommit
             containerTemplate {
                 name 'jnlp'
@@ -94,6 +92,9 @@ pipeline {
         stage("Setup Container Templates") {
             steps {
                 script {
+                    sh """
+                       oc whoami
+                    """
                     pipelineUtils.setupContainerTemplates(openshiftProject)
                 }
             }
@@ -153,17 +154,28 @@ pipeline {
         }
         stage("Run Stage Job") {
             steps {
-                build job: 'ci-pipeline-linchpin',
+                build job: 'ci-linchpin',
                         parameters: [
-                                string(name: 'ghprbActualCommit', value: "${env.ghprbActualCommit}"),
-                                string(name: 'ghprbGhRepository', value: "${env.ghprbGhRepository}"),
-                                string(name: 'ghprbPullAuthorLogin', value: "${env.ghprbPullAuthorLogin}"),
-                                string(name: 'sha1', value: "${env.sha1}"),
-                                string(name: 'ghprbPullId', value: "${env.ghprbPullId}"),
-                                string(name: 'FEDORA26_TAG', value: tagMap['fedora26']),
-                                string(name: 'FEDORA27_TAG', value: tagMap['fedora27']),
-                                string(name: 'CENTOS6_TAG', value: tagMap['centos6']),
-                                string(name: 'CENTOS7_TAG', value: tagMap['centos7'])
+                                string(name: 'ghprbActualCommit',
+                                       value: "${env.ghprbActualCommit}"),
+                                string(name: 'ghprbGhRepository',
+                                       value: "${env.ghprbGhRepository}"),
+                                string(name: 'ghprbPullAuthorLogin',
+                                       value: "${env.ghprbPullAuthorLogin}"),
+                                string(name: 'sha1',
+                                       value: "${env.sha1}"),
+                                string(name: 'ghprbPullId',
+                                       value: "${env.ghprbPullId}"),
+                                string(name: 'ghprbGhRepository',
+                                       value: "${env.ghprbGhRepository}"),
+                                string(name: 'FEDORA26_TAG',
+                                       value: tagMap['fedora26']),
+                                string(name: 'FEDORA27_TAG',
+                                       value: tagMap['fedora27']),
+                                string(name: 'CENTOS6_TAG',
+                                       value: tagMap['centos6']),
+                                string(name: 'CENTOS7_TAG',
+                                       value: tagMap['centos7'])
                         ],
                         wait: true
             }

--- a/config/Dockerfiles/JenkinsfileGHPRMerge
+++ b/config/Dockerfiles/JenkinsfileGHPRMerge
@@ -1,0 +1,104 @@
+/**
+ * CI Stage Linchpin Merge
+ *
+ * This is a declarative pipeline for the CI linchpin pipeline
+ * that includes the building of images based on PRs
+ *
+ */
+
+import groovy.json.JsonOutput
+
+// Openshift project
+openshiftProject = "continuous-infra"
+topic = env.topic ?: 'org.centos.prod'
+env.MSG_PROVIDER = 'fedora-fedmsg'
+
+// Defaults for SCM operations
+env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
+env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
+
+library identifier: "ci-pipeline@master",
+        retriever: modernSCM([$class: 'GitSCMSource',
+                              remote: "https://github.com/CentOS-Paas-SIG/ci-pipeline"])
+
+library identifier: "cico-pipeline-library@master",
+        retriever: modernSCM([$class: 'GitSCMSource',
+                              remote: "https://github.com/CentOS/cico-pipeline-library"])
+
+properties([
+  buildDiscarder(logRotator(artifactNumToKeepStr: '20', numToKeepStr: '20')),
+  [$class: 'GithubProjectProperty', displayName: '', projectUrlStr: 'https://github.com/CentOS-PaaS-SIG/linchpin/'],
+  [$class: 'org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty', triggers:[
+    [
+      $class: 'org.jenkinsci.plugins.ghprb.GhprbTrigger',
+      orgslist: 'CentOS-PaaS-SIG',
+      cron: 'H/5 * * * *',
+      triggerPhrase: '.*\\[merge\\].*',
+      onlyTriggerPhrase: true,
+      useGitHubHooks: true,
+      permitAll: true,
+      autoCloseFailedPullRequests: false,
+      displayBuildErrorsOnDownstreamBuilds: true,
+      extensions: [
+        [
+          $class: 'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus',
+          commitStatusContext: 'Merge PR',
+          showMatrixStatus: false,
+          triggeredStatus: 'Starting job...',
+          startedStatus: 'merging...',
+        ]
+      ]
+    ]
+  ]]
+])
+
+pipeline {
+    agent none
+    stages {
+        stage("ci-linchpin-GHPR-merge") {
+            steps {
+                node('master') {
+                    lock('merge-and-image-rebuild-lock') {
+                        script {
+                            // need this for ghprb plugin since it is really a post
+                            // build step and it assumes the build is complete.
+                            currentBuild.result = 'SUCCESS'
+                        }
+                        step([$class: 'GhprbPullRequestMerge', allowMergeWithoutTriggerPhrase: false, deleteOnMerge: false, disallowOwnCode: false, failOnNonMerge: false, mergeComment: ' ', onlyAdminsMerge: false])
+                        script {
+                            mTopic = "${topic}.ci.linchpin.pr_merge.queued"
+                            mProperties = "topic=${topic}.ci.linchpin.pr_merge.queued\n" +
+                                "ghprbActualCommit=${env.ghprbActualCommit}\n" +
+                                "ghprbPullId=${env.ghprbPullId}\n" +
+                                "ghprbPullAuthorLogin=${env.ghprbPullAuthorLogin}\n" +
+                                "sha1=${env.sha1}"
+                            mContent = [
+                                "topic": "${topic}.ci.linchpin.pr_merge.queued",
+                                "ghprbActualCommit": env.ghprbActualCommit,
+                                "ghprbPullId": env.ghprbPullId,
+                                "ghprbPullAuthorLogin": env.ghprbPullAuthorLogin,
+                                "sha1": env.sha1
+                            ]
+                            mContentString = JsonOutput.toJson(mContent)
+                            pipelineUtils.sendMessage(mTopic, mProperties, mContentString)
+                        }
+                        build job: 'ci-linchpin-merge',
+                            parameters: [
+                                    string(name: 'ghprbActualCommit',
+                                           value: "${env.ghprbActualCommit}"),
+                                    string(name: 'ghprbPullId',
+                                           value: "${env.ghprbPullId}"),
+                                    string(name: 'ghprbGhRepository',
+                                           value: "${env.ghprbGhRepository}"),
+                                    string(name: 'ghprbPullAuthorLogin',
+                                           value: "${env.ghprbPullAuthorLogin}"),
+                                    string(name: 'sha1',
+                                           value: "${env.sha1}")
+                            ],
+                            wait: true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/config/Dockerfiles/JenkinsfileGHPRTrigger
+++ b/config/Dockerfiles/JenkinsfileGHPRTrigger
@@ -1,0 +1,101 @@
+/**
+ * CI Stage Linchpin Trigger
+ *
+ * This is a declarative pipeline for the CI linchpin pipeline
+ * that includes the building of images based on PRs
+ *
+ */
+
+import groovy.json.JsonOutput
+
+// Openshift project
+openshiftProject = "continuous-infra"
+topic = env.topic ?: 'org.centos.prod'
+env.MSG_PROVIDER = 'fedora-fedmsg'
+
+// Defaults for SCM operations
+env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
+env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
+
+library identifier: "ci-pipeline@master",
+        retriever: modernSCM([$class: 'GitSCMSource',
+                              remote: "https://github.com/CentOS-Paas-SIG/ci-pipeline"])
+
+library identifier: "cico-pipeline-library@master",
+        retriever: modernSCM([$class: 'GitSCMSource',
+                              remote: "https://github.com/CentOS/cico-pipeline-library"])
+
+properties([
+  buildDiscarder(logRotator(artifactNumToKeepStr: '20', numToKeepStr: '20')),
+  [$class: 'GithubProjectProperty', displayName: '', projectUrlStr: 'https://github.com/CentOS-PaaS-SIG/linchpin/'],
+  [$class: 'org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty', triggers:[
+    [
+      $class: 'org.jenkinsci.plugins.ghprb.GhprbTrigger',
+      orgslist: 'CentOS-PaaS-SIG',
+      cron: 'H/5 * * * *',
+      triggerPhrase: '.*\\[test\\].*',
+      onlyTriggerPhrase: false,
+      useGitHubHooks: true,
+      permitAll: true,
+      autoCloseFailedPullRequests: false,
+      displayBuildErrorsOnDownstreamBuilds: true,
+      extensions: [
+        [
+          $class: 'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus',
+          commitStatusContext: 'Docker Build',
+          showMatrixStatus: false,
+          triggeredStatus: 'Starting job...',
+          startedStatus: 'Building...',
+        ]
+      ]
+    ]
+  ]]
+])
+
+pipeline {
+    agent none
+    stages {
+        stage("ci-linchpin-GHPR-trigger") {
+            steps {
+                node('master') {
+                    script {
+                        mTopic = "${topic}.ci.linchpin.pr.queued"
+                        mProperties = "topic=${topic}.ci.linchpin.pr.queued\n" +
+                            "ghprbActualCommit=${env.ghprbActualCommit}\n" +
+                            "ghprbPullId=${env.ghprbPullId}\n" +
+                            "ghprbPullAuthorLogin=${env.ghprbPullAuthorLogin}\n" +
+                            "sha1=${env.sha1}"
+                        mContent = [
+                            "topic": "${topic}.ci.linchpin.pr.queued",
+                            "ghprbActualCommit": env.ghprbActualCommit,
+                            "ghprbPullId": env.ghprbPullId,
+                            "ghprbPullAuthorLogin": env.ghprbPullAuthorLogin,
+                            "sha1": env.sha1
+                        ]
+                        mContentString = JsonOutput.toJson(mContent)
+                        pipelineUtils.sendMessage(mTopic, mProperties, mContentString)
+                        echo "PR number is: ${env.ghprbPullId}"
+                        env.changeLogStr = pipelineUtils.getChangeLogFromCurrentBuild()
+                        echo env.changeLogStr
+                    }
+                    writeFile file: 'changelog.txt', text: env.changeLogStr
+                    archiveArtifacts allowEmptyArchive: true, artifacts: 'changelog.txt'
+                    build job: 'ci-linchpin-container',
+                        parameters: [
+                                string(name: 'ghprbActualCommit',
+                                       value: "${env.ghprbActualCommit}"),
+                                string(name: 'ghprbPullId',
+                                       value: "${env.ghprbPullId}"),
+                                string(name: 'ghprbGhRepository',
+                                       value: "${env.ghprbGhRepository}"),
+                                string(name: 'ghprbPullAuthorLogin',
+                                       value: "${env.ghprbPullAuthorLogin}"),
+                                string(name: 'sha1',
+                                       value: "${env.sha1}")
+                        ],
+                        wait: true
+                }
+            }
+        }
+    }
+}

--- a/config/Dockerfiles/JenkinsfileMergePR
+++ b/config/Dockerfiles/JenkinsfileMergePR
@@ -19,34 +19,32 @@ library identifier: "ci-pipeline@master",
 properties([
   buildDiscarder(logRotator(artifactNumToKeepStr: '20', numToKeepStr: '20')),
   [$class: 'GithubProjectProperty', displayName: '', projectUrlStr: 'https://github.com/CentOS-PaaS-SIG/linchpin/'],
-  [$class: 'org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty', triggers:[
+  parameters(
     [
-      $class: 'org.jenkinsci.plugins.ghprb.GhprbTrigger',
-      orgslist: 'CentOS-PaaS-SIG',
-      cron: 'H/5 * * * *',
-      triggerPhrase: '.*\\[merge\\].*',
-      onlyTriggerPhrase: true,
-      useGitHubHooks: true,
-      permitAll: true,
-      autoCloseFailedPullRequests: false,
-      displayBuildErrorsOnDownstreamBuilds: true,
-      extensions: [
-        [
-          $class: 'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus',
-          commitStatusContext: 'Docker Build',
-          showMatrixStatus: false,
-          triggeredStatus: 'Starting job...',
-          startedStatus: 'Building...',
-        ]
-      ]
+      string(defaultValue: 'develop',
+             description: '',
+             name: 'ghprbActualCommit'),
+      string(defaultValue: '',
+             description: '',
+             name: 'sha1'),
+      string(defaultValue: '',
+             description: 'Pull Request Number',
+             name: 'ghprbPullId'),
+      string(defaultValue: '',
+             description: 'Pull Request Author username',
+             name: 'ghprbPullAuthorLogin'),
+      string(defaultValue: '',
+             description: 'Git Hub Repository',
+             name: 'ghprbGhRepository'),
     ]
-  ]]
+  ),
 ])
 
 pipeline {
     agent {
         kubernetes {
             cloud 'openshift'
+            serviceAccount 'jenkins'
             label 'merge-trigger-' + env.ghprbActualCommit
             containerTemplate {
                 name 'jnlp'
@@ -83,26 +81,15 @@ pipeline {
         }
         stage("Merge PR and Rebuild Images") {
             steps {
-                // lock to make sure only one is allowed at anytime
-                lock('merge-and-image-rebuild-lock') {
-                    script {
-                        // need this for ghprb plugin since it is really
-                        // a post build step and it assumes the build is complete.
-                        currentBuild.result = 'SUCCESS'
-                    }
-
-                    step([$class: 'GhprbPullRequestMerge', allowMergeWithoutTriggerPhrase: false, deleteOnMerge: false, disallowOwnCode: false, failOnNonMerge: false, mergeComment: ' ', onlyAdminsMerge: false])
-
-                    script {
-                        openshift.withCluster() {
-                            openshift.withProject(openshiftProject) {
-                                imageOperations.each {
-                                    pipelineUtils.buildStableImage(openshiftProject, it)
-                                }
+                script {
+                    openshift.withCluster() {
+                        openshift.withProject(openshiftProject) {
+                            imageOperations.each {
+                                pipelineUtils.buildStableImage(openshiftProject, it)
                             }
                         }
-                        pipelineUtils.sendPRCommentforTags(imageOperations)
                     }
+                    pipelineUtils.sendPRCommentforTags(imageOperations)
                 }
             }
         }

--- a/config/Dockerfiles/JenkinsfileMessageBusMerge
+++ b/config/Dockerfiles/JenkinsfileMessageBusMerge
@@ -1,0 +1,56 @@
+import groovy.json.*
+
+properties(
+        [
+                buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '50', daysToKeepStr: '', numToKeepStr: '100')),
+                parameters(
+                    [
+                        string(description: 'fedmsg msg', name: 'CI_MESSAGE'),
+                    ]
+                ),
+                pipelineTriggers(
+                        [[$class: 'CIBuildTrigger', checks: [],  overrides: [topic: 'org.centos.prod'], providerName: 'fedora-fedmsg', selector: 'topic = "org.centos.prod.ci.linchpin.pr_merge.queued"']]
+                )
+        ]
+)
+
+node('master') {
+    ansiColor('xterm') {
+        timestamps {
+            stage('ci-linchpin-messageBus-trigger') {
+
+                echo "CI_MESSAGE: ${env.CI_MESSAGE}"
+
+                // parse CI_MESSAGE json
+                def json_msg = readJSON text: CI_MESSAGE
+                // parse message-content json
+                def msg_content = readJSON text: json_msg['message-content']
+
+                def ghprbPullId = msg_content['ghprbPullId']
+                def ghprbPullAuthorLogin = msg_content['ghprbPullAuthorLogin']
+                def ghprbActualCommit = msg_content['ghprbActualCommit']
+                def sha1 = msg_content['sha1']
+
+                currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - PR: ${ghprbPullId} - Author: ${ghprbPullAuthorLogin}"
+                if (ghprbActualCommit != null && ghprbActualCommit != "develop") {
+                  currentBuild.description = "<a href=\"https://github.com/${msg_content.ghprbGhRepository}/pull/${ghprbPullId}\">PR #${ghprbPullId} (${ghprbPullAuthorLogin})</a>"
+                }
+
+                build job: "ci-linchpin-merge",
+                  parameters: [
+                    string(name: 'ghprbActualCommit',
+                           value: "${ghprbActualCommit}"),
+                    string(name: 'ghprbPullId',
+                           value: "${ghprbPullId}"),
+                    string(name: 'ghprbGhRepository', 
+                           value: "${env.ghprbGhRepository}"),
+                    string(name: 'ghprbPullAuthorLogin',
+                           value: "${ghprbPullAuthorLogin}"),
+                    string(name: 'sha1',
+                           value: "${sha1}")
+                  ],
+                  wait: true
+            }
+        }
+    }
+}

--- a/config/Dockerfiles/JenkinsfileMessageBusTrigger
+++ b/config/Dockerfiles/JenkinsfileMessageBusTrigger
@@ -1,0 +1,56 @@
+import groovy.json.*
+
+properties(
+        [
+                buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '50', daysToKeepStr: '', numToKeepStr: '100')),
+                parameters(
+                    [
+                        string(description: 'fedmsg msg', name: 'CI_MESSAGE'),
+                    ]
+                ),
+                pipelineTriggers(
+                        [[$class: 'CIBuildTrigger', checks: [],  overrides: [topic: 'org.centos.prod'], providerName: 'fedora-fedmsg', selector: 'topic = "org.centos.prod.ci.linchpin.pr.queued"']]
+                )
+        ]
+)
+
+node('master') {
+    ansiColor('xterm') {
+        timestamps {
+            stage('ci-linchpin-messageBus-trigger') {
+
+                echo "CI_MESSAGE: ${env.CI_MESSAGE}"
+
+                // parse CI_MESSAGE json
+                def json_msg = readJSON text: CI_MESSAGE
+                // parse message-content json
+                def msg_content = readJSON text: json_msg['message-content']
+
+                def ghprbPullId = msg_content['ghprbPullId']
+                def ghprbPullAuthorLogin = msg_content['ghprbPullAuthorLogin']
+                def ghprbActualCommit = msg_content['ghprbActualCommit']
+                def sha1 = msg_content['sha1']
+
+                currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - PR: ${ghprbPullId} - Author: ${ghprbPullAuthorLogin}"
+                if (ghprbActualCommit != null && ghprbActualCommit != "develop") {
+                  currentBuild.description = "<a href=\"https://github.com/${msg_content.ghprbGhRepository}/pull/${ghprbPullId}\">PR #${ghprbPullId} (${ghprbPullAuthorLogin})</a>"
+                }
+
+                build job: "ci-linchpin-container",
+                  parameters: [
+                    string(name: 'ghprbActualCommit',
+                           value: "${ghprbActualCommit}"),
+                    string(name: 'ghprbPullId',
+                           value: "${ghprbPullId}"),
+                    string(name: 'ghprbGhRepository', 
+                           value: "${env.ghprbGhRepository}"),
+                    string(name: 'ghprbPullAuthorLogin',
+                           value: "${ghprbPullAuthorLogin}"),
+                    string(name: 'sha1',
+                           value: "${sha1}")
+                  ],
+                  wait: true
+            }
+        }
+    }
+}

--- a/config/s2i/jenkins/jenkins-continuous-infra-slave-buildconfig-template.yaml
+++ b/config/s2i/jenkins/jenkins-continuous-infra-slave-buildconfig-template.yaml
@@ -43,7 +43,7 @@ parameters:
 - description: Git repository with Dockerfile and slave entrypoint.
   displayName: Repository URL
   name: REPO_URL
-  value: https://github.com/CentOS-PaaS-SIG/ci-pipeline.git
+  value: https://github.com/CentOS-PaaS-SIG/linchpin.git
 - description: The sub-directory inside the repository.
   displayName: Context Directory
   name: CONTEXTDIR

--- a/config/s2i/jenkins/slave/Dockerfile
+++ b/config/s2i/jenkins/slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/jenkins-slave-base-centos7
+FROM openshift/jenkins-slave-base-centos7:v3.7
 RUN yum install -y epel-release
 # add ruby for ghi
 RUN yum install -y ansible jq ruby


### PR DESCRIPTION
Two types of triggers now:
 - GHPRB : Git Hub PR Builder
 - MessageBus: Allows for downstream behind firewalls

The GHPRB trigger sends a message on the bus that will
trigger the messagebus job.

Please let me merge this after review - I will need to update the jobs on centos ci since things have been renamed.