### PR TITLE
Fix ovirt provider; Add count, disk provisioning and network delay

### DIFF
--- a/linchpin/provision/roles/ovirt/files/schema.json
+++ b/linchpin/provision/roles/ovirt/files/schema.json
@@ -13,6 +13,7 @@
                 "cluster": { "type": "string", "required": true },
                 "template": { "type": "string", "required": false },
                 "memory": { "type": "string", "required": false },
+                "count": { "type": "integer", "required": false },
                 "cpu_cores": { "type": "integer", "required": false },
                 "cpu_shares": { "type": "integer", "required": false },
                 "cpu_sockets": { "type": "integer", "required": false },
@@ -36,6 +37,9 @@
                     "required": false,
                     "schema": {
                         "name": { "type": "string", "required": true },
+                        "size": { "type": "string", "required": true },
+                        "format": { "type": "string", "required": true },
+                        "storage_domain": { "type": "string", "required": true },
                         "id": { "type": "string", "required": false },
                         "interface": { "type": "string", "required": false },
                         "bootable": { "type": "string", "required": false }

--- a/linchpin/provision/roles/ovirt/tasks/provision_ovirt_vms.yml
+++ b/linchpin/provision/roles/ovirt/tasks/provision_ovirt_vms.yml
@@ -1,8 +1,33 @@
+---
+
+- name: "Provision ovirt_disk resources"
+  ovirt_disks:
+    state: "{{ state }}"
+    auth: "{{ ovirt_auth }}"
+    name: "{{ ovirt_resource_name }}-{{ disk_item['name'] }}"
+    size: "{{ disk_item['size'] }}"
+    format: "{{ disk_item['format'] }}"
+    storage_domain: "{{ disk_item['storage_domain'] }}"
+    interface: "{{ disk_item['interface'] | default(omit) }}"
+  with_items: "{{ res_def['disks'] | default([]) }}"
+  loop_control:
+    loop_var: disk_item
+  register: disk
+
+- set_fact:
+    disks: []
+    
+- set_fact:
+    disks: "{{ disks | default([]) }} + {{ [{ 'name': disks_item['disk']['alias'] }] }}"
+  with_items: "{{ disk.results }}"
+  loop_control:
+    loop_var: disks_item
+    
 - name: "Provision/deprovision ovirt_vms resources"
   ovirt_vms:
     state: "{{ state }}"
     auth: "{{ ovirt_auth }}"
-    name: "{{ res_grp_name }}_{{ res_def['res_name'] }}"
+    name: "{{ ovirt_resource_name }}"
     template: "{{ res_def['template'] | default(omit) }}"
     cluster: "{{ res_def['cluster'] }}"
     memory: "{{ res_def['memory'] | default(omit) }}"
@@ -16,23 +41,59 @@
     cd_iso: "{{ res_def['cd_iso'] | default(omit) }}"
     type: "{{ res_def['type'] | default(omit) }}"
     operating_system: "{{ res_def['operating_system'] | default(omit) }}"
-    disks: "{{ res_def['disks'] | default(omit) }}"
+    disks: "{{ disks | default(omit) }}"
     nics: "{{ res_def['nics'] | default(omit) }}"
+    fetch_nested: true
+    nested_attributes: ips
+  when: not async
+
+# If the machine isn't powered on and the guest agent has not reported the
+# IP address fetch_nested will not be able to retrieve the nested_attributes: ips
+# - After the machine has been created start the vm
+# - Wait for an IPv4 address
+# - Use ovirt_vms to fetch variables
+  
+- name: "Start Ovirt VMs"
+  ovirt_vms:
+    state: "running"
+    auth: "{{ ovirt_auth }}"
+    name: "{{ ovirt_resource_name }}"
+  when: not async
+  
+- name: Wait for IPv4 address
+  ovirt_nics_facts:
+    auth: "{{ ovirt_auth }}"
+    vm: "{{ ovirt_resource_name }}"
+    name: "nic1"
+  register: nics
+  when: not async
+  until: 
+    - ovirt_nics | length > 0
+    - ovirt_nics[0].reported_devices | length > 0
+    - ovirt_nics[0].reported_devices[0].ips | selectattr('version', 'match', 'v4') | list | length > 0
+  retries: 12
+  delay: 30
+  
+- name: "Retrieve Nested Attributes for Ovirt VM"
+  ovirt_vms:
+    state: "{{ state }}"
+    auth: "{{ ovirt_auth }}"
+    name: "{{ ovirt_resource_name }}"
     fetch_nested: true
     nested_attributes: ips
   when: not async
   register: res_def_output
-
+    
 - name: "Append outputitem to topology_outputs"
   set_fact:
-    topology_outputs_ovirt_vms: "{{ topology_outputs_ovirt_vms + [res_def_output] }}"
+    topology_outputs_ovirt_vms: "{{ topology_outputs_ovirt_vms + [ res_def_output ] }}"
   when: not async
 
 - name: "Provision/deprovision ovirt_vms resources"
   ovirt_vms:
     state: "{{ state }}"
     auth: "{{ ovirt_auth }}"
-    name: "{{ res_grp_name }}_{{ res_def['res_name'] }}"
+    name: "{{ ovirt_resource_name }}"
     template: "{{ res_def['template'] | default(omit) }}"
     cluster: "{{ res_def['cluster'] }}"
     memory: "{{ res_def['memory'] | default(omit) }}"
@@ -46,15 +107,14 @@
     cd_iso: "{{ res_def['cd_iso'] | default(omit) }}"
     type: "{{ res_def['type'] | default(omit) }}"
     operating_system: "{{ res_def['operating_system'] | default(omit) }}"
-    disks: "{{ res_def['disks'] | default(omit) }}"
+    disks: "{{ disks | default(omit) }}"
     nics: "{{ res_def['nics'] | default(omit) }}"
     fetch_nested: true
     nested_attributes: ips
-  when: async == false
+  when: async
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output
-  when: async
 
 # following tasks saves the async job details
 - name: "Async:: save the job id"

--- a/linchpin/provision/roles/ovirt/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/ovirt/tasks/provision_res_defs.yml
@@ -1,2 +1,10 @@
-- name: "Provision resources of type {{ res_def['res_type'] | default(res_def['type']) }}"
-  include: "provision_{{ res_def['res_type'] | default(res_def['type']) }}.yml"
+---
+
+- name: "Provision resources of type {{ res_def['role']  }}"
+  include_tasks: "provision_{{ res_def['role'] }}.yml"
+  vars:
+    ovirt_resource_name: "{{ ovirt_resource_item }}"
+  with_sequence: start=1 end={{ res_def['count'] }} format="{{ res_def['name'] }}-{% if enable_uhash %}{{ uhash }}{% endif %}-%02d"
+  loop_control:
+    loop_var: ovirt_resource_item
+  


### PR DESCRIPTION
- `res_def['res_name']` does not exist.  Modified to use `res_def['name']`.
- Added `count` parameter
- Added creation of disks
- Added do-until for the guest agent to provide an IPv4 address which is used in inventory.

Topology Example:
```
---
topology_name: kubevirt_cluster
resource_groups:
  - resource_group_name: ovirt
    resource_group_type: ovirt
    resource_definitions:
      - name: master
        template: centos
        cluster: Default
        role: ovirt_vms
        count: 1
        disks:
        - name: docker
          size: 1GiB
          format: cow
          interface: virtio_scsi
          storage_domain: n1-virtomation-com-Local
        - name: gluster
          size: 1GiB
          format: cow
          interface: virtio_scsi
          storage_domain: n1-virtomation-com-Local
      - name: node
        template: centos
        cluster: Default
        role: ovirt_vms
        count: 2
    credentials:
      filename: ovirt_creds.yml
      profile: ovirt
```

cc: @lukas-bednar

