### PR TITLE
Name in topology, distilled data

### DIFF
--- a/docs/source/examples/workspace/linchpin.conf
+++ b/docs/source/examples/workspace/linchpin.conf
@@ -85,6 +85,12 @@ use_rundb_for_actions = True
 #distill_data = False
 distill_data = True
 
+# If desired, enabling distill_on_error will distill any successfully (and
+# possibly failed) provisioned resources. This is predicated on the data
+# being written to the RunDB (usually means _async tasks may never record
+# data upon failure).
+distill_on_error = False
+
 # LinchPin sets several extra_vars (evars) that are passed to the playbooks.
 # This section controls those items.
 [evars]

--- a/docs/source/examples/workspace/topologies/bkr-new.yml
+++ b/docs/source/examples/workspace/topologies/bkr-new.yml
@@ -10,15 +10,16 @@ resource_groups:
         # options to configure amount of time spent polling beaker:
         # 60 attempts with 60 seconds wait time between them,
         # provisioning timeout is roughly 3600 seconds
-        max_attempts: 60
+        max_attempts: 240
         attempt_wait_time: 60
         # option to set cancellation message if linchpin cancels provisioning
         cancel_message: Job cancelled on account of rain
         recipesets:
           - distro: RHEL-6.5
             arch: x86_64
-            hostrequires:
-              - tag: hypervisor
-                op: "="
-                value: KVM
             count: 1
+            name: rhel65
+          - distro: RHEL-7.4
+            arch: x86_64
+            count: 1
+            name: rhel74

--- a/docs/source/examples/workspace/topologies/bkr-new.yml
+++ b/docs/source/examples/workspace/topologies/bkr-new.yml
@@ -19,7 +19,3 @@ resource_groups:
             arch: x86_64
             count: 1
             name: rhel65
-          - distro: RHEL-7.4
-            arch: x86_64
-            count: 1
-            name: rhel74

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -24,6 +24,7 @@ default_pinfile = PinFile
 external_providers_path = %(default_config_path)s/linchpin-x
 use_rundb_for_actions = False
 distill_data = False
+distill_on_error = False
 
 [evars]
 _check_mode = False
@@ -65,7 +66,7 @@ source = templates/
 pinfile = PinFile
 
 [distiller]
-bkr_server = id,url,system
+bkr_server = id,url,system,name
 dummy_node: hosts
 aws_ec2 = instances.id,instances.public_ip,instances.private_ip,instances.public_dns_name,instances.private_dns_name,instances.tags:name
 os_server = servers.id,servers.interface_ip,servers.name,servers.private_v4,servers.public_v4

--- a/linchpin/provision/roles/beaker/files/schema.json
+++ b/linchpin/provision/roles/beaker/files/schema.json
@@ -54,6 +54,7 @@
                                     }
                                 },
                                 "bkr_data": { "type": "string", "required": false },
