### PR TITLE
use match instead of equalto.

### DIFF
--- a/config/Dockerfiles/linchpin-tests.sh
+++ b/config/Dockerfiles/linchpin-tests.sh
@@ -17,14 +17,6 @@ for i in $DRIVERS; do
         tar xvf $CREDS_PATH/${i}.tgz -C $tmpdir
         $tmpdir/install.sh
     fi
-    # Horrible hacks until CentOS support is fixed..
-    # See Issue: https://github.com/CentOS-PaaS-SIG/duffy-ansible-module/issues/3
-    if [ "$target" = "centos7" ] && \
-       [ "$i" = "aws-ec2-new" ]; then
-        test_summary="$(tput setaf 4)SKIPPED$(tput sgr0)\t${testname}"
-        summary="${summary}\n${test_summary}"
-        continue
-    fi
     ./config/Dockerfiles/linchpin-test.sh $i 2>&1 |tee ${target}_logs/${i}.log
     if [ $? -eq 0 ]; then
         test_summary="$(tput setaf 2)SUCCESS$(tput sgr0)\t${testname}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_cfn.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_cfn.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Set cfn parameters for template"
   set_fact:
-    cfn_grp_vars : "{{ res_grp_vars | selectattr('resource_group_name', 'equalto', res_grp_name ) | first }}"
+    cfn_grp_vars : "{{ res_grp_vars | selectattr('resource_group_name', 'match', '^' + res_grp_name + '$') | first }}"
 
 - name: "Set cfn parameters for template"
   set_fact:

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2.yml
@@ -18,7 +18,7 @@
     count: "{{ res_def['count'] }}"
     vpc_subnet_id: "{{ res_def['vpc_subnet_id']| default(omit) }}"
     assign_public_ip: "{{ res_def['assign_public_ip']| default(omit) }}"
-    instance_tags: "{{ res_grp_vars | selectattr('resource_group_name', 'equalto', res_grp_name ) | first }}"
+    instance_tags: "{{ res_grp_vars | selectattr('resource_group_name', 'match', '^' + res_grp_name + '$') | first }}"
   register: res_def_output
   when: not async
 
@@ -40,7 +40,7 @@
     count: "{{ res_def['count'] }}"
     vpc_subnet_id: "{{ res_def['vpc_subnet_id']| default(omit) }}"
     assign_public_ip: "{{ res_def['assign_public_ip'] | default(omit) }}"
-    instance_tags: "{{ res_grp_vars | selectattr('resource_group_name', 'equalto', res_grp_name ) | first }}"
+    instance_tags: "{{ res_grp_vars | selectattr('resource_group_name', 'match', '^' + res_grp_name + '$') | first }}"
   async: "{{ async_timeout }}"
   poll: 0
   register: res_def_output

--- a/linchpin/provision/roles/aws/tasks/teardown_aws_cfn.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_aws_cfn.yml
@@ -1,10 +1,10 @@
 - name: "Debug:: checking cfn parameters"
   debug:
-    msg: "{{ res_grp_vars | selectattr('resource_group_name', 'equalto', res_grp_name ) | first }}"
+    msg: "{{ res_grp_vars | selectattr('resource_group_name', 'match', '^' + res_grp_name + '$') | first }}"
 
 - name: "Set cfn parameters for template"
   set_fact:
-    cfn_grp_vars : "{{ res_grp_vars | selectattr('resource_group_name', 'equalto', res_grp_name ) | first }}"
+    cfn_grp_vars : "{{ res_grp_vars | selectattr('resource_group_name', 'match', '^' + res_grp_name + '$') | first }}"
 
 - name: "Set cfn parameters for template"
   set_fact:

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -41,7 +41,7 @@
 
   - name: combine bkr_id_values with bkr_hosts
     set_fact:
-      tmp_hosts: "{{ item | combine(bkr_hosts | selectattr('id', 'equalto', item.id) | first) }}"
+      tmp_hosts: "{{ item | combine(bkr_hosts | selectattr('id', 'match', '^' + item.id + '$') | first) }}"
     with_items: "{{ bkr_id_values }}"
     register: tmp_info
 
@@ -68,7 +68,7 @@
 
   - name: "set topology_outputs_beaker_server"
     set_fact:
-      tmp_topo_bkr_srvc: "{{ item | combine(_topo_out_bkr_server['hosts'] | selectattr('id', 'equalto', item.id) | first) }}"
+      tmp_topo_bkr_srvc: "{{ item | combine(_topo_out_bkr_server['hosts'] | selectattr('id', 'match', '^' + item.id + '$') | first) }}"
     when: state == 'present'
     with_items: "{{ topology_outputs_beaker_server }}"
     register: tmp_bkr

--- a/linchpin/provision/roles/openstack/tasks/provision_os_heat.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_heat.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Set Heat parameters for template"
   set_fact:
-    heat_params : "{{ res_grp_vars | selectattr('resource_group_name', 'equalto', res_grp_name ) | first }}"
+    heat_params : "{{ res_grp_vars | selectattr('resource_group_name', 'match', '^' + res_grp_name + '$') | first }}"
 
 - name: "Set Heat parameters for template"
   set_fact:


### PR DESCRIPTION
rhel/centos 7 has an older version of jinja2 which doesn't include equalto.