### PR TITLE
Prepare to use workspaces for tests using linchpin fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ ansible.cfg
 docs/build/
 _autosummary
 docs/source/generated/
-docs/source/examples/workspace/resources
+resources
 
 # packaging files
 build

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ keys/
 
 # ignore items imported during testing
 duffy-ansible-module
+duffy.py
 docs/source/examples/workspace/dummy-data.yml
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -357,4 +357,9 @@ extlinks = {
     'https://raw.githubusercontent.com/CentOS-PaaS-SIG/linchpin/develop/%s', ''),
     'dirs1.5': (
     'https://github.com/CentOS-PaaS-SIG/linchpin/tree/develop/docs/source/examples/%s', ''),
+    'lp_dir': (
+    'https://github.com/herlo/linchpin/tree/fetch_by_branch/%s', ''),
+    'lp_code': (
+    'https://raw.githubusercontent.com/herlo/linchpin/fetch_by_branch/%s', ''),
 }
+

--- a/docs/source/examples/workspace/PinFile.libvirt.yml
+++ b/docs/source/examples/workspace/PinFile.libvirt.yml
@@ -8,3 +8,34 @@ libvirt-network:
 
 libvirt-storage:
     topology: libvirt-storage.yml
+
+libvirt-custom-img:
+  topology:
+    topology_name: libvirt-custom-img
+    resource_groups:
+      - resource_group_name: libvirt-custom-img
+        resource_group_type: libvirt
+        resource_definitions:
+          - role: libvirt_node
+            name: lci-centos7
+            uri: qemu:///system
+            count: 1
+            image_src: file:///home/herlo/Isos/CentOS-7-x86_64-GenericCloud.qcow2.xz
+            memory: 1024
+            vcpus: 1
+            arch: x86_64
+            networks:
+              - name: default
+            ssh_key: libvirt
+            additional_storage: 10G
+            cloud_config:
+              virt_type: virt-customize
+              root_password: "testrootpwd" # insecure plaintext password
+              users:
+                - name: herlo
+                  groups: wheel
+                  inject_ssh_keys: true  # by default linchpin generated libvirt key is injected.
+              run_commands:
+                - "yum install -y epel-release"
+              packages:
+                - nginx

--- a/docs/source/examples/workspace/linchpin.conf
+++ b/docs/source/examples/workspace/linchpin.conf
@@ -217,6 +217,15 @@ generate_resources = False
 # formal name of the generated PinFile. Can be changed as desired.
 #pinfile = PinFile
 
+# This section covers settings for the `linchpin fetch` command
+#[fetch]
+
+# If desired, disable the caching functionality
+#cache_ws = True
+
+# How long before an update to the destination workspace from the cache
+#cache_days = 1
+
 # This section covers logging setup
 [logger]
 

--- a/docs/source/examples/workspaces/dummy-aws/PinFile.dummy-aws.yml
+++ b/docs/source/examples/workspaces/dummy-aws/PinFile.dummy-aws.yml
@@ -1,0 +1,48 @@
+---
+dummy-aws:
+  topology:
+    topology_name: dummy-aws
+    resource_groups:
+      - resource_group_name: dummy-topology
+        resource_group_type: dummy
+        resource_definitions:
+          - name: "{{ distro | default('') }}test"
+            role: "dummy_node"
+            count: 1
+      - resource_group_name: aws-topology
+        resource_group_type: aws
+        resource_definitions:
+          - name: demo-day
+            flavor: m1.small
+            role: aws_ec2
+            region: us-east-1
+            image: ami-984189e2
+            count: 1
+            instance_tags:
+              color: blue
+              shape: oval
+            security_group:
+              - default
+              - public
+        credentials:
+          filename: aws.key
+          profile: default
+  layout:
+    inventory_layout:
+      vars:
+        hostname: __IP__
+      hosts:
+        dummy-node:
+          count: 1
+          host_groups:
+            - dummy-layout
+        aws-node:
+          count: 1
+          host_groups:
+            - aws-layout
+      host_groups:
+        all:
+          vars:
+            ansible_python_interpreter: /usr/bin/python3
+            ansible_user: root
+            ansible_ssh_common_args: -o StrictHostKeyChecking=no

--- a/docs/source/examples/workspaces/dummy-two/PinFile.dummy-two.yml
+++ b/docs/source/examples/workspaces/dummy-two/PinFile.dummy-two.yml
@@ -1,0 +1,4 @@
+---
+dummy-two:
+  topology: dummy-two.yml
+  layout: dummy-new.yml

--- a/docs/source/examples/workspaces/dummy-two/topologies/dummy-two.yml
+++ b/docs/source/examples/workspaces/dummy-two/topologies/dummy-two.yml
@@ -1,0 +1,24 @@
+---
+topology_name: "dummy_cluster" # topology name
+resource_groups:
+  - resource_group_name: "dummy"
+    resource_group_type: "dummy"
+    resource_definitions:
+      - name: "{{ distro | default('') }}test"
+        role: "dummy_node"
+        count: 1
+  - resource_group_name: os-two
+    resource_group_type: openstack
+    resource_definitions:
+      - name: "{{ distro | default('') }}frontend"
+        role: os_server
+        flavor: m1.small
+        image: CentOS-7-x86_64-GenericCloud-1612
+        count: 1
+        keypair: ci-factory
+        auto_ip: no
+        networks:
+          - e2e-openstack
+    credentials:
+      filename: clouds.yaml
+      profile: ci-rhos