+                                "name": { "type": "string", "required": false },
                                 "count": { "type": "integer", "required": false },
                                 "ids": {
                                     "type": "list",

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -17,6 +17,21 @@
   register: bkr
   ignore_errors: true
 
+
+- name: "set bkr_rsets"
+  set_fact:
+      bkr_rsets: "{{ bkr_rsets | default([]) }} + {{ rd.recipesets }}"
+  with_items: "{{ res_defs['resource_definitions'] }}"
+  loop_control:
+    loop_var: rd
+
+- name: "set bkr_names"
+  set_fact:
+      bkr_names: "{{ bkr_names | default([]) }} + {{ [{'name': brs['name']}] }}"
+  with_items: "{{ bkr_rsets }}"
+  loop_control:
+    loop_var: brs
+
 - block:
   - name: "set bkr ids from results"
     set_fact:
@@ -25,29 +40,92 @@
     loop_control:
       loop_var: result
 
-  - name: set bkr hosts from results
+  - name: "count bkr_ids"
     set_fact:
-      bkr_hosts: "{{ bkr_hosts | default([]) }} + {{ result['hosts'] }}"
+        bkr_id_count: "{{ (bkr_ids | length, 'count', 'id') }}"
+
+#  - debug:
+#      var: bkr_id_count
+
+  - name: "set bkr_hosts from results"
+    set_fact:
+      bkr_hosts: "{{ bkr_hosts | default([]) }} + {{ bh['hosts'] }}"
     with_items: "{{ bkr.results }}"
     loop_control:
-      loop_var: result
+      loop_var: bh
+
+  - name: "count bkr_hosts"
+    set_fact:
+      bkr_host_count: "{{ (bkr_hosts | length, 'count', 'distro') }}"
+
+#  - debug:
+#      var: bkr_host_count
+
+  - name: "set unique value based upon count"
+    set_fact:
+      combine_keys: "{{ combine_keys | default([]) }} + [{{ cks }}]"
+    with_items:
+      - "{{ bkr_id_count }}"
+      - "{{ bkr_host_count }}"
+    loop_control:
+      loop_var: cks
+
+  # take the first item sorted, get the last value out of the triple tuple
+  - name: "set unique value based upon count"
+    set_fact:
+      combine_key: "{{ combine_keys | sort(reverse=True) | first | last }}"
+
+#  - name: debug bkr_hosts
+#    debug:
+#      var: bkr_hosts
+
+#  - name: debug bkr_names
+#    debug:
+#      var: bkr_names
+
+  - name: "set bkr_host_values to an empty list"
+    set_fact:
+      bkr_host_values: []
+
+  - name: "combine bkr_hosts and bkr_names"
+    set_fact:
+      bkr_host_values: "{{ bkr_host_values }} + [{{ bhv.0 | combine(bhv.1) }}]"
+    with_together:
+        - "{{ bkr_hosts }}"
+        - "{{ bkr_names }}"
+    loop_control:
+      loop_var: bhv
 
   - name: "split id and url into separate components"
     set_fact:
-      bkr_id_values: "{{ bkr_id_values | default([]) + [{ 'id': result.key, 'url': result.value }] }}"
+      bkr_id_values: "{{ bkr_id_values | default([]) + [{ 'id': bids.key, 'url': bids.value }] }}"
     with_dict: "{{ bkr_ids }}"
     loop_control:
-      loop_var: result
+      loop_var: bids
 
-  - name: combine bkr_id_values with bkr_hosts
+  - name: "combine bkr_id_values with bkr_hosts"
     set_fact:
-      tmp_hosts: "{{ item | combine(bkr_hosts | selectattr('id', 'match', '^' + item.id + '$') | first) }}"
-    with_items: "{{ bkr_id_values }}"
+      tmp_hosts: "{{ bhv | combine(bkr_id_values | selectattr('id', 'match', '^' + bhv.id + '$') | first) }}"
+    with_items: "{{ bkr_host_values }}"
     register: tmp_info
+    loop_control:
+      loop_var: bhv
+
+#  - name: debug tmp_hosts
+#    debug:
+#      var: tmp_hosts
+#
+#  - name: debug tmp_info
+#    debug:
+#      var: tmp_info.results
 
   - name: "Set topology_outputs_beaker_server to the current job(s) data"
     set_fact:
       topology_outputs_beaker_server: "{{ tmp_info.results | map(attribute='ansible_facts.tmp_hosts') | list }}"
+
+#  - name: debug topology_outputs_beaker_server
+#    debug:
+#      var: topology_outputs_beaker_server
 
   - name: "Add beaker job info to the rundb"
     rundb:
@@ -66,14 +144,37 @@
       provision_params: "{{ bkr.results[0].provision_params }}"
     register: _topo_out_bkr_server
 
-  - name: "set topology_outputs_beaker_server"
+#  - name: debug _topo_out_bkr_server
+#    debug:
+#      var: _topo_out_bkr_server
+
+
+  - name: "set topology_outputs_beaker_server using id"
     set_fact:
-      tmp_topo_bkr_srvc: "{{ item | combine(_topo_out_bkr_server['hosts'] | selectattr('id', 'match', '^' + item.id + '$') | first) }}"
-    when: state == 'present'
+      tmp_topo_bkr_srvc: "{{ ttbs | combine(_topo_out_bkr_server['hosts'] | selectattr('id', 'match', '^' + ttbs.id + '$') | first) }}"
+    with_items: "{{ topology_outputs_beaker_server }}"
+    when:
+      - state == 'present'
+      - combine_key == 'id'
+    register: tmp_bkr
+    loop_control:
+      loop_var: ttbs
+
+  - name: "set topology_outputs_beaker_server using distro"
+    set_fact:
+      tmp_topo_bkr_srvc: "{{ ttbs | combine(_topo_out_bkr_server['hosts'] | selectattr('distro', 'match', '^' + ttbs.distro + '$') | first) }}"
+    when:
+      - state == 'present'
+      - combine_key == 'distro'
     with_items: "{{ topology_outputs_beaker_server }}"
     register: tmp_bkr
+    loop_control:
+      loop_var: ttbs
 
   - name: "Set topology_outputs_beaker_server to the current job(s) data"
     set_fact:
       topology_outputs_beaker_server: "{{ tmp_bkr.results | map(attribute='ansible_facts.tmp_topo_bkr_srvc') | list }}"
 
+#  - name: debug topology_outputs_beaker_server
+#    debug:
+#      var: topology_outputs_beaker_server

--- a/linchpin/tests/mockdata/dummy/linchpin.conf
+++ b/linchpin/tests/mockdata/dummy/linchpin.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 pkg = linchpin
+rundb_conn = /tmp/rundb-::mac::.json
 
 [evars]
 enable_uhash = True

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
-__short_version__ = '1.5.2'
-__version__ = '1.5.2'
+__short_version__ = '1.5.3'
+__version__ = '1.5.3a'


### PR DESCRIPTION
Per #542, the name field should be available in topologies for bkr_server, os_server, and aws_ec2 roles/resources. In turn, this name data will now be distilled (if used) into the context printed at the end of each run.

The majority of the work was done in the beaker provision_resource_group.yml playbook, which involved merging the bkr_id values, the bkr_host values, and the bkr_name values into the output to ensure easy distillation.

Additionally, this PR addresses #531 by adding a new flag option (distill_on_error) to the linchpin.conf enabling distilled data to write out any successfully provisioned resources, even if some fail.