### PR TITLE
bugfix: Change the order of picking hosts from resources to Inventory

### DIFF
--- a/linchpin/provision/InventoryFilters/InventoryFilter.py
+++ b/linchpin/provision/InventoryFilters/InventoryFilter.py
@@ -72,7 +72,6 @@ class InventoryFilter(object):
     def add_ips_to_groups(self, inven_hosts, layout):
         # create a ip to host mapping based on count
         ip_to_host = {}
-        inven_hosts.reverse()
         for host_name in layout['hosts']:
             if 'count' in layout['hosts'][host_name]:
                 count = layout['hosts'][host_name]['count']


### PR DESCRIPTION
Currently, The latest provisioned first is chosen in to inventory according
to the layout rules. However this needs to change because when using
multiple resource definitions the order does not comply to layout
refer issue #540 for more details. Current commit fixes #540 