### PR TITLE
Replace PyYAML, python-requests, python-ipaddress with RPMs (centos7)

### DIFF
--- a/config/Dockerfiles/centos7/Dockerfile
+++ b/config/Dockerfiles/centos7/Dockerfile
@@ -10,12 +10,15 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 RUN yum -y install python-pip \
     && pip install -U pip \
     && pip install -U setuptools \
-    && yum -y install ansible curl gcc python-devel openssl-devel \
+    && yum -y install curl \
+    && curl -o /etc/yum.repos.d/herlo-linchpin-epel7.repo \
+    https://copr.fedorainfracloud.org/coprs/herlo/linchpin-epel7/repo/epel-7/herlo-linchpin-epel7-epel-7.repo; \
+    yum -y install gcc python-devel openssl-devel ansible \
                     libvirt-daemon-driver-* libvirt-daemon libvirt-daemon-kvm \
                     qemu-kvm libvirt-daemon-config-network libvirt-python \
                     libvirt-devel file openssh mkisofs libvirt-client \
-                    net-tools git python-krbV make \
-                    libxslt-python krb5-workstation python-requests; \
+                    net-tools git python-krbV make libxslt-python krb5-workstation \
+                    PyYAML python-ipaddress python-requests; \
     #rm -rf /usr/lib/python2.7/site-packages/{urllib3,ipaddress}*; \
     #rm -rf /usr/lib64/python2.7/site-packages/{PyYAML,yaml}*; \
     #pip install -U 'ipaddress>=1.0.17'; \

--- a/config/Dockerfiles/centos7/Dockerfile
+++ b/config/Dockerfiles/centos7/Dockerfile
@@ -5,14 +5,27 @@ LABEL description "This container will verify linchpin works under Centos7"
 ENV HOME=/root
 WORKDIR $HOME
 
+COPY centos7/centos7-pike.repo /etc/yum.repos.d/centos7-pike.repo
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum -y install python-pip ansible curl gcc python-devel openssl-devel \
-                   libvirt-daemon-driver-* libvirt-daemon libvirt-daemon-kvm \
-                   qemu-kvm libvirt-daemon-config-network libvirt-python \
-                   libvirt-devel file openssh mkisofs libvirt-client \ 
-                   virt-install net-tools git python-krbV make \
-                   libxslt-python krb5-workstation \
-    && yum clean all; \
+RUN yum -y install python-pip \
+    && pip install -U pip \
+    && pip install -U setuptools \
+    && yum -y install ansible curl gcc python-devel openssl-devel \
+                    libvirt-daemon-driver-* libvirt-daemon libvirt-daemon-kvm \
+                    qemu-kvm libvirt-daemon-config-network libvirt-python \
+                    libvirt-devel file openssh mkisofs libvirt-client \
+                    net-tools git python-krbV make \
+                    libxslt-python krb5-workstation python-requests; \
+    #rm -rf /usr/lib/python2.7/site-packages/{urllib3,ipaddress}*; \
+    #rm -rf /usr/lib64/python2.7/site-packages/{PyYAML,yaml}*; \
+    #pip install -U 'ipaddress>=1.0.17'; \
+    #pip install -U 'urllib3<1.24,>=1.21.1'; \
+    #pip install -U 'requests>=2.14.2'; \
+    #pip install -U 'PyYAML>=3.12'; \
+    #pip uninstall -y urllib3; \
+    #yum -y install virt-install \
+    #echo 'pip freeze | grep requests'; \
+    #pip freeze | grep requests; \
     (cd /lib/systemd/system/sysinit.target.wants/; for i in *; \
      do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
     rm -f /lib/systemd/system/multi-user.target.wants/*;\
@@ -24,14 +37,12 @@ RUN yum -y install python-pip ansible curl gcc python-devel openssl-devel \
     rm -f /lib/systemd/system/anaconda.target.wants/*; \
     systemctl enable libvirtd; \
     systemctl enable virtlockd
-RUN pip install -U pip
-RUN pip install -U setuptools
 RUN sed -i "/Service/a ExecStartPost=\/bin\/chmod 666 /dev/kvm" /usr/lib/systemd/system/libvirtd.service
 
 RUN curl -o /etc/yum.repos.d/beaker-client.repo \
             https://beaker-project.org/yum/beaker-client-CentOS.repo; \
-    yum install beaker-client; \
-    yum clean all
+    yum -y install beaker-client \
+    && yum clean all && rm -rf /var/cache/yum;
 
 COPY centos7/default.xml /etc/libvirt/qemu/networks/
 

--- a/config/Dockerfiles/centos7/centos7-pike.repo
+++ b/config/Dockerfiles/centos7/centos7-pike.repo
@@ -1,0 +1,8 @@
+[centos-openstack-pike]
+name=CentOS 7 Openstack (pike) repo
+baseurl=http://mirror.centos.org/centos/7/cloud/x86_64/openstack-pike/
+skip_if_unavailable=True
+gpgcheck=0
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
+enabled=1
+


### PR DESCRIPTION
The CentOS7 container would not succecssfully build the linchpin executable after some sort of change recently. This update uses custom built rpms from a COPR repository, along with a CentOS7 (openstack-pike) repository to get linchpin to install again.

The reason this is a problem is that pip will not uninstall certain distutils packages (the above named are the ones dealt with here) using pip. RPM dependencies cause things to be uninstalled which are needed, and CentOS7 core doesn't have new enough RPMs.