### PR TITLE
Update cerberus to version 1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ansible>=2.3.1
 six>=1.10.0
 shade>=1.18.0,!=1.21.0
 naked
-Cerberus<=1.1
+Cerberus<=1.2
 tinydb
 requests>=2.14.2
 ipaddress>=1.0.17


### PR DESCRIPTION
This upgrade from version 1.1 to 1.2 will allow cerberus to recursively validate sub-schemas, such as the networks sub-schema in libvirt_node