--- a/docs/source/examples/workspaces/linchpin.conf
+++ b/docs/source/examples/workspaces/linchpin.conf
@@ -1,0 +1,308 @@
+# This file is a well-documented, and commented out (mostly) file, which
+# covers the configuration options available in LinchPin
+#
+# Used to override default configuration settings for LinchPin
+# Defaults exist in linchpin/linchpin.constants file
+#
+# Uncommented options enable features found in v1.5.1 or newer and
+# can be turned off by commenting them out.
+#
+# structured in INI style
+# use %% to allow code interpolation
+# use % to use config interpolation
+#
+
+[DEFAULT]
+# name of the python package (Redundant, but easier than programmatically
+# obtaining the value. It's very unlikely to change.)
+pkg = linchpin
+
+# Useful for storing the RunDB or other components like global credentials
+# travis-ci doesn't like ~/.config/linchpin, use /tmp
+#default_config_path = ~/.config/linchpin
+
+# When creating an provider not already included in LinchPin, this path
+# extends where LinchPin will look to run the appropriate playbooks
+#external_providers_path = %(default_config_path)s/linchpin-x
+
+# When adding anything to the lp section, it should be general for
+# the entire application.
+[lp]
+
+# load custom ansible modules from here
+#module_folder = library
+
+# rundb tracks provisioning transactions
+# If you add a new one, rundb/drivers.py needs to be updated to match
+# rundb_conn is the location of the run database.
+# A common reason to move it is to use the rundb centrally across
+# the entire system, or in a central db on a shared filesystem.
+# System-wide RunDB: rundb_conn = ~/.config/linchpin/rundb-::mac::.json
+#rundb_conn = {{ workspace }}/.rundb/rundb-::mac::.json
+rundb_conn = ~/.config/linchpin/rundb-::mac::.json
+
+# name the type of Run database. Currently only TinyRunDB exists
+#rundb_type = TinyRunDB
+
+# How to connect to the RunDB, if it's on a separate server,
+# it may be tcp or ssh
+#rundb_conn_type = file
+
+# The schema is used because TinyDB is a NoSQL db. Another DB
+# may use this as a way to manage fields in a specific table.
+#rundb_schema = {"action": "",
+#                "inputs": [],
+#                "outputs": [],
+#                "start": "",
+#                "end": "",
+#                "rc": 0,
+#                "uhash": ""}
+
+# each entry in the RunDB contains a unique-ish hash (uhash). This
+# sets the hashing mechanism used to generate the uhash.
+#rundb_hash = sha256
+
+# The default dateformat used in LinchPin. Specifically used in the
+# RunDB for recording start and end dates, but also used elsewhere.
+#dateformat = %%m/%%d/%%Y %%I:%%M:%%S %%p
+
+# The name of the pinfile. Someone could adjust this and use TopFile
+# or somesuch. The ramifications of this would mean that the file in
+# the workspace that linchpin reads would change to this value.
+#default_pinfile = PinFile
+
+# By default, whenever linchpin performs an action
+# (linchpin up/linchpin destroy), the data is read from the PinFile.
+# Enabling 'use_rundb_for_actions' will allow destroy and certain up
+# actions (specifically when using --run-id or --tx-id) to pull data
+# from the RunDB instead.
+#use_rundb_for_actions = False
+use_rundb_for_actions = True
+
+# A user can request specific data distilled from the RunDB. This flag
+# enables the Context Distiller.
+# NOTE: This flag requires generate_resources = False.
+#distill_data = False
+distill_data = True
+
+# If desired, enabling distill_on_error will distill any successfully (and
+# possibly failed) provisioned resources. This is predicated on the data
+# being written to the RunDB (usually means _async tasks may never record
+# data upon failure).
+distill_on_error = False
+
+# User can make linchpin use the actual return codes for final return code
+# if enabled True, even if one target provision is successfull linchpin 
+# returns exit code zero else returns the sum of all the return codes
+# use_actual_rcs = False
+
+# LinchPin sets several extra_vars (evars) that are passed to the playbooks.
+# This section controls those items.
+[evars]
+
+# enables the ansible --check option
+# _check_mode = False
+
+# enables the ansible async ability. For some providers, it allows multiple
+# provisioning tasks to happen at once, then will collect the data afterward.
+# The default is perform the provision actions in serial.
+#_async = False
+
+# How long to wait before failing (in seconds) for an async task.
+#async_timeout = 1000
+
+# the uhash value will still exist, but will not be added to
+# instances or the inventory_path
+#enable_uhash = False
+enable_uhash = True
+
+# in older versions of linchpin (<v1.0.4), a resources folder exists, which
+# dumped the data that is now stored in the RunDB. To disable the resources
+# output, set the value to False.
+#generate_resources = True
+generate_resources = False
+
+# default paths in playbooks
+#
+# lp_path = <src_dir>/linchpin
+# determined in the load_config method of # linchpin.cli.LinchpinCliContext
+
+# Each of the following items controls the path (usually along with the
+# default values below) to the corresponding item.
+
+# In the workspace (generally), this is the location of the layouts and
+# topologies looked up by the PinFile. If either of these change, the
+# value in linchpin/templates must also change.
+#layouts_folder = layouts
+#topologies_folder = topologies
+
+# The relative location for hooks
+#hooks_folder = hooks
+
+# The relative location for provider roles
+#roles_folder = roles
+
+# The relative location for storing inventories
+#inventories_folder = inventories
+
+# The relative location for resources output (deprecated)
+#resources_folder = resources
+
+# The relative location to find schemas (deprecated)
+#schemas_folder = schemas
+
+# The relative location to find playbooks
+#playbooks_folder = provision
+
+# The default path to schemas for validation (deprecated)
+#default_schemas_path = {{ lp_path }}/defaults/%(schemas_folder)s
+
+# The default path to topologies if they aren't in the workspace
+#default_topologies_path = {{ lp_path }}/defaults/%(topologies_folder)s
+
+# The default path to inventory layouts if they aren't in the workspace
+#default_layouts_path = {{ lp_path }}/defaults/%(layouts_folder)s
+
+# The default path for outputting ansible static inventories
+#default_inventories_path = {{ lp_path }}/defaults/%(inventories_folder)s
+
+# The default path to the ansible roles which control the providers
+#default_roles_path = {{ lp_path }}/%(playbooks_folder)s/%(roles_folder)s
+
+# In older versions (<1.2.x), the schema was held here. These schemas are
+# deprecated.
+#schema_v3 = %(default_schemas_path)s/schema_v3.json
+#schema_v4 = %(default_schemas_path)s/schema_v4.json
+
+# The location where default credentials data would exist. This path doesn't
+# automatically exist
+#default_credentials_path = %(default_config_path)s
+
+# The location where default resources will be dumped. This path doesn't
+# automatically exist
+#default_resources_path = {{ workspace }}/%(resources_folder)s
+
+# If desired, one could overwrite the location of the generated inventory path
+#inventory_path = {{ workspace }}/{{inventories_folder}}/happy.inventory
+
+# Libvirt images can be stored almost anywhere (not /tmp).
+# Unprivileged users need not setup sudo to manage a path to which they have rights.
+# The following are specific settings to manage libvirt images and instances
+
+# the location to store generated ssh keys and the like
+#default_ssh_key_path = ~/.ssh
+
+# Where to store the libvirt images for copying/booting instances
+#libvirt_image_path = /var/lib/libvirt/images/
+
+# What user to use to access libvirt.
+# Using root means sudo without password must be setup
+#libvirt_user = root
+
+# When using root or any privileged user, this must be set to yes.
+# sudo without password must also be setup
+#libvirt_become = yes
+
+# This section covers settings for the `linchpin init` command
+#[init]
+
+# source path of files generated by linchpin init
+#source = templates/
+
+# formal name of the generated PinFile. Can be changed as desired.
+#pinfile = PinFile
+
+# This section covers settings for the `linchpin fetch` command
+#[fetch]
+
+# If desired, disable the caching functionality
+#cache_ws = True
+
+# How long before an update to the destination workspace from the cache
+#cache_days = 1
+
+# This section covers logging setup
+[logger]
+
+# Turns off and on the logger functionality
+#enable = True
+
+# Full path to the location of the linchpin log file
+file = ~/.config/linchpin/linchpin.log
+
+# Log format used. See https://docs.python.org/2/howto/logging-cookbook.html
+#format = %%(levelname)s %%(asctime)s %%(message)s
+
+# Date format used. See https://docs.python.org/2/howto/logging-cookbook.html
+#dateformat = %%m/%%d/%%Y %%I:%%M:%%S %%p
+
+# Level of logging provided
+#level = logging.DEBUG
+
+# Logging to the console via STDERR
+#[console]
+
+# logging to the console should also be possible
+# NOTE: Placeholder only, cannot disable.
+#enable = True
+
+# Log format used. See https://docs.python.org/2/howto/logging-cookbook.html
+#format = %%(message)s
+
+# Level of logging provided
+#level = logging.INFO
+
+# LinchPin hooks have several states depending on the action. Currently, there
+# are three hook states relating to tasks being completed.
+# * up - when performing the up (provision) action
+# * destroy - when performing the destroy (teardown) action
+# * inv - when performing the internal inventory generation action
+#   (currently unimplemented)
+#[hookstates]
+
+# when performing the up action, these hooks states are run
+#up = pre,post,inv
+
+# when performing the inv action, these hooks states are run
+#inv = post
+
+# when performing the destroy action, these hooks states are run
+#destroy = pre,post
+
+# This section covers file extensions for generating or looking
+# up specific files
+#[extensions]
+
+# When looking for provider playbooks, use this extension
+#playbooks = .yml
+
+# When generating inventory files, use this extension
+#inventory = .inventory
+
+# This section controls the ansible settings for display or other settings
+#[ansible]
+
+# If set to true, this enables verbose output automatically to the screen.
+# This is equivalent of passing `-v` to the linchpin command line shell.
+#console = False
+
+# When linchpin is run, certain states are called at certain points along the
+# execution timeline. These STATES are defined below.
+#[states]
+# in future each state will have comma separated substates
+
+# The name of the state which occurs before (pre) provisioning (up)
+#preup = preup
+
+# The name of the state which occurs before (pre) teardown (destroy)
+#predestroy = predestroy
+
+# The name of the state which occurs after (post) provisioning (up)
+#postup = postup
+
+# The name of the state which occurs after (pre) teardown (destroy)
+#postdestroy = postdestroy
+
+# The name of the state which occurs after (post) inventory is generated (inv)
+#postinv = inventory
+

--- a/docs/source/examples/workspaces/os-server-addl-vols/PinFile
+++ b/docs/source/examples/workspaces/os-server-addl-vols/PinFile
@@ -1,0 +1,51 @@
+---
+os-server-new:
+  topology:
+    topology_name: os-server-new
+    resource_groups:
+      - resource_group_name: os-server-new
+        resource_group_type: openstack
+        resource_definitions:
+          - name: "database"
+            role: os_server
+            flavor: m1.small
+            image: CentOS-7-x86_64-GenericCloud-1612
+            count: 2
+            keypair: ci-factory
+            fip_pool: 10.8.240.0
+            additional_volumes:
+              - name: "hello"
+                size: 1
+                device_name: "/dev/vdb"
+            networks:
+              - e2e-openstack
+          - name: "frontend"
+            role: os_server
+            flavor: m1.small
+            image: CentOS-7-x86_64-GenericCloud-1612
+            count: 2
+            keypair: ci-factory
+            fip_pool: 10.8.240.0
+            additional_volumes:
+              - name: "hello"
+                size: 1
+                device_name: "/dev/vdb"
+            networks:
+              - e2e-openstack
+        credentials:
+          filename: clouds.yaml
+          profile: ci-rhos
+  layout:
+    inventory_layout:
+      vars:
+        hostname: __IP__
+      hosts:
+        db-node:
+          count: 1
+          host_groups:
+            - database
+        frontend-node:
+          count: 1
+          host_groups:
+            - frontend
+

