### PR TITLE
Bugfix: Making linchpin work with Ansible 2.5.x

### DIFF
--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 ansible24 = float(ansible.__version__[0:3]) >= 2.4
+ansible_version = float(ansible.__version__[0:3])
 
 
 # CentOS 6 EPEL provides an alternate Jinja2 package
@@ -108,6 +109,10 @@ def ansible_runner(playbook_path,
     # that onto this method down the road. The verbosity flag would just live
     # in options and we could set the defaults.
 
+    # module path cannot accept list in ansible 2.3.x versions
+    if ansible_version <= 2.3:
+        module_path = ":".join(module_path)
+
     connect_type = 'ssh'
     if 'localhost' in inventory_src:
         extra_vars["ansible_python_interpreter"] = sys.executable
@@ -167,8 +172,10 @@ def ansible_runner(playbook_path,
                                  options,
                                  inventory_src=inventory_src,
                                  console=console)
-
-    cb = PlaybookCallback(options=options)
+    if ansible_version >= 2.5:
+        cb = PlaybookCallback(options=options, ansible_version=ansible_version)
+    else:
+        cb = PlaybookCallback(options=options)
 
     if not console:
         results = {}

--- a/linchpin/callbacks.py
+++ b/linchpin/callbacks.py
@@ -6,9 +6,23 @@ class PlaybookCallback(CallbackBase):
     """Playbook callback"""
 
 
-    def __init__(self, display=None, options=None):
-        super(PlaybookCallback, self).__init__(display=display,
-                                               options=options)
+    def __init__(self, display=None, options=None, ansible_version=2.3):
+
+        # note the following if else ladder should be restructured after
+        # linchpin ansible minimum requirements changed until then
+        # code should be remained unchanged to maintain backward
+        # compatibility to ansible 2.3.1 version
+        if ansible_version >= 2.5:
+            self._load_name = None
+            super(PlaybookCallback, self).__init__(display=display,
+                                                   options=options)
+        elif ansible_version >= 2.4:
+            super(PlaybookCallback, self).__init__(display=display,
+                                                   options=options)
+        else:
+            # since ansible 2.3.1 version does not support options in
+            # inside PlaybbookCallback the options are omitted
+            super(PlaybookCallback, self).__init__(display=display)
 
         self._options = options
         self._display.verbosity = options.verbosity

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ apache-libcloud>=0.20.1
 click
 camel
 yamlordereddictloader
-ansible>=2.3.1,<2.5.0
+ansible>=2.3.1
 six>=1.10.0
 shade>=1.18.0,!=1.21.0
 naked


### PR DESCRIPTION
PlaybookCallback defined does not have attribute _loader_name which is
required by the ansible executor.py is added in constructor before the
super call. Further, reverted ansible version in requirements.txt
back to >=2.3.1.
Fixes #564 #563