### PR TITLE
This changes the selective target testing logic slightly.

### DIFF
--- a/config/Dockerfiles/JenkinsfileContainer
+++ b/config/Dockerfiles/JenkinsfileContainer
@@ -25,8 +25,7 @@ tagMap['centos7'] = STABLE_LABEL
 
 // Target: [ PATH/IN/REPO to match, ]
 p_targets = ['dummy':
-              ["^linchpin/provision/roles/dummy/.*",
-               "^linchpin/provision/dummy.yml"],
+              ["^(?!linchpin/version.py).*"],
              'duffy':
               ["^linchpin/provision/roles/duffy/.*",
                "^linchpin/provision/duffy.yml"],

--- a/src/org/centos/pipeline/LinchpinPipelineUtils.groovy
+++ b/src/org/centos/pipeline/LinchpinPipelineUtils.groovy
@@ -32,9 +32,9 @@ def getTargetsToTest(targetsMap) {
                 def file = files[k]
                 for (e in targetsMap) {
                     if (matchPath(file.path, e.value)) {
+                        println "${e.key} matched ${file.path}"
                         this_match = true
                         targets[e.key] = 1
-                        break
                     }
                 }
                 if (!this_match) {


### PR DESCRIPTION
- don't break out of the target selection routine when you get a match.
  This allows multiple targets to match for the same file.
- Change the dummy regex to match all files except linchpin/version.py
  This means we will only test the dummy target for non-target specific
  changes.  But if the linchpin/version.py file is changed we will test
  every target.  This is a good compromise for speed for every PR
  and completeness when doing a release.