--- a/docs/source/examples/workspaces/os-server-addl-vols/PinFile
+++ b/docs/source/examples/workspaces/os-server-addl-vols/PinFile
@@ -1,25 +1,12 @@
 ---
-os-server-new:
+os-server-addl-vols:
   topology:
-    topology_name: os-server-new
+    topology_name: os-server-addl-vols
     resource_groups:
-      - resource_group_name: os-server-new
+      - resource_group_name: os-server-addl-vols
         resource_group_type: openstack
         resource_definitions:
           - name: "database"
-            role: os_server
-            flavor: m1.small
-            image: CentOS-7-x86_64-GenericCloud-1612
-            count: 2
-            keypair: ci-factory
-            fip_pool: 10.8.240.0
-            additional_volumes:
-              - name: "hello"
-                size: 1
-                device_name: "/dev/vdb"
-            networks:
-              - e2e-openstack
-          - name: "frontend"
             role: os_server
             flavor: m1.small
             image: CentOS-7-x86_64-GenericCloud-1612
@@ -40,12 +27,8 @@ os-server-new:
       vars:
         hostname: __IP__
       hosts:
-        db-node:
-          count: 1
+        addl-vols-node:
+          count: 2
           host_groups:
-            - database
-        frontend-node:
-          count: 1
-          host_groups:
-            - frontend
+            - hello
 

--- a/docs/source/examples/workspaces/os-server-addl-vols/PinFile
+++ b/docs/source/examples/workspaces/os-server-addl-vols/PinFile
@@ -6,7 +6,7 @@ os-server-addl-vols:
       - resource_group_name: os-server-addl-vols
         resource_group_type: openstack
         resource_definitions:
-          - name: "database"
+          - name: "hello"
             role: os_server
             flavor: m1.small
             image: CentOS-7-x86_64-GenericCloud-1612
@@ -14,7 +14,7 @@ os-server-addl-vols:
             keypair: ci-factory
             fip_pool: 10.8.240.0
             additional_volumes:
-              - name: "hello"
+              - name: "volume"
                 size: 1
                 device_name: "/dev/vdb"
             networks:

--- a/docs/source/examples/workspaces/os-server-addl-vols/README.rst
+++ b/docs/source/examples/workspaces/os-server-addl-vols/README.rst
@@ -1,0 +1,4 @@
+os-server-addl-vols
+====================
+
+This workspace enables openstack server additional volumes. Essentially allowing a user to add more disk space to the provisioned instances.

--- a/docs/source/examples/workspaces/os-server-addl-vols/linchpin.conf
+++ b/docs/source/examples/workspaces/os-server-addl-vols/linchpin.conf
@@ -1,0 +1,1 @@
+docs/source/examples/workspace/linchpin.conf

--- a/docs/source/examples/workspaces/os-server-addl-vols/linchpin.conf
+++ b/docs/source/examples/workspaces/os-server-addl-vols/linchpin.conf
@@ -1,1 +1,1 @@
-docs/source/examples/workspace/linchpin.conf
+../linchpin.conf

--- a/docs/source/examples/workspaces/random/PinFile.dyasny.yml
+++ b/docs/source/examples/workspaces/random/PinFile.dyasny.yml
@@ -1,0 +1,5 @@
+---
+libvirt-dyasny:
+  topology: libvirt-dyasny.yml
+  layout: libvirt-dyasny.yml
+

--- a/docs/source/examples/workspaces/random/PinFile.libvirt-dummy.yml
+++ b/docs/source/examples/workspaces/random/PinFile.libvirt-dummy.yml
@@ -1,0 +1,53 @@
+---
+libvirt-dummy:
+  topology:
+    topology_name: libvirt-dummy
+    resource_groups:
+      - resource_group_name: libvirt-new
+        resource_group_type: libvirt
+        resource_definitions:
+          - role: libvirt_node
+            name: centos71
+            uri: qemu:///system
+            count: 1
+            image_src: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1608.qcow2.xz
+            memory: 2048
+            vcpus: 1
+            arch: x86_64
+            ssh_key: libvirt
+            networks:
+              - name: default
+            additional_storage: 10G
+            cloud_config:
+              users:
+                - name: herlo
+                  gecos: Clint Savage
+                  groups: wheel
+                  sudo: ALL=(ALL) NOPASSWD:ALL
+                  ssh-import-id: gh:herlo
+                  lock_passwd: true
+            count: 1
+      - resource_group_name: dummy-topology
+        resource_group_type: dummy
+        resource_definitions:
+          - name: "{{ distro | default('') }}test"
+            role: "dummy_node"
+  layout:
+    inventory_layout:
+      vars:
+        hostname: __IP__
+      hosts:
+        libvirt-node:
+          count: 1
+          host_groups:
+            - dummy-layout
+        dummy-node:
+          count: 1
+          host_groups:
+            - aws-layout
+      host_groups:
+        all:
+          vars:
+            ansible_python_interpreter: /usr/bin/python3
+            ansible_user: root
+            ansible_ssh_common_args: -o StrictHostKeyChecking=no

--- a/docs/source/examples/workspaces/random/PinFile.openstack-aws.yml
+++ b/docs/source/examples/workspaces/random/PinFile.openstack-aws.yml
@@ -1,0 +1,57 @@
+---
+openstack-aws:
+  topology:
+    topology_name: kusc-resources
+    resource_groups:
+      - resource_group_name: aws
+        resource_group_type: aws
+        resource_definitions:
+          - name: demo-day
+            flavor: m1.small
+            role: aws_ec2
+            region: us-east-1
+            image: ami-984189e2
+            count: 1
+            instance_tags:
+              color: blue
+              shape: oval
+            security_group:
+              - default
+              - public
+        credentials:
+          filename: aws.key
+          profile: default
+      - resource_group_name: openstack-topology
+        resource_group_type: openstack
+        resource_definitions:
+            - role: os_server
+              name: kusc-openstack
+              flavor: m1.large.small.disk
+              image:  Fedora-Cloud-Base-28-released-latest
+              count: 1
+              keypair: ci-factory
+              networks:
+                - e2e-openstack
+              fip_pool: 10.8.240.0
+        credentials:
+            filename: clouds.yaml
+            profile: ci-rhos
+    layout:
+      inventory_layout:
+        vars:
+          hostname: __IP__
+        hosts:
+          beaker-node:
+            count: 1
+            host_groups:
+              - beaker-layout
+          openstack-node:
+            count: 1
+            host_groups:
+              - openstack-layout
+        host_groups:
+          all:
+            vars:
+              ansible_python_interpreter: /usr/bin/python3
+              ansible_user: root
+              ansible_ssh_common_args: -o StrictHostKeyChecking=no

--- a/docs/source/examples/workspaces/random/hooks/cinch.yml
+++ b/docs/source/examples/workspaces/random/hooks/cinch.yml
@@ -1,1 +1,0 @@
-/home/herlo/.local/lib/python2.7/site-packages/cinch/site.yml

--- a/docs/source/examples/workspaces/random/hooks/cinch.yml
+++ b/docs/source/examples/workspaces/random/hooks/cinch.yml
@@ -1,0 +1,1 @@
+/home/herlo/.local/lib/python2.7/site-packages/cinch/site.yml

--- a/docs/source/examples/workspaces/random/layouts/libvirt-dyasny.yml
+++ b/docs/source/examples/workspaces/random/layouts/libvirt-dyasny.yml
@@ -1,0 +1,70 @@
+inventory_layout:
+#  inventory_file: cnv-inventory.inv
+  vars:
+    hostname: __IP__
+  hosts:
+    "{{ executor_name }}-master":
+      count: 1
+      host_groups:
+        - masters
+        - etcd
+        - nodes
+        - nfs
+        - glusterfs
+    "{{ executor_name }}-node":
+      count: 2
+      host_groups:
+        - nodes
+        - glusterfs
+  host_groups:
+    OSEv3:
+      children:
+        - masters
+        - nodes
+        - etcd
+        - nfs
+        - glusterfs
+      vars:
+        ansible_ssh_user: root
+        containerized: true
+        openshift_version: "3.9.25"
+        openshift_release: "v3.9"
+        openshift_image_tag: "v3.9.25"
+        openshift_schedulable: true
+        osm_default_node_selector: ""
+        openshift_node_labels: "{'region': 'infra','zone': 'default', 'node-role.kubernetes.io/compute': 'true'}"
+        openshift_deployment_type: openshift-enterprise
+        openshift_clock_enabled: true
+        openshift_master_identity_providers: "[{'name': 'allow_all_auth', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]"
+        openshift_disable_check: "memory_availability,disk_availability"
+        openshift_enable_excluders: false
+        template_service_broker_install: false
+        openshift_use_manageiq: false
+        openshift_install_examples: false
+        openshift_master_default_subdomain: "cloudapps.{{ domain }}"
+        openshift_hosted_registry_routehost: "registry.cloudapps.{{ domain }}"
+
+        openshift_hosted_etcd_storage_kind: nfs
+        openshift_hosted_etcd_storage_nfs_options: "*(rw,root_squash,sync,no_wdelay)"
+        openshift_hosted_etcd_storage_nfs_directory: "/opt/osev3-etcd"
+        openshift_hosted_etcd_storage_volume_name: "etcd-vol2"
+        openshift_hosted_etcd_storage_access_modes: "['ReadWriteOnce']"
+        openshift_hosted_etcd_storage_volume_size: "1100M"
+        openshift_hosted_etcd_storage_labels: "{'storage': 'etcd'}"
+
+        ansible_service_broker_local_registry_whitelist: "[\".*-apb$\"]"
+
+        docker_dev: "/dev/vdb"
+        glusterfs_devices: "['/dev/vdc']"
+
+        # webconsole
+        openshift_web_console_prefix: "jniederm/origin-"
+        openshift_web_console_version: "demo-v10"
+
+        # cns
+        openshift_storage_glusterfs_namespace: "app-storage"
+        openshift_storage_glusterfs_storageclass: true
+        openshift_storageclass_default: false
+        openshift_storage_glusterfs_storageclass_default: true
+        openshift_storage_glusterfs_block_deploy: false
+

