### PR TITLE
Remove CRUFTY bits and use git for pypi packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ansible.cfg
 *.swp
 .fuse*
+.cache
+.pytest_cache
 
 # generated files
 docs/build/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include requirements.txt
 include README.rst
 include LICENSE
 
-include linchpin/linchpin.conf
+include linchpin/linchpin.constants
 
 recursive-include docs *
 recursive-include linchpin/examples *

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
 __short_version__ = '1.5.3'
-__version__ = '1.5.3a2'
+__version__ = '1.5.3a3'

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
 __short_version__ = '1.5.3'
-__version__ = '1.5.3a3'
+__version__ = '1.5.3a5'

--- a/linchpin/version.py
+++ b/linchpin/version.py
@@ -1,2 +1,2 @@
 __short_version__ = '1.5.3'
-__version__ = '1.5.3a1'
+__version__ = '1.5.3a2'

--- a/scripts/create_pypi_package.sh
+++ b/scripts/create_pypi_package.sh
@@ -23,8 +23,8 @@ CLEAN_CMD="clean"
 REG_CMD="register"
 UPLOAD_CMD="${PKG_TYPES} upload"
 GIT=$(which git)
-#LP_GIT_URL=git://github.com/CentOS-PaaS-SIG/linchpin
-LP_GIT_URL=git://github.com/herlo/linchpin
+LP_GIT_URL=git://github.com/CentOS-PaaS-SIG/linchpin
+#LP_GIT_URL=git://github.com/herlo/linchpin
 
 TMP_DIR=$(mktemp -d)
 
@@ -37,7 +37,7 @@ ${GIT} fetch --all --tags --prune
 ${GIT} checkout tags/${GIT_TAG} -b lp_${GIT_TAG}
 
 if [ "$?" != "0" ]; then
-    echo "Tag could not be checked out, verify tag is correct and try again"
+    echo "Tag could not be checked out, verify tag is in git and try again"
     exit 2
 fi
 

--- a/scripts/create_pypi_package.sh
+++ b/scripts/create_pypi_package.sh
@@ -7,44 +7,39 @@ else
 fi
 
 if [ $# -lt 1 ]; then
-  echo "Usage $0 <lp-path> [<pypi-site>]"
+  echo "Usage $0 <tag> [<pypi-site>]"
   echo
-  echo lp-path: path to linchpin source
-  echo 'pypi-site: path to linchpin source (default: pypitest)'
+  echo "tag: version tag (eg. v1.5.3)"
+  echo "pypi-site: path to linchpin source (default: pypitest)"
   exit 1
 fi
 
+GIT_TAG=${1}
 PROMPT=1
-LP_PATH=${1}
 
 PKG_TYPES="sdist bdist_wheel"
 SETUP_CMD="python setup.py"
 CLEAN_CMD="clean"
 REG_CMD="register"
 UPLOAD_CMD="${PKG_TYPES} upload"
+GIT=$(which git)
+#LP_GIT_URL=git://github.com/CentOS-PaaS-SIG/linchpin
+LP_GIT_URL=git://github.com/herlo/linchpin
 
-# find extraneous files and remove them
-CRUFTIES=('coverage.xml' 'linchpin.log' '*.pyc', '*.retry', '*.sw*')
-CRUFTY_DIRS=('linchpin.egg-info' 'build' 'dist' 'docs/build' 'provision/outputs' 'provision/inventories')
-
-echo "REMOVING CRUFTY FILES"
-
-for CRUFT in "${CRUFTIES[@]}"; do
-    #echo find ${LP_PATH} -name "${CRUFT}" -delete
-    find ${LP_PATH} -name "${CRUFT}" -delete
-done
-
-echo
-echo "REMOVING CRUFTY DIRS"
-
-for CRUFT_DIR in "${CRUFTY_DIRS[@]}"; do
-    #echo rm -rf ${LP_PATH}/${CRUFT_DIR}
-    rm -rf ${LP_PATH}/${CRUFT_DIR}
-done
+TMP_DIR=$(mktemp -d)
 
 CLEAN="${SETUP_CMD} ${CLEAN_CMD}"
-REG="${SETUP_CMD} ${REG_CMD} -r ${PYPI}"
 UPLOAD="${SETUP_CMD} ${UPLOAD_CMD} -r ${PYPI}"
+
+${GIT} clone ${LP_GIT_URL} ${TMP_DIR}
+pushd ${TMP_DIR}
+${GIT} fetch --all --tags --prune
+${GIT} checkout tags/${GIT_TAG} -b lp_${GIT_TAG}
+
+if [ "$?" != "0" ]; then
+    echo "Tag could not be checked out, verify tag is correct and try again"
+    exit 2
+fi
 
 for ACTION in "${CLEAN}" "${UPLOAD}"; do
     if [ ${PROMPT} -eq 1 ]; then
@@ -60,6 +55,8 @@ for ACTION in "${CLEAN}" "${UPLOAD}"; do
         ${ACTION}
     fi
 done
+
+popd
 
 
 #echo ${REG_CMD}


### PR DESCRIPTION
After releasing v1.5.3a1, I noticed that items in docs/source/examples/workspace/inventories/ were being packaged up even though that data is from specific runs of linchpin during testing.

This new create_pypi_package.sh checks out from git.

The requirements are that the tags be pushed to upstream prior to running this command. If not, the creation of packages will fail.