### PR TITLE
Openstack Security Group testing fix

### DIFF
--- a/config/Dockerfiles/linchpin-test.sh
+++ b/config/Dockerfiles/linchpin-test.sh
@@ -1,12 +1,14 @@
 #!/bin/bash -xe
 
-TARGET=$1
+TARGET=${1}
+DISTRO=${2}
 
 function clean_up {
     set +e
-    linchpin -w . -v destroy $TARGET
+    linchpin -w . -v --template-data "{\"distro\": \"${DISTRO}-\"}" destroy ${TARGET}
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM
 
 pushd docs/source/examples/workspace
-linchpin -w . -v up $TARGET
+echo "DISTRO: ${DISTRO}"
+linchpin -w . -v --template-data "{\"distro\": \"${DISTRO}-\"}" up ${TARGET}

--- a/config/Dockerfiles/linchpin-tests.sh
+++ b/config/Dockerfiles/linchpin-tests.sh
@@ -17,7 +17,7 @@ for i in $TARGETS; do
         tar xvf $CREDS_PATH/${i}.tgz -C $tmpdir
         $tmpdir/install.sh
     fi
-    ./config/Dockerfiles/linchpin-test.sh $i 2>&1 |tee ${distro}_logs/${i}.log
+    ./config/Dockerfiles/linchpin-test.sh $i ${distro} 2>&1 |tee ${distro}_logs/${i}.log
     if [ $? -eq 0 ]; then
         test_summary="$(tput setaf 2)SUCCESS$(tput sgr0)\t${testname}"
     else

--- a/docs/source/examples/workspace/topologies/os-sg-new.yml
+++ b/docs/source/examples/workspace/topologies/os-sg-new.yml
@@ -4,7 +4,7 @@ resource_groups:
   - resource_group_name: os-sg-new
     resource_group_type: openstack
     resource_definitions:
-      - name: security_group
+      - name: "{{ distro | default('') }}security_group"
         role: os_sg
         description: "Openstack Security Group with ssh access"
         rules:

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -399,7 +399,6 @@ class LinchpinCli(LinchpinAPI):
 
         use_pinfile = True
         pf = None
-        pf_data = None
 
         return_data = OrderedDict()
         return_code = 0

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -431,7 +431,7 @@ class LinchpinCli(LinchpinAPI):
                 pf = self.parser.process(pf_w_path, data_w_path=pf_data_path)
 
             if pf:
-                provision_data = self._build(pf, pf_data)
+                provision_data = self._build(pf, pf_data=self.pf_data)
 
             return_code, return_data = self._execute(provision_data,
                                                      targets,

--- a/linchpin/provision/roles/openstack/tasks/provision_os_sg.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_sg.yml
@@ -1,20 +1,22 @@
 ---
-- name: "provisioning/deprovisioning of security group with auth"
+- name: "provision/teardown security group with auth"
   os_security_group:
     auth: "{{ auth_var | default(omit) }}"
     name: "{{ res_def['res_name'] | default(res_def['name']) }}"
+    description: "{{ res_def['description'] | default('Created by LinchPin') }}"
     state: "{{ state }}"
     wait: "yes"
   when: auth_var is defined
 
-- name: "provisioning/deprovisioning of security group no auth"
+- name: "provision/teardown security group no auth"
   os_security_group:
     name: "{{ res_def['res_name'] | default(res_def['name']) }}"
+    description: "{{ res_def['description'] | default('Created by LinchPin') }}"
     state: "{{ state }}"
     wait: "yes"
   when: auth_var is not defined
 
-- name: "provisioning/deprovisioning of security group"
+- name: "provision/teardown security group"
   os_security_group_rule:
     auth: "{{ group.0 }}"
     security_group: "{{ group.1 }}"
@@ -35,7 +37,7 @@
   register: res_def_output
   when: state == "present" and auth_var is defined
 
-- name: "provisioning/deprovisioning of security group"
+- name: "provision/teardown security group"
   os_security_group_rule:
     security_group: "{{ group.0 }}"
     state: "{{ group.1 }}"


### PR DESCRIPTION
The code below should continue to run all tests as normal. But the os-sg-new test, which creates an openstack security group will have the distro prepended to the name of the security group. This should help with the race condition discovered in [#571#issuecomment-387111515](https://github.com/CentOS-PaaS-SIG/linchpin/pull/571#issuecomment-387111515) when running all distros in parallel.

There was also a small bug fixed in the linchpin cli code which was not passing the template-data to all components of the PinFile structure.