### PR TITLE
Fix layout templating

### DIFF
--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -427,7 +427,8 @@ class LinchpinCli(LinchpinAPI):
             if not pf_data_path:
                 pf = self.parser.process(pf_w_path, data=self.pf_data)
             else:
-                pf = self.parser.process(pf_w_path, data_w_path=pf_data_path)
+                pf = self.parser.process(pf_w_path,
+                                         data='@{0}'.format(pf_data_path))
 
             if pf:
                 provision_data = self._build(pf, pf_data=self.pf_data)
@@ -526,6 +527,7 @@ class LinchpinCli(LinchpinAPI):
                 if not isinstance(pf[target]['layout'], dict):
                     layout_path = self.find_include(pf[target]["layout"],
                                                     ftype='layout')
+
                     layout_data = self.parser.process(layout_path, data=pf_data)
                     layout_data = self._make_layout_integers(layout_data)
                     provision_data[target]['layout'] = layout_data

--- a/linchpin/utils/dataparser.py
+++ b/linchpin/utils/dataparser.py
@@ -36,7 +36,7 @@ class DataParser(object):
         self._mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
 
 
-    def process(self, file_w_path, data=None, data_w_path=None):
+    def process(self, file_w_path, data=None):
         """ Processes the PinFile and any data (if a template)
         using Jinja2. Returns json of PinFile, topology, layout,
         and hooks.
@@ -58,8 +58,8 @@ class DataParser(object):
         with open(file_w_path, 'r') as stream:
             file_data = stream.read()
 
-            if data_w_path:
-                with open(data_w_path, 'r') as strm:
+            if data.startswith('@'):
+                with open(data[1:], 'r') as strm:
                     data = strm.read()
 
             try:

--- a/linchpin/utils/dataparser.py
+++ b/linchpin/utils/dataparser.py
@@ -48,8 +48,6 @@ class DataParser(object):
             A JSON representation of data mapped to a Jinja2 template in
             file_w_path
 
-        :param data_w_path:
-            If data is passed as a file, this is used
         """
 
         if not data:


### PR DESCRIPTION
Adjusted the dataparser.process function to treat all data as a potential file. It checks now for a leading '@' and reads the file into data before continuing. The inventory_layout templating was failing because it wasn't passing any values along.

Fixes #584