### PR TITLE
Add support for domain specification in dnsmasq

### DIFF
--- a/docs/source/examples/workspace/topologies/libvirt-el7net.yml
+++ b/docs/source/examples/workspace/topologies/libvirt-el7net.yml
@@ -10,6 +10,7 @@ resource_groups:
         ip: 192.168.74.100
         dhcp_start: 192.168.74.101
         dhcp_end: 192.168.74.112
+        domain: linchpin.net
       - name: centos74
         role: libvirt_node
         uri: qemu:///system

--- a/docs/source/libvirt.rst
+++ b/docs/source/libvirt.rst
@@ -72,6 +72,38 @@ with a :ref:`libvirt_node`, it must precede it.
 * :docs1.5:`Topology Example <workspace/topologies/libvirt-el7net.yml>`
 * `Ansible module <http://docs.ansible.com/ansible/latest/virt_net_module.html>`_
 
+Topology Schema
+~~~~~~~~~~~~~~~
+
+Within Linchpin, the :term:`libvirt_network` :term:`resource_definition` has more
+options than what are shown in the examples above. For each :term:`libvirt_network`
+definition, the following options are available.
+
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| Parameter          | req'd | type     | where used      | default             | comments                 |
++====================+=======+==========+=================+=====================+==========================+
+| role               | true  | string   | role            |                     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| name               | true  | string   | module: name    |                     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| uri                | false | string   | module: name    |  qemu:///system     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| ip                 | true  | string   | xml: ip         |                     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| dhcp_start         | false | string   | xml: dhcp_start |                     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| dhcp_end           | false | string   | xml: dhcp_end   |                     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| domain             | false | string   | xml: domain     |                     | Automated DNS for guests |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| forward_mode       | false | string   | xml: forward    | nat                 |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| forward_dev        | false | string   | xml: forward    |                     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+| bridge             | false | string   | xml: bridge     |                     |                          |
++--------------------+-------+----------+-----------------+---------------------+--------------------------+
+
+
 .. note:: This resource will not be torn down during a :term:`destroy` action.
    This is because other resources may depend on the now existing resource.
 

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -63,7 +63,8 @@
                     "prefix": { "type": "string", "required": false },
                     "dhcp_start": { "type": "string", "required": false },
                     "dhcp_end": { "type": "string", "required": false },
-                    "bridge": { "type": "string", "required": false }
+                    "bridge": { "type": "string", "required": false },
+                    "domain": { "type": "string", "required": false }
                 }
             },
             {

--- a/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
+++ b/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
@@ -6,6 +6,9 @@
   <forward mode="{{ res_def['forward_mode'] | default('nat') }}"
 {% if res_def['forward_dev'] is defined %}
      dev="{{ res_def['forward_dev'] }}"{% endif %}/>
+{% if res_def['domain'] is defined %}
+  <domain name="{{ res_def['domain'] }}" localOnly="yes"/>
+{% endif %}
   <ip address="{{ res_def['ip'] }}">
 {% if res_def['dhcp_start'] is defined %}
     <dhcp>


### PR DESCRIPTION
There are some caveats to this.

- Currently additional networks only works if cloud-config is not used. (This is not new but it was not clear to me, so it might not be clear to others)
- You will need to use virt-customize on the image to set the hostname.  The default hostname of localhost will not update dns records.

A future RFE would be to drop the requirement on virt-install and try to integrate virt-customize.

fixes #543 