--- a/docs/source/examples/workspaces/random/template-data/Data-dyasny.yml
+++ b/docs/source/examples/workspaces/random/template-data/Data-dyasny.yml
@@ -1,0 +1,2 @@
+---
+domain: example.com

--- a/docs/source/examples/workspaces/random/template-data/Data-lbednar.yml
+++ b/docs/source/examples/workspaces/random/template-data/Data-lbednar.yml
@@ -1,0 +1,8 @@
+---
+executor_name: my-executor-lbednar
+keypair: my-executor-lbednar-net-key
+network: my-executor-lbednar-net
+security_group: my-executor-lbednar-secgroup
+image: rhel-7.4-server-x86_64-latest
+fip_pool: 10.8.240.0
+os_cloud: centralci

--- a/docs/source/examples/workspaces/random/template-data/dummy-data.yml
+++ b/docs/source/examples/workspaces/random/template-data/dummy-data.yml
@@ -1,0 +1,2 @@
+---
+distro: "fedora27-"

--- a/docs/source/examples/workspaces/random/topologies/libvirt-cinch.yml
+++ b/docs/source/examples/workspaces/random/topologies/libvirt-cinch.yml
@@ -1,0 +1,25 @@
+---
+topology_name: libvirt-cinch
+resource_groups:
+  - resource_group_name: libvirt-cinch
+    resource_group_type: libvirt
+    resource_definitions:
+      - role: libvirt_node
+        name: centos71
+        uri: qemu:///system
+        count: 1
+        image_src: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1608.qcow2.xz
+        memory: 1024
+        vcpus: 1
+        arch: x86_64
+        networks:
+          - name: default
+        additional_storage: 10G
+        cloud_config:
+          users:
+            - name: herlo
+              gecos: Clint Savage
+              groups: wheel
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              ssh-import-id: gh:herlo
+              lock_passwd: true

--- a/docs/source/examples/workspaces/random/topologies/libvirt-dyasny.yml
+++ b/docs/source/examples/workspaces/random/topologies/libvirt-dyasny.yml
@@ -1,0 +1,28 @@
+---
+topology_name: cnv_libvirt_cluster
+resource_groups:
+  - resource_group_name: libvirt
+    resource_group_type: libvirt
+    resource_definitions:
+      - role: libvirt_node
+        name: master
+        uri: qemu:///system
+        count: 1
+        image_src: file:///var/lib/libvirt/images/base_image.qcow2
+        memory: 1024
+        vcpus: 2
+        arch: x86_64
+        ssh_key: id_rsa
+        networks:
+          - name: default
+      - role: libvirt_node
+        name: node
+        uri: qemu:///system
+        count: 2
+        image_src: file:///var/lib/libvirt/images/base_image.qcow2
+        memory: 1024
+        vcpus: 1
+        arch: x86_64
+        ssh_key: id_rsa
+        networks:
+          - name: default

--- a/docs/source/examples/workspaces/random/topologies/libvirt-f27net.yml
+++ b/docs/source/examples/workspaces/random/topologies/libvirt-f27net.yml
@@ -1,0 +1,31 @@
+---
+topology_name: "libvirt_fedora27"
+resource_groups:
+  - resource_group_name: "libvirt_fedora27"
+    resource_group_type: "libvirt"
+    resource_definitions:
+      - name: linchpin-fedora27
+        role: libvirt_network
+        uri: qemu:///system
+        ip: 192.168.27.100
+        dhcp_start: 192.168.27.101
+        dhcp_end: 192.168.27.112
+      - name: fedora27
+        role: libvirt_node
+        uri: qemu:///system
+        image_src: https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2
+        count: 1
+        memory: 1024
+        vcpus: 1
+        networks:
+          - name: linchpin-fedora27
+        additional_storage: 10G
+        cloud_config:
+          users:
+            - name: herlo
+              gecos: Clint Savage
+              groups: wheel
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              ssh-import-id: gh:herlo
+              lock_passwd: true
+

--- a/docs/source/examples/workspaces/random/topologies/os-server-lbednar.yml
+++ b/docs/source/examples/workspaces/random/topologies/os-server-lbednar.yml
@@ -1,0 +1,29 @@
+---
+topology_name: my_cluster
+resource_groups:
+  - resource_group_name: openstack
+    resource_group_type: openstack
+    resource_definitions:
+      - name: "{{ executor_name }}-master"
+        type: os_server
+        flavor: w1.large
+        image: "{{ image }}"
+        count: 1
+        keypair: "{{ keypair }}"
+        networks:
+          - "{{ network }}"
+        fip_pool: "{{ fip_pool }}"
+        security_groups: "{{ security_group }}"
+      - name: "{{ executor_name }}-node"
+        type: os_server
+        flavor: w1.large
+        image: "{{ image }}"
+        count: 2
+        keypair: "{{ keypair }}"
+        networks:
+          - "{{ network }}"
+        fip_pool: "{{ fip_pool }}"
+        security_groups: "{{ security_group }}"
+    credentials:
+      filename: clouds.yml
+      profile: "{{ os_cloud }}"

--- a/docs/source/examples/workspaces/random/topologies/os-server-w-vol-new.yml
+++ b/docs/source/examples/workspaces/random/topologies/os-server-w-vol-new.yml
@@ -1,0 +1,26 @@
+---
+topology_name: os-single-new
+resource_groups:
+  - resource_group_name: os-server-enw
+    resource_group_type: openstack
+    resource_definitions:
+      - name: volume-a
+        role: os_volume
+        size: 1
+        count: 1
+      - name: frontend
+        role: os_server
+        flavor: m1.small
+        image: Fedora-Cloud-Base-26-compose-latest
+        count: 1
+        keypair: ci-factory
+        networks:
+          - atomic-e2e-jenkins-test
+        fip_pool: 10.8.240.0
+        volumes:
+          - volume-a_0
+    credentials:
+      filename: clouds.yaml
+      profile: ci-rhos
+
+

--- a/docs/source/examples/workspaces/simple/PinFile
+++ b/docs/source/examples/workspaces/simple/PinFile
@@ -1,0 +1,11 @@
+---
+simple:
+  topology:
+    topology_name: simple
+    resource_groups:
+      - resource_group_name: simple
+        resource_group_type: dummy
+        resource_definitions:
+          - name: web
+            role: dummy_node
+            count: 2

--- a/docs/source/examples/workspaces/simple/README.rst
+++ b/docs/source/examples/workspaces/simple/README.rst
@@ -1,0 +1,5 @@
+simple
+======
+
+This workspace provides a simple PinFile example. It will be used likely for
+``lincphin init`` and ``linchpin fetch`` documentation.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -61,6 +61,8 @@ Authentication
 
     :doc:`cli`
         Linchpin Command-Line Interface
+    :doc:`workflow`
+        Common LinchPin Workflows
     :doc:`managing_resources`
         Managing Resources
     :doc:`providers`

