### PR TITLE
Use pytest on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
 
 script:
   - flake8 --exclude=\.eggs,tests,docs --ignore=E124,E303 --max-line-length 80 .
-  - $(which python) $(which nosetests) -s linchpin/tests/*
+  - $(which python) setup.py test
+#  - $(which python) $(which nosetests) -s linchpin/tests/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ click
 camel
 yamlordereddictloader
 ansible>=2.3.1,<2.5.0
-#shade>=1.22.2 # F27 has 1.18.1
-shade>=1.8.0,!=1.21.0
+six>=1.10.0
+shade>=1.18.0,!=1.21.0
 naked
 Cerberus<=1.1
 tinydb

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ click
 camel
 yamlordereddictloader
 ansible>=2.3.1,<2.5.0
-shade>=1.22.2
+#shade>=1.22.2 # F27 has 1.18.1
+shade>=1.8.0,!=1.21.0
 naked
 Cerberus<=1.1
 tinydb
 requests>=2.14.2
-jsonschema
 ipaddress>=1.0.17
 PyYAML>=3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --verbose -k 'not tests_fetch_pass'
+python_files = linchpin/tests/*

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ reqs_file = 'requirements.txt'.format(dir_path)
 with open(reqs_file) as f:
     required = f.read().splitlines()
 
+setup_required = list(required)
+setup_required.append('pytest-runner')
+
 ignore_dir = ['.git']
 
 setup(
@@ -25,12 +28,13 @@ setup(
     author='samvaran kashyap rallabandi',
     author_email='linchpin@redhat.com',
     url='http://linchpin.readthedocs.io/',
-    setup_requires=required,
+    setup_requires=setup_required,
     install_requires=required,
     entry_points='''
         [console_scripts]
         linchpin=linchpin.shell:runcli
     ''',
+    tests_require=["pytest","nose", "mock", "coverage", "flake8"],
     extras_require={
         'krbV': ["python-krbV"],
         'beaker': ['beaker-client>=23.3', 'python-krbV'],

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         [console_scripts]
         linchpin=linchpin.shell:runcli
     ''',
-    tests_require=["pytest","nose", "mock", "coverage", "flake8"],
+    tests_require=["pytest", "nose", "mock", "coverage", "flake8"],
     extras_require={
         'krbV': ["python-krbV"],
         'beaker': ['beaker-client>=23.3', 'python-krbV'],


### PR DESCRIPTION
jsonschema is no longer required ( schemacheck ansible module still needs to be removed)
pytest finds and performs tests, updated this in the .travis.yml as well.
testing shade 1.18 for compatibility with F27 distro packaging (EPEL doesn't have shade at all, only pip)