### PR TITLE
Check that virt-install exists

### DIFF
--- a/config/Dockerfiles/centos7/Dockerfile
+++ b/config/Dockerfiles/centos7/Dockerfile
@@ -26,7 +26,7 @@ RUN yum -y install python-pip \
     #pip install -U 'requests>=2.14.2'; \
     #pip install -U 'PyYAML>=3.12'; \
     #pip uninstall -y urllib3; \
-    #yum -y install virt-install \
+    yum -y install virt-install \
     #echo 'pip freeze | grep requests'; \
     #pip freeze | grep requests; \
     (cd /lib/systemd/system/sysinit.target.wants/; for i in *; \

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -223,6 +223,9 @@
   delegate_to: "{{ uri_hostname }}"
   when: res_def['cloud_config'] is defined and node_exists['failed'] is defined and uri_hostname != 'localhost'
 
+- name: "Check that virt-install exists"
+  command: which virt-install
+
 - name: "Install VM"
   command: "virt-install --connect {{ definition[6] }} --import --name {{ definition[0] }}_{{ definition[7] }} --autostart --network bridge={{ definition[3] }},model=virtio --ram {{ definition[4] }} --disk path={{ definition[1] }}/{{ definition[0] }}_{{ definition[7] }}.{{ definition[2] }},format={{ definition[5] }},bus=virtio,cache=none --disk path=/tmp/vm-{{ definition[0] }}_{{ definition[7] }}.iso,device=cdrom --wait 10 --os-type=linux --nographics"
   with_nested:


### PR DESCRIPTION
When provisioning libvirt, the step to "Install VM" is set to ignore errors.  If virt-install does not exist on the system, there will not be an error until the VM attempts to get a dhcp ip address a few steps later. This fix checks that virt-install exists first so that the error is reported immediately.