--- a/docs/source/includes/fetch.rst
+++ b/docs/source/includes/fetch.rst
@@ -1,0 +1,27 @@
+The ``linchpin fetch`` command provides a simple way to access a resource from
+a remote location. One could simply perform a `git clone`, or use `wget` to
+download a ``workspace``. However, ``linchpin fetch`` makes this process
+simpler, and includes some tooling to make the workflow smooth.
+
+.. code-block:: bash
+
+    $ linchpin fetch --help
+    Usage: linchpin fetch [OPTIONS] REMOTE
+
+      Fetches a specified linchpin workspace or component from a remote location
+
+    Options:
+      -t, --type TYPE              Which component of a workspace to fetch.
+                                   (Default: workspace)
+      -r, --root ROOT              Use this to specify the location of the
+                                   workspace within the root url. If root is not
+                                   set, the root of the given remote will be used.
+      --dest DEST                  Workspaces destination, the fetched workspace
+                                   will be relative to this location. (Overrides
+                                   -w/--workspace)
+      --branch REF                 Specify the git branch. Used only with git
+                                   protocol (eg. master).
+      --protocol [git|http|local]  Specify a protocol. (Default: git)
+      --nocache                    Do not check the cached time, just copy the
+                                   data to the destination
+      -h, --help                   Show this message and exit.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -9,4 +9,5 @@ Before investigating the main components of LinchPin -- provisioning, topologies
 
    installation
    getting_started
-   intro_config.rst
+   workflow
+   intro_config

--- a/docs/source/workflow.rst
+++ b/docs/source/workflow.rst
@@ -1,0 +1,155 @@
+Common Workflows
+================
+
+.. __foreword:
+
+Having a basic understanding of LinchPin is crucial to this section. Knowing
+the basic :doc:`CLI <cli>` operations leads nicely into using LinchPin in powerful
+ways.
+
+.. toctree::
+   :maxdepth: 1
+
+.. contents:: Topics
+
+.. _wf_fetch:
+
+Using ``linchpin fetch``
+------------------------
+
+.. include:: includes/fetch.rst
+
+Fetching a Remote Workspace
+---------------------------
+
+This document will cover how to use ``linchpin fetch`` to obtain a workspace
+from both a git repository. An example for fetching an http workspace can be
+found :doc:`here <fetch_http>`.
+
+First, determine the destination. By default, the destination location
+is the current working directory. In this guide, we'll use ``/tmp/workspaces``.
+
+.. code-block:: bash
+
+    $ mkdir /tmp/workspaces
+    $ cd /tmp/workspaces
+
+Using the simplest possible ``linchpin fetch`` command will fetch the
+workspaces from `git://github.com/herlo/lp_test_workspace`.
+
+.. code-block:: bash
+
+    $ linchpin fetch git://github.com/herlo/lp_test_workspace
+    destination workspace: /tmp/workspaces/
+
+    $ pwd
+    /tmp/workspaces
+    $ ls -l
+    total 4
+    -rw-rw-r-- 1 herlo herlo 980 Sep  5 13:53 linchpin.log
+    drwxrwxr-x 5 herlo herlo 140 Sep  5 13:54 multi-target
+    drwxrwxr-x 2 herlo herlo  80 Sep  5 13:54 openstack
+    drwxrwxr-x 3 herlo herlo 120 Sep  5 13:54 os-server-addl-vols
+
+The directory structure of `<https://github.com/herlo/lp_test_workspace>`_
+should match the local directory as shown above.
+
+As can be easily seen, ``linchpin fetch`` performed a git clone. Then copied
+all of the directories to the current directory. ``linchpin fetch`` assumes the
+root of the repository is a workspace.
+
+Additional Options
+``````````````````
+
+If pulling all workspaces was not the intended action, there are other useful
+options. First, perform a little clean up.
+
+.. code-block:: bash
+
+    $ cd && rm -rf /tmp/workspaces  # remove the workspaces directory
+    $ ls -l /tmp/workspaces
+    ls: cannot access '/tmp/workspaces/': No such file or directory
+
+.. note:: From here on in, this guide will use the LinchPin git repository.
+          There are several :lp_dir:`workspaces <docs/source/examples/workspaces>`
+          with useful use cases. Feel free to peruse them as desired. This guide
+          will use these workspaces going forward.
+
+To clone from a repository with multiple workspaces (eg. the linchpin
+repository), a root must be specified. It is also recommended to use the
+``--dest`` flag.
+
+.. code-block:: bash
+
+    $ linchpin fetch git://github.com/CentOS-PaaS-SIG/linchpin \
+    > --root workspaces/simple --dest /tmp/workspaces
+    Created destination workspace: /tmp/workspaces/simple
+
+In this example, there are additional options. Let's cover them in
+detail:
+
+``--root ROOT``
+    This is the root of the repository. Normally, the root of the repository
+    is used. However, if the workspaces reside elsewhere (eg. workspaces),
+    use this option.
+
+``--dest DESTINATION``
+    If the current working directory is not the desired location, use this
+    option.
+
+Performing a listing will show how these options affected the fetch.
+
+.. code-block:: bash
+
+    $ ls -R /tmp/workspaces/
+    /tmp/workspaces/:
+    simple
+
+    /tmp/workspaces/simple:
+    PinFile  README.rst
+
+As expected, the ``simple`` root was pulled down, and placed inside the
+``/tmp/workspaces`` directory on the local machine.
+
+To have **all** workspaces copied into /tmp/workspaces, a change is needed.
+
+.. code-block:: bash
+
+    $ linchpin fetch git://github.com/CentOS-PaaS-SIG/linchpin \
+    > --root workspaces --dest /tmp
+    destination workspace: /tmp/workspaces
+
+.. note:: An observant user will notice that the same destination was used.
+          This is because ``linchpin fetch`` maps the ROOT to the destination
+          automatically. This behavior can be adjusted by removing the --dest
+          option and specifying --workspace instead.
+
+Listing the files again reveals more workspaces.
+
+.. code-block:: bash
+
+    $ ls /tmp/workspaces/
+    dummy-aws  dummy-two  os-server-addl-vols  random  simple
+
+Take a moment and investigate each of these workspaces. 
+
+Contents of a Workspace
+-----------------------
+
+Whether a workspace watch created, or pulled using ``linchpin fetch``, they
+all have should some common components.
+
+``README.rst``
+    A short description of the purpose for (or use case) the workspace
+``PinFile``
+    A declarative file which indicates which resources should be provisioned,
+    any inventory layout to be generated, hooks, and other configurations
+
+.. note:: The ``PinFile`` can be in YAML, JSON format. It can also be a script
+          that returns JSON to STDOUT
+
+No other requirements are put on a workspace. However, there can be several
+other files or directories. See :doc:`managing_resources` for more information.
+
+
+

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -729,6 +729,7 @@ class LinchpinCli(LinchpinAPI):
         """
 
         dest = self.workspace
+        root_ws=None
         if dest_ws:
             if not ws_set:
                 if root:

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -691,7 +691,7 @@ class LinchpinCli(LinchpinAPI):
 
     def lp_fetch(self, src, root=None, fetch_type='workspace',
                  fetch_protocol=None, fetch_ref=None, ws_set=False,
-                 dest_ws=None):
+                 dest_ws=None, nocache=False):
         """
         Fetch a workspace from git, http(s), or a local directory, and
         generate a provided workspace
@@ -725,6 +725,11 @@ class LinchpinCli(LinchpinAPI):
                         root is provided, a random workspace name will be
                         generated. The destination can also be explicitly set
                         by using -w (see linchpin --help).
+
+        :param nocache: If true, don't copy from the cache dir, unless it's
+                        longer than the configured fetch.cache_days (1 day)
+                        (default: False)
+
         """
 
         dest = self.workspace
@@ -790,4 +795,8 @@ class LinchpinCli(LinchpinAPI):
                                                   root_ws=root_ws,
                                                   ref=fetch_ref)
         fetch_class.fetch_files()
+
+        if nocache:
+            self.set_cfg('fetch', 'cache_ws', 'False')
+
         fetch_class.copy_files()

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -795,9 +795,9 @@ class LinchpinCli(LinchpinAPI):
 
 
         fetch_class = FETCH_CLASS[protocol](self.ctx, fetch_type, src,
-                                                  dest, cache_path, root=root,
-                                                  root_ws=root_ws,
-                                                  ref=fetch_ref)
+                                            dest, cache_path, root=root,
+                                            root_ws=root_ws,
+                                            ref=fetch_ref)
         fetch_class.fetch_files()
 
         if nocache:

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -748,7 +748,7 @@ class LinchpinCli(LinchpinAPI):
             dest_ws = self.workspace
             if root:
                 abs_root = os.path.expanduser(os.path.realpath(root))
-                root = os.path.basename(abs_root.rstrip(os.path.sep))
+                root_ws = os.path.basename(abs_root.rstrip(os.path.sep))
 #                else:
 #                    pass  # dest = self.workspace (set at the top)
 
@@ -776,7 +776,8 @@ class LinchpinCli(LinchpinAPI):
         if not os.path.exists(cache_path):
             os.makedirs(cache_path)
 
-        if fetch_protocol is None:
+        protocol = fetch_protocol
+        if protocol is None:
             protocol_regex = OrderedDict([
                 ('((git|ssh|http(s)?)|(git@[\w\.]+))'
                     '(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?',
@@ -789,11 +790,11 @@ class LinchpinCli(LinchpinAPI):
                     fetch_protocol = obj
                     break
 
-        if fetch_protocol is None:  # assume fetch_protocol is git if None
-            fetch_protocol = 'FetchGit'
+        if protocol is None:  # assume fetch_protocol is git if None
+            protocol = 'FetchGit'
 
 
-        fetch_class = FETCH_CLASS[fetch_protocol](self.ctx, fetch_type, src,
+        fetch_class = FETCH_CLASS[protocol](self.ctx, fetch_type, src,
                                                   dest, cache_path, root=root,
                                                   root_ws=root_ws,
                                                   ref=fetch_ref)

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -689,7 +689,7 @@ class LinchpinCli(LinchpinAPI):
                               tx_id=tx_id)
 
 
-    def lp_fetch(self, src, root=None, fetch_type='workspace',
+    def lp_fetch(self, src, root='', fetch_type='workspace',
                  fetch_protocol=None, fetch_ref=None, dest_ws=None,
                  nocache=False):
         """
