### PR TITLE
ks_meta in recipesets is valid schema.

### DIFF
--- a/linchpin/provision/roles/beaker/files/schema.json
+++ b/linchpin/provision/roles/beaker/files/schema.json
@@ -25,6 +25,7 @@
                                 "method": { "type": "string", "required": false },
                                 "arch": { "type": "string", "required": false },
                                 "variant": { "type": "string", "required": false },
+                                "ks_meta": { "type": "string", "required": false },
                                 "taskparam": {
                                     "type": "list",
                                     "required": false,


### PR DESCRIPTION
While trying to provision a resource in beaker using the restraint harness I found that linchpin doesn't accept the ks_meta param in topology.