### PR TITLE
Fix parsing regression for layouts and topologies

### DIFF
--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -499,7 +499,7 @@ class LinchpinCli(LinchpinAPI):
 
             if not isinstance(pf[target]['topology'], dict):
                 topology_path = self.find_include(pf[target]["topology"])
-                topology_data = self.parser.process(topology_path, data=pf_data)
+                topology_data = self.parser.process(topology_path, data=self.pf_data)
             else:
                 topology_data = pf[target]['topology']
 
@@ -512,7 +512,7 @@ class LinchpinCli(LinchpinAPI):
                     layout_path = self.find_include(pf[target]["layout"],
                                                     ftype='layout')
 
-                    layout_data = self.parser.process(layout_path, data=pf_data)
+                    layout_data = self.parser.process(layout_path, data=self.pf_data)
                     layout_data = self._make_layout_integers(layout_data)
                     provision_data[target]['layout'] = layout_data
                 else:

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -499,7 +499,8 @@ class LinchpinCli(LinchpinAPI):
 
             if not isinstance(pf[target]['topology'], dict):
                 topology_path = self.find_include(pf[target]["topology"])
-                topology_data = self.parser.process(topology_path, data=self.pf_data)
+                topology_data = self.parser.process(topology_path,
+                                                    data=self.pf_data)
             else:
                 topology_data = pf[target]['topology']
 
@@ -512,7 +513,8 @@ class LinchpinCli(LinchpinAPI):
                     layout_path = self.find_include(pf[target]["layout"],
                                                     ftype='layout')
 
-                    layout_data = self.parser.process(layout_path, data=self.pf_data)
+                    layout_data = self.parser.process(layout_path,
+                                                      data=self.pf_data)
                     layout_data = self._make_layout_integers(layout_data)
                     provision_data[target]['layout'] = layout_data
                 else:


### PR DESCRIPTION
It seems that in 1.5.3, the pf_data somehow changed back from self.pf_data. This adjusts that back so pf_data (template data) will be propagated and processed through to both the topology and inventory_layout.