@@ -730,13 +730,14 @@ class LinchpinCli(LinchpinAPI):
         """
 
         root_ws = ''
-        if dest_ws:
+        if dest_ws and dest_ws != '.':
             if root:
                 abs_root = os.path.expanduser(os.path.realpath(root))
                 root_ws = os.path.basename(abs_root.rstrip(os.path.sep))
             else:
                 # generate a unique value for the root
-                uroot = hashlib.new('sha256:{0}{1}'.format(src, dest_ws))
+                hash_string = 'sha256:{0}{1}'.format(src, dest_ws)
+                uroot = hashlib.new(hash_string)
                 uroot = uroot.hexdigest()[:8]
 
                 # generate a random location to put an underscore
@@ -793,7 +794,7 @@ class LinchpinCli(LinchpinAPI):
 
 
         fetch_class = FETCH_CLASS[fetch_protocol](self.ctx, fetch_type, src,
-                                                  dest, cache_path, root,
+                                                  dest, cache_path, root=root,
                                                   root_ws=root_ws,
                                                   ref=fetch_ref)
         fetch_class.fetch_files()

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -698,38 +698,37 @@ class LinchpinCli(LinchpinAPI):
 
         :param src:         The URL or URI of the remote directory
 
-        :param root:        Used to specify the location of the workspace within
-                            the remote. If root is not set, the root of the given
-                            remote will be used.
+        :param root:        Used to specify the location of the workspace
+                            within the remote. If root is not set, the root
+                            of the given remote will be used.
 
-        :param fetch_type:   Specifies which component(s) of a workspace the user wants
-                            to fetch. Types include: topology, layout, resources,
-                            hooks, workspace.
+        :param fetch_type:  Specifies which component(s) of a workspace the
+                            user wants to fetch. Types include: topology,
+                            layout, resources, hooks, workspace.
                             (default: workspace)
 
         :param fetch_protocol:  The protocol to use to fetch the workspace.
                                 (default: git)
 
         :param fetch_ref:   Specify the git branch. Used only with git protocol
-                            (eg. master). If not used, the default branch will be used.
+                            (eg. master). If not used, the default branch will
+                            be used.
 
-        :param ws_set:  Boolean to determine if the workspace was set. If so, use this
-                        value as the absolut path to workspace.
+        :param ws_set:  Boolean to determine if the workspace was set. If so,
+                        use this value as the absolut path to workspace.
 
-        :param dest_ws: Workspaces destination, the workspace will be relative to
-                        this location.
+        :param dest_ws: Workspaces destination, the workspace will be relative
+                        to this location.
 
-                        If `-r/--root` is provided, its basename will be the name
-                        of the workspace within the destination. If no root is
-                        provided, a random workspace name will be generated. The
-                        destination can also be explicitly set by using -w (see
-                        linchpin --help).
-
-
+                        If `-r/--root` is provided, its basename will be the
+                        name of the workspace within the destination. If no
+                        root is provided, a random workspace name will be
+                        generated. The destination can also be explicitly set
+                        by using -w (see linchpin --help).
         """
 
         dest = self.workspace
-        root_ws=None
+        root_ws = None
         if dest_ws:
             if not ws_set:
                 if root:
@@ -738,9 +737,11 @@ class LinchpinCli(LinchpinAPI):
                     dest = '{0}/{1}'.format(dest_ws, root_ws)
                 else:
                     # generate a unique value for the root
-                    uroot = hashlib.new('sha256:{0}{1}'.format(remote, dest))
-                    uroot = uh.hexdigest()[:8]
-                    min_under = randint(1,7)  # generate a location to put an underscore
+                    uroot = hashlib.new('sha256:{0}{1}'.format(src, dest))
+                    uroot = uroot.hexdigest()[:8]
+
+                    # generate a random location to put an underscore
+                    min_under = randint(1, 7)
                     max_under = min_under + 1
                     uroot = uroot[:min_under] + '_' + uroot[max_under:]
                     dest = '{0}/{1}'.format(dest_ws, uroot)

--- a/linchpin/fetch/fetch.py
+++ b/linchpin/fetch/fetch.py
@@ -37,7 +37,7 @@ class Fetch(object):
     def copy_files(self):
 
         if self.fetch_type == 'workspace':
-            src_dir ='{0}/{1}'.format(self.td, self.root)
+            src_dir = '{0}/{1}'.format(self.td, self.root)
             self.copy_dir(src_dir, self.dest)
         else:
             self.transfer_section(self.fetch_type)

--- a/linchpin/fetch/fetch.py
+++ b/linchpin/fetch/fetch.py
@@ -15,9 +15,10 @@ from linchpin.exceptions import LinchpinError
 class Fetch(object):
     __metaclass__ = ABCMeta
 
-    def __init__(self, ctx, fetch_type, dest, root, root_ws='', ref=None):
+    def __init__(self, ctx, fetch_type, dest, root='', root_ws='', ref=None):
         """
         """
+
         self.ctx = ctx
         self.fetch_type = fetch_type
         self.root = root
@@ -34,8 +35,10 @@ class Fetch(object):
         pass
 
     def copy_files(self):
+
         if self.fetch_type == 'workspace':
-            self.copy_dir('{0}/{1}'.format(self.td, self.root), self.dest)
+            src_dir ='{0}/{1}'.format(self.td, self.root)
+            self.copy_dir(src_dir, self.dest)
         else:
             self.transfer_section(self.fetch_type)
 
@@ -57,6 +60,7 @@ class Fetch(object):
 
 
     def copy_dir(self, src, dest):
+
         for root, dirs, files in os.walk(src):
             files = [f for f in files if not f[0] == '.']
             dirs[:] = [d for d in dirs if not d[0] == '.']
@@ -101,16 +105,15 @@ class Fetch(object):
                             cp_files = True
 
                 if cp_files:
+
                     try:
                         if (os.path.islink(s_file) and
                                 os.path.exists(os.readlink(s_file))):
-                            s_file = '{0}/{1}'.format(self.td,
-                                                      os.readlink(s_file))
+                            s_file = os.readlink(s_file)
 
                         shutil.copy2(s_file, d_file)
-                    except (IOError, OSError):
-                        self.ctx.log_state('Unable to copy file:'
-                                           ' {0}'.format(s_file))
+                    except (IOError, OSError) as e:
+                        self.ctx.log_state(e)
 
 
     def read_cfg(self):

--- a/linchpin/fetch/fetch.py
+++ b/linchpin/fetch/fetch.py
@@ -78,11 +78,11 @@ class Fetch(object):
                 s_file = os.path.join(root, f)
                 d_file = os.path.join(dest_path, f)
 
-                # fetch.always_update_workspace flag determines whether or not to update.
-                # can be overwritten on the cli with --force (or the like)
+                # fetch.always_update_workspace flag determines whether or
+                # not to update. can be overwritten on the cli with --nocache.
                 cache_ws = (ast.literal_eval(
-                                self.ctx.get_cfg('fetch', 'cache_ws',
-                                                 default='True')))
+                            self.ctx.get_cfg('fetch', 'cache_ws',
+                                             default='True')))
 
                 copy_files = False
                 if not cache_ws:

--- a/linchpin/fetch/fetch.py
+++ b/linchpin/fetch/fetch.py
@@ -13,10 +13,13 @@ from linchpin.exceptions import LinchpinError
 class Fetch(object):
     __metaclass__ = ABCMeta
 
-    def __init__(self, ctx, fetch_type, dest, root, ref=None):
+    def __init__(self, ctx, fetch_type, dest, root, root_ws=None, ref=None):
+        """
+        """
         self.ctx = ctx
         self.fetch_type = fetch_type
         self.root = root
