### PR TITLE
Fixes ovirt role template error

### DIFF
--- a/linchpin/provision/roles/ovirt/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/ovirt/tasks/provision_resource_group.yml
@@ -33,7 +33,7 @@
   - name: "Provisioning resource definitions of current group"
     include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
     with_nested:
-      - "{{ res_grp['resource_definitions']) }}"
+      - "{{ res_grp['resource_definitions'] }}"
       - ["{{ res_grp['resource_group_name'] }}"]
     loop_control:
       loop_var: res_item


### PR DESCRIPTION
Quick fix removing ')'

```
TASK [ovirt : Provisioning resource definitions of current group]
***********************************************
task path:
/home/user/venv/lib/python2.7/site-packages/linchpin/provision/roles/ovirt/tasks/provision_resource_gr
yml:33
fatal: [localhost]: FAILED! => {
    "msg": "template error while templating string: unexpected ')'.
    String: {{ res_grp['resource_definitions']) }
    }
```