+        self.root_ws = root_ws
         self.ref = ref
         self.tempdirs = []
         self.dest = os.path.abspath(os.path.realpath(dest))
@@ -30,8 +33,7 @@ class Fetch(object):
 
     def copy_files(self):
         if self.fetch_type == 'workspace':
-            for path in self.tempdirs:
-                self.copy_dir(path, self.dest)
+            self.copy_dir('{0}/{1}'.format(self.td, self.root), self.dest)
         else:
             self.transfer_section(self.fetch_type)
 
@@ -41,16 +43,16 @@ class Fetch(object):
         dir_exists = True
         if section not in os.listdir(self.dest):
             dir_exists = False
-            os.mkdir(dest_dir)
+            os.makedirs(dest_dir)
 
-        for path in self.tempdirs:
-            src_dir = os.path.join(path, section)
-            if not os.path.exists(src_dir):
-                if not dir_exists:
-                    shutil.rmtree(dest_dir)
-                raise LinchpinError('The {0} directory does not exist in '
-                                    '{1}'.format(self.fetch_type, self.src))
-            self.copy_dir(src_dir, dest_dir)
+        src_dir = os.path.join('{0}/{1}'.format(self.td, self.root), section)
+        if not os.path.exists(src_dir):
+            if not dir_exists:
+                shutil.rmtree(dest_dir)
+            raise LinchpinError('The {0} directory does not exist in '
+                                '{1}'.format(self.fetch_type, self.src))
+        self.copy_dir(src_dir, dest_dir)
+
 
     def copy_dir(self, src, dest):
         for root, dirs, files in os.walk(src):

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -9,7 +9,7 @@ from linchpin.exceptions import LinchpinError
 class FetchGit(Fetch):
 
     def __init__(self, ctx, fetch_type, src, dest, cache_dir, root,
-                 root_ws=None, ref=None):
+                 root_ws='', ref=None):
         super(FetchGit, self).__init__(ctx, fetch_type, dest, root,
                                        root_ws=root_ws, ref=ref)
         self.src = src
@@ -17,6 +17,7 @@ class FetchGit(Fetch):
         self.cache_dir = os.path.join(cache_dir, "git")
         if not os.path.exists(self.cache_dir):
             os.mkdir(self.cache_dir)
+
 
     def fetch_files(self):
         # The key cannot contain ':' since linchpin does not support python 3.
@@ -29,8 +30,7 @@ class FetchGit(Fetch):
         if self.ref:
             ref = self.ref
 
-        key = "{0}|{1}|{2}".format(self.dest.replace(':', ''),
-                                   self.src.replace(':', ''), ref)
+        key = "{0}|{1}".format(self.src.replace(':', ''), ref)
 
         fetch_dir = self.cfgs["git"].get(key, None)
         self.td = self.call_clone(fetch_dir)
@@ -47,22 +47,22 @@ class FetchGit(Fetch):
         if self.ref:
             ref = self.ref
 
-        if fetch_dir:
+        if fetch_dir and os.path.exists(fetch_dir):
             cmd = ['git', '-C', fetch_dir, 'pull', '--quiet']
             retval = subprocess.call(cmd, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
-            tempdir = fetch_dir
         else:
-            tempdir = tempfile.mkdtemp(prefix="git_", dir=self.cache_dir)
+            if not fetch_dir:
+                fetch_dir = tempfile.mkdtemp(prefix="git_", dir=self.cache_dir)
 
             cmd = ['git', 'clone', '--quiet', self.src]
             if ref:
                 cmd.extend(['-b', ref])
-            cmd.append(tempdir)
+            cmd.append(fetch_dir)
 
             retval = subprocess.call(cmd, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
 
         if retval != 0:
             raise LinchpinError("Unable to clone {0}".format(self.src))
-        return tempdir
+        return fetch_dir

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -8,10 +8,11 @@ from linchpin.exceptions import LinchpinError
 
 class FetchGit(Fetch):
 
-    def __init__(self, ctx, fetch_type, src, dest, cache_dir, root, ref=None):
-        super(FetchGit, self).__init__(ctx, fetch_type, dest, root)
+    def __init__(self, ctx, fetch_type, src, dest, cache_dir, root,
+                 root_ws=None, ref=None):
+        super(FetchGit, self).__init__(ctx, fetch_type, dest, root,
+                                       root_ws=root_ws, ref=ref)
         self.src = src
-        self.ref = ref
 
         self.cache_dir = os.path.join(cache_dir, "git")
         if not os.path.exists(self.cache_dir):
@@ -32,19 +33,16 @@ class FetchGit(Fetch):
                                    self.src.replace(':', ''), ref)
 
         fetch_dir = self.cfgs["git"].get(key, None)
-        td = self.call_clone(fetch_dir)
+        self.td = self.call_clone(fetch_dir)
+
+        self.td_w_root = '{0}/{1}'.format(self.td, self.root)
 
         if fetch_dir is None:
             self.write_cfg("git", key, td)
 
-        if self.root is not None:
-            for ext in self.root:
-                self.tempdirs.append(os.path.join(td, ext.lstrip('/')))
-        else:
-            self.tempdirs.append(td)
-
 
     def call_clone(self, fetch_dir=None):
+
         ref = ''
         if self.ref:
             ref = self.ref

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -38,7 +38,7 @@ class FetchGit(Fetch):
         self.td_w_root = '{0}/{1}'.format(self.td, self.root)
 
         if fetch_dir is None:
-            self.write_cfg("git", key, td)
+            self.write_cfg("git", key, self.td)
 
 
     def call_clone(self, fetch_dir=None):

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -37,7 +37,7 @@ class FetchGit(Fetch):
 
         self.td_w_root = '{0}/{1}'.format(self.td, self.root)
 
-        if fetch_dir is None:
+        if not fetch_dir:
             self.write_cfg("git", key, self.td)
 
 

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -8,9 +8,9 @@ from linchpin.exceptions import LinchpinError
 
 class FetchGit(Fetch):
 
-    def __init__(self, ctx, fetch_type, src, dest, cache_dir, root,
+    def __init__(self, ctx, fetch_type, src, dest, cache_dir, root='',
                  root_ws='', ref=None):
-        super(FetchGit, self).__init__(ctx, fetch_type, dest, root,
+        super(FetchGit, self).__init__(ctx, fetch_type, dest, root=root,
                                        root_ws=root_ws, ref=ref)
         self.src = src
 

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -7,9 +7,11 @@ from linchpin.exceptions import LinchpinError
 
 
 class FetchGit(Fetch):
-    def __init__(self, ctx, fetch_type, src, dest, cache_dir, root):
+
+    def __init__(self, ctx, fetch_type, src, dest, cache_dir, root, ref=None):
         super(FetchGit, self).__init__(ctx, fetch_type, dest, root)
         self.src = src
+        self.ref = ref
 
         self.cache_dir = os.path.join(cache_dir, "git")
         if not os.path.exists(self.cache_dir):
@@ -21,8 +23,13 @@ class FetchGit(Fetch):
         # urls in key during parsing. Delimiters can be specified when
         # initializing a configparser object in python 3 so this does not
         # become an issue.
-        key = "{0}|{1}".format(self.dest.replace(':', ''),
-                               self.src.replace(':', ''))
+
+        ref = 'None'
+        if self.ref:
+            ref = self.ref
+
+        key = "{0}|{1}|{2}".format(self.dest.replace(':', ''),
+                                   self.src.replace(':', ''), ref)
 
         fetch_dir = self.cfgs["git"].get(key, None)
         td = self.call_clone(fetch_dir)
@@ -38,14 +45,19 @@ class FetchGit(Fetch):
 
 
     def call_clone(self, fetch_dir=None):
+        ref = ''
+        if self.ref:
+            ref = self.ref
+
         if fetch_dir:
             retval = subprocess.call(
                 ['git', '-C', fetch_dir, 'pull', '--quiet'])
             tempdir = fetch_dir
         else:
             tempdir = tempfile.mkdtemp(prefix="git_", dir=self.cache_dir)
-            retval = subprocess.call(
-                ['git', 'clone', '--quiet', self.src, tempdir])
+            cmd = ['git', 'clone', '--quiet', self.src, '-b', ref, tempdir]
+            retval = subprocess.call(cmd, stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
 
         if retval != 0:
             raise LinchpinError("Unable to clone {0}".format(self.src))

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -43,17 +43,24 @@ class FetchGit(Fetch):
 
     def call_clone(self, fetch_dir=None):
 
-        ref = ''
+        ref = None
         if self.ref:
             ref = self.ref
 
+        import pdb
+        pdb.set_trace()
         if fetch_dir:
             retval = subprocess.call(
                 ['git', '-C', fetch_dir, 'pull', '--quiet'])
             tempdir = fetch_dir
         else:
             tempdir = tempfile.mkdtemp(prefix="git_", dir=self.cache_dir)
-            cmd = ['git', 'clone', '--quiet', self.src, '-b', ref, tempdir]
+
+            cmd = ['git', 'clone', '--quiet', self.src]
+            if ref:
+                cmd.extend(['-b', ref])
+            cmd.append(tempdir)
+
             retval = subprocess.call(cmd, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
 

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -47,11 +47,10 @@ class FetchGit(Fetch):
         if self.ref:
             ref = self.ref
 
-        import pdb
-        pdb.set_trace()
         if fetch_dir:
-            retval = subprocess.call(
-                ['git', '-C', fetch_dir, 'pull', '--quiet'])
+            cmd = ['git', '-C', fetch_dir, 'pull', '--quiet']
+            retval = subprocess.call(cmd, stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
             tempdir = fetch_dir
         else:
             tempdir = tempfile.mkdtemp(prefix="git_", dir=self.cache_dir)

--- a/linchpin/fetch/fetch_http.py
+++ b/linchpin/fetch/fetch_http.py
@@ -12,7 +12,7 @@ class FetchHttp(Fetch):
     def __init__(self, ctx, fetch_type, src, dest, cache_dir, root='',
                  root_ws='', ref=None):
         super(FetchHttp, self).__init__(ctx, fetch_type, dest, root=root,
-                                       root_ws=root_ws, ref=ref)
+                                        root_ws=root_ws, ref=ref)
 
         self.cache_dir = os.path.join(cache_dir, "http")
         if not os.path.exists(self.cache_dir):

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -76,6 +76,10 @@ aws_ec2 = instances.id,instances.public_ip,instances.private_ip,instances.public
 os_server = servers.id,servers.interface_ip,servers.name,servers.private_v4,servers.public_v4
 libvirt_node = name,ip
 
+[fetch]
+cache_ws = True
+cache_days = 1
+
 [logger]
 enable = True
 file = linchpin.log

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -310,7 +310,7 @@ def destroy(ctx, targets, run_id, tx_id):
 @click.option('-t', '--type', 'fetch_type', metavar='TYPE', required=False,
               default='workspace', help='Which component of a workspace to'
               ' fetch. (Default: workspace)')
-@click.option('-r', '--root', metavar='ROOT', default=None,
+@click.option('-r', '--root', metavar='ROOT', default='',
               help='Use this to specify the location of the workspace'
                    ' within the root url. If root is not set, the root'
                    ' of the given remote will be used.')

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -324,8 +324,9 @@ def destroy(ctx, targets, run_id, tx_id):
 @click.option('--protocol', 'fetch_protocol', default='git',
               type=click.Choice(['git', 'http', 'local']),
               help='Specify a protocol. (Default: git)')
-@click.option('--nocache', is_flag=True, 
-              help='Do not check the cached time, just copy the data to the destination')
+@click.option('--nocache', is_flag=True,
+              help='Do not check the cached time, just copy the data to the'
+                   ' destination')
 @pass_context
 def fetch(ctx, remote, fetch_type, root, dest_ws,
           fetch_ref, fetch_protocol, nocache):

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -308,24 +308,27 @@ def destroy(ctx, targets, run_id, tx_id):
 
 @runcli.command()
 @click.argument('remote', default=None, required=True, nargs=1)
-@click.option('-t', '--type', 'fetch_type', required=False, default='workspace',
-              help='Which component of a workspace to fetch.'
-                   ' (Default: workspace)')
-@click.option('-r', '--root', default=None,
+@click.option('-t', '--type', 'fetch_type', metavar='TYPE', required=False,
+              default='workspace', help='Which component of a workspace to'
+              ' fetch. (Default: workspace)')
+@click.option('-r', '--root', metavar='ROOT', default=None,
               help='Use this to specify the location of the workspace'
                    ' within the root url. If root is not set, the root'
                    ' of the given remote will be used.')
-@click.option('--dest', 'dest_ws', default=None,
+@click.option('--dest', 'dest_ws', metavar='DEST', default=None,
               help='Workspaces destination, the workspace will be relative to'
                    ' this location.')
-@click.option('--branch', 'fetch_ref', default=None,
+@click.option('--branch', 'fetch_ref', metavar='REF', default=None,
               help='Specify the git branch. Used only with'
                    ' git protocol (eg. master).')
 @click.option('--protocol', 'fetch_protocol', default='git',
               type=click.Choice(['git', 'http', 'local']),
               help='Specify a protocol. (Default: git)')
+@click.option('--nocache', is_flag=True, 
+              help='Do not check the cached time, just copy the data to the destination')
 @pass_context
-def fetch(ctx, remote, fetch_type, root, dest_ws, fetch_ref, fetch_protocol):
+def fetch(ctx, remote, fetch_type, root, dest_ws,
+          fetch_ref, fetch_protocol, nocache):
     """
     Fetches a specified linchpin workspace or component from a remote location
 
@@ -335,11 +338,12 @@ def fetch(ctx, remote, fetch_type, root, dest_ws, fetch_ref, fetch_protocol):
 
     if not fetch_type:
         fetch_type = 'workspace'
+
     try:
         ws_set = ctx.get_cfg('tmp', 'ws_set', default=False)
         lpcli.lp_fetch(remote, root=root, fetch_type=fetch_type,
                        fetch_protocol=fetch_proto, fetch_ref=fetch_ref,
-                       ws_set=ws_set, dest_ws=dest_ws)
+                       ws_set=ws_set, dest_ws=dest_ws, nocache=nocache)
     except LinchpinError as e:
         ctx.log_state(e)
         sys.exit(1)

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -160,7 +160,6 @@ def runcli(ctx, config, pinfile, template_data, outfile,
 
     if workspace is not None:
         ctx.workspace = os.path.realpath(os.path.expanduser(workspace))
-        ctx.set_cfg('tmp', 'ws_set', True)
         ctx.log_debug("ctx.workspace: {0}".format(ctx.workspace))
 
     # global LinchpinCli placeholder
@@ -316,8 +315,8 @@ def destroy(ctx, targets, run_id, tx_id):
                    ' within the root url. If root is not set, the root'
                    ' of the given remote will be used.')
 @click.option('--dest', 'dest_ws', metavar='DEST', default=None,
-              help='Workspaces destination, the workspace will be relative to'
-                   ' this location.')
+              help='Workspaces destination, the fetched workspace will be'
+                   ' relative to this location. (Overrides -w/--workspace)')
 @click.option('--branch', 'fetch_ref', metavar='REF', default=None,
               help='Specify the git branch. Used only with'
                    ' git protocol (eg. master).')
@@ -341,10 +340,9 @@ def fetch(ctx, remote, fetch_type, root, dest_ws,
         fetch_type = 'workspace'
 
     try:
-        ws_set = ctx.get_cfg('tmp', 'ws_set', default=False)
         lpcli.lp_fetch(remote, root=root, fetch_type=fetch_type,
                        fetch_protocol=fetch_proto, fetch_ref=fetch_ref,
-                       ws_set=ws_set, dest_ws=dest_ws, nocache=nocache)
+                       dest_ws=dest_ws, nocache=nocache)
     except LinchpinError as e:
         ctx.log_state(e)
         sys.exit(1)

--- a/scripts/install_libvirt_deps.sh
+++ b/scripts/install_libvirt_deps.sh
@@ -6,12 +6,19 @@ else
     LP_PATH=${PWD}
 fi
 
+DNF='dnf'
+grep -i fedora /etc/os-release
+
+if [ "${?}" != 0 ]; then
+    DNF='yum'
+fi
+
 if [ "${USER}" != "root" ]; then
-    sudo dnf install libvirt-devel -yq
-    sudo dnf install libguestfs-tools python-libguestfs -yq
+    sudo ${DNF} install libvirt-devel -yq
+    sudo ${DNF} install libguestfs-tools python-libguestfs -yq
 else
-    dnf install libvirt-devel -yq
-    dnf install libguestfs-tools python-libguestfs -yq
+    ${DNF} install libvirt-devel -yq
+    ${DNF} install libguestfs-tools python-libguestfs -yq
 fi
 
 if [ -e "${LP_PATH}" ]; then

--- a/workspaces
+++ b/workspaces
@@ -1,0 +1,1 @@
+docs/source/examples/workspaces


### PR DESCRIPTION
Fixes #618 
Fixes #619 

The linchpin repository will have multiple workspaces in the examples section (with a symlink from the root 'workspaces' path).

In the future, tests, examples, etc. will use workspaces. There will be a README.rst and a standard set of items to add to each workspace as well. The workspaces now exist.

Some work on the linchpin fetch functionality needed to occur as well to ensure pulling of a particular branch or reference. 