### PR TITLE
Add linchpin validate command

### DIFF
--- a/docs/source/advanced/validator.rst
+++ b/docs/source/advanced/validator.rst
@@ -1,0 +1,151 @@
+Validate Command
+-----------------
+
+The purpose of the validate command is to determine whether topologies are
+syntactically valid and, if not, provide a list of errors that occured during
+validation
+
+Using the validate command
+```````````````````````````
+
+The command `linchpin validate` looks at the topology file for each target in
+a given PinFile. If the topology is not valid under the current schema, it will
+attempt to convert the topology to an older schema and try again. If the
+topology is still invalid, the command will report the topology and a list of
+errors found.
+
+Invalid Topologies
+++++++++++++++++++
+
+Here is a simple PinFile and topology file. The topology file has some errors
+and will not validate.
+
+.. code-block:: yaml
+
+   ---
+   libvirt-new:
+      topology: libvirt-new.yml
+      layout: libvirt.yml
+
+   libvirt:
+      topology: libvirt.yml
+      layout: libvirt.yml
+
+   libvirt-network:
+      topology: libvirt-network.yml
+
+
+.. code-block:: yaml
+
+   ---
+   topology_name: libvirt-new
+   resource_groups:
+     - resource_group_name: libvirt-new
+       resource_group_type: libvirt
+       resource_definitions:
+         - role: libvirt_node
+           uri: qemu:///system
+           count: "1"
+           image_src: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1608.qcow2.xz
+           memory: 2048
+           vcpus: 1
+           arch: x86_64
+           ssh_key: libvirt
+           networks:
+             - name: default
+               additional_storage: 10G
+           cloud_config:
+             users:
+               - name: herlo
+                 gecos: Clint Savage
+                 groups: wheel
+                 sudo: ALL=(ALL) NOPASSWD:ALL
+                 ssh-import-id: gh:herlo
+                 lock_passwd: true
+
+.. code-block:: bash
+
+   $ linchpin validate
+   topology for target 'libvirt-network' is valid
+
+   Topology for target 'libvirt-new' does not validate
+   topology: 'OrderedDict([('topology_name', 'libvirt-new'), ('resource_groups', [OrderedDict([('resource_group_name', 'libvirt-new'), ('resource_group_type', 'libvirt'), ('resource_definitions', [OrderedDict([('role', 'libvirt_node'), ('uri', 'qemu:///system'), ('image_src', 'http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1608.qcow2.xz'), ('memory', 2048), ('vcpus', '1'), ('arch', 'x86_64'), ('ssh_key', 'libvirt'), ('networks', [OrderedDict([('name', 'default'), ('hello', 'world')])]), ('additional_storage', '10G'), ('cloud_config', OrderedDict([('users', [OrderedDict([('name', 'herlo'), ('gecos', 'Clint Savage'), ('groups', 'wheel'), ('sudo', 'ALL=(ALL) NOPASSWD:ALL'), ('ssh-import-id', 'gh:herlo'), ('lock_passwd', True)])])])), ('count', 1)])])])])])'
+   errors:
+         res_defs[0][count]: value for field 'count' must be of type 'integer'
+         res_defs[0][networks][0][additional_storage]: field 'additional_storage' could not be recognized within the schema provided
+         res_defs[0][name]: field 'name' is required
+
+   topology for target 'libvirt' is valid under old schema
+   topology for target 'libvirt-network' is valid
+
+
+The `linchpin validate` command can also provide a list of errors against the
+old schema with the `--old-schema` floag
+
+.. code-block:: bash
+
+   $ linchpin validate --old-schema
+   
+   Topology for target 'libvirt-new' does not validate
+   topology: 'OrderedDict([('topology_name', 'libvirt-new'), ('resource_groups', [OrderedDict([('resource_group_name', 'libvirt-new'), ('resource_group_type', 'libvirt'), ('resource_definitions', [OrderedDict([('role', 'libvirt_node'), ('uri', 'qemu:///system'), ('image_src', 'http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1608.qcow2.xz'), ('memory', 2048), ('vcpus', '1'), ('arch', 'x86_64'), ('ssh_key', 'libvirt'), ('networks', [OrderedDict([('name', 'default'), ('hello', 'world')])]), ('additional_storage', '10G'), ('cloud_config', OrderedDict([('users', [OrderedDict([('name', 'herlo'), ('gecos', 'Clint Savage'), ('groups', 'wheel'), ('sudo', 'ALL=(ALL) NOPASSWD:ALL'), ('ssh-import-id', 'gh:herlo'), ('lock_passwd', True)])])])), ('count', 1)])])])])])'
+   errors:
+         res_defs[0][networks][0][additional_storage]: field 'additional_storage' could not be recognized within the schema provided
+         res_defs[0][name]: field 'name' is required
+
+   topology for target 'libvirt' is valid under old schema
+   topology for target 'libvirt-network' is valid
+
+As you can see, validation under both schemas result in an error stating that
+the field `additional_storage` could not be recognized.  In this case, there is
+simply an indentation error. `additional_storage` is a recognized field within
+`resource_definitions` but not within the `networks` sub-schema. Other times
+this unrecognized field may be a spelling error.  Both fields also flag the
+missing "name" field, which is required.  Both of these errors must be fixed
+in order for the topology file to validate.  Because making `count` a string
+only results in an error when validating against the old schema, this field
+does not have to be changed in order for the topology file to pass validation.
+However, it is best to change it anyway and keep your topology as up-to-date as
+possible.
+
+Valid Topologies
+++++++++++++++++
+
+The topology below has been fixed so that it will validate under the current schema.
+
+.. code-block:: yaml
+
+   ---
+   topology_name: libvirt-new
+   resource_groups:
+     - resource_group_name: libvirt-new
+       resource_group_type: libvirt
+       resource_definitions:
+         - role: libvirt_node
+           name: centos71
+           uri: qemu:///system
+           count: 1
+           image_src: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1608.qcow2.xz
+           memory: 2048
+           vcpus: 1
+           arch: x86_64
+           ssh_key: libvirt
+           networks:
+             - name: default
+           additional_storage: 10G
+           cloud_config:
+             users:
+               - name: herlo
+                 gecos: Clint Savage
+                 groups: wheel
+                 sudo: ALL=(ALL) NOPASSWD:ALL
+                 ssh-import-id: gh:herlo
+                 lock_passwd: true
+
+If `linchpin validate` is run on the PinFile above, this will be the output:
+
+.. code-block:: bash
+
+   $ linchpin validate
+   topology for target 'libvirt-new' is valid
+   topology for target 'libvirt' is valid under old schema
+   topology for target 'libvirt-network' is valid

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -7,7 +7,6 @@ import time
 import errno
 import hashlib
 
-from cerberus import Validator
 from uuid import getnode as get_mac
 from collections import OrderedDict
 
@@ -24,6 +23,9 @@ from linchpin.exceptions import LinchpinError
 from linchpin.exceptions import SchemaError
 from linchpin.exceptions import TopologyError
 from linchpin.exceptions import ValidationError
+from linchpin.exceptions import ValidationErrorHandler
+
+from linchpin.utils.validator import AnyofValidator
 
 from linchpin.InventoryFilters import GenericInventory
 
@@ -420,17 +422,54 @@ class LinchpinAPI(object):
 
             res_defs = group.get('resource_definitions')
 
+
             # preload this so it will validate against the schema
             document = {'res_defs': res_defs}
-            v = Validator(schema)
+            v = AnyofValidator(schema,
+                               error_handler=ValidationErrorHandler)
 
             if not v.validate(document):
-                raise SchemaError('Schema validation failed:'
-                                  ' {0}'.format(v.errors))
+                try:
+                    err = self._gen_error_msg("", "", v.errors)
+                    raise SchemaError(err)
+                except NotImplementedError as e:
+                    # we shouldn't have this issue using cerberus >= 1.2, but
+                    # this is here just in case an older version has to be used
+                    print "There was an error validating your schema, but we " \
+                        "can't seem to format it for you"
+                    print "Here's the raw error data in case you want to go " \
+                        "through it by hand:"
+                    print v._errors
 
             resources.append(group)
 
         return resources
+
+
+    def _gen_error_msg(self, prefix, section, error):
+        # set the prefix for this subtree
+        if section != "":
+            if prefix != "":
+                prefix += "[" + str(section) + "]"
+            else:
+                prefix = str(section)
+
+        if isinstance(error, str):
+            if prefix == "":
+                return error
+            return prefix + ": " + error + os.linesep
+        elif isinstance(error, list):
+            msg = ""
+            for i, e in enumerate(error):
+                # we don't need to change the Vprefix here
+                msg += self._gen_error_msg(prefix, "", e)
+            return msg
+        else:  # in this case, error is a dict
+            msg = ""
+            for key, val in error.iteritems():
+                msg += self._gen_error_msg(prefix, key, val)
+            return msg
+
 
     def generate_inventory(self, topology_data, layout, inv_format="cfg"):
         inv = GenericInventory.GenericInventory(inv_format=inv_format)
@@ -629,8 +668,10 @@ class LinchpinAPI(object):
                     self._convert_topology(topology_data)
                     resources = self._validate_topology(topology_data)
                 except SchemaError:
-                    raise ValidationError("Topology '{0}' does not"
-                                          " validate".format(topology_data))
+                    raise ValidationError("Topology '{0}' does not validate."
+                                          "For more information run `linchpin"
+                                          "validate`".format(topology_data))
+
 
             self.set_evar('topo_data', topology_data)
 
@@ -741,6 +782,71 @@ class LinchpinAPI(object):
                            'results_data': results}}
 
         return (return_code, lp_data)
+
+
+    def do_validation(self, provision_data, old_schema=False):
+        """
+        This function takes provision_data, and attempts to validate the
+        topologies for that data
+
+        :param provision_data: PinFile data as a dictionary, with
+        target information
+        """
+
+        results = {}
+
+
+        return_code = 0
+
+        for target in provision_data.keys():
+            if not isinstance(provision_data[target], dict):
+                raise LinchpinError("Target '{0}' does not"
+                                    " exist.".format(target))
+
+        targets = [x.lower() for x in provision_data.keys()]
+        if 'linchpin' in targets:
+            raise LinchpinError("Target 'linchpin' is not allowed.")
+
+        for target in provision_data.keys():
+            self.ctx.log_debug("Processing target: {0}".format(target))
+
+            results[target] = {}
+            self.set_evar('target', target)
+
+            topology_data = provision_data[target].get('topology')
+
+            try:
+                self._validate_topology(topology_data)
+            except SchemaError as e:
+                # try to validate against old schema
+                try:
+                    self._convert_topology(topology_data)
+                    self._validate_topology(topology_data)
+                except SchemaError as s:
+                    error = """
+Topology for target '{0}' does not validate
+topology: '{1}'
+errors:
+""".format(target, topology_data)
+                    if old_schema:
+                        # there's an inline way of doing this with join() but
+                        # this looks cleaner
+                        for line in iter(str(s).splitlines(True)):
+                            error += "\t" + line
+                    else:
+                        for line in iter(str(e).splitlines(True)):
+                            error += "\t" + line
+
+                    results[target] = error
+                    return_code += 1
+                else:
+                    results[target] = "valid with old schema"
+
+
+            else:
+                results[target] = "valid"
+
+        return return_code, results
 
 
     def get_run_data(self, tx_id, fields, targets=()):

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -405,6 +405,46 @@ class LinchpinCli(LinchpinAPI):
 
 
 
+    def lp_validate(self, targets=(), old_schema=False):
+        """
+        This function takes a list of targets, and validates their topology.
+
+        :param targets:
+            A tuple of targets to provision
+
+        :param old_schema
+            Denotes whether schema should be validated with the old schema
+            rather than the new one!/usr/bin/env python
+        """
+
+        # Prep input data
+
+        pf_w_path = self._get_pinfile_path()
+        pf_data_path = self._get_data_path()
+        if not pf_data_path:
+            pf = self.parser.process(pf_w_path, data=self.pf_data)
+        else:
+            pf = self.parser.process(pf_w_path,
+                                     data='@{0}'.format(pf_data_path))
+
+        if pf:
+            provision_data = self._build(pf, pf_data=self.pf_data)
+
+            pf_outfile = self.get_cfg('tmp', 'outfile')
+            if pf_outfile:
+                self.parser.write_json(provision_data, pf_outfile)
+
+        prov_data = OrderedDict()
+
+        if len(targets):
+            for target in targets:
+                prov_data[target] = provision_data.get(target)
+        else:
+            prov_data = provision_data
+
+        return self.do_validation(prov_data, old_schema=old_schema)
+
+
     def lp_destroy(self, targets=(), run_id=None, tx_id=None):
 
         """
@@ -488,6 +528,7 @@ class LinchpinCli(LinchpinAPI):
                 pf_outfile = self.get_cfg('tmp', 'outfile')
                 if pf_outfile:
                     self.parser.write_json(provision_data, pf_outfile)
+
 
             return_code, return_data = self._execute(provision_data,
                                                      targets,

--- a/linchpin/exceptions/__init__.py
+++ b/linchpin/exceptions/__init__.py
@@ -1,3 +1,5 @@
+from cerberus import errors as cerberus_errors
+
 
 class LinchpinError(Exception):
 
@@ -45,3 +47,15 @@ class ActionError(LinchpinError):
 
     def __init__(self, *args, **kwargs):
         LinchpinError.__init__(self, *args, **kwargs)
+
+
+class ValidationErrorHandler(cerberus_errors.BasicErrorHandler):
+    messages = cerberus_errors.BasicErrorHandler.messages.copy()
+    messages[cerberus_errors.REQUIRED_FIELD.code] = "field '{field}' is"\
+        + "required"
+    messages[cerberus_errors.UNKNOWN_FIELD.code] = "field '{field}' could not "\
+        + "be recognized within the schema provided"
+    messages[cerberus_errors.BAD_TYPE.code] = "value for field '{field}' must "\
+        + "be of type '{constraint}'"
+    messages[cerberus_errors.UNALLOWED_VALUE.code] = "unallowed value " \
+        + "'{value}' for field '{field}'. Allowed values are: {constraint}"

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -31,9 +31,12 @@
                         "type": "list",
                         "required": false,
                         "schema": {
-                           "name": { "type": "string", "required": true },
-                           "ip": { "type": "string", "required": false },
-                           "mac": { "type": "string", "required": false }
+                            "type": "dict",
+                            "schema": {
+                                "name": { "type": "string", "required": true },
+                                "ip": { "type": "string", "required": false },
+                                "mac": { "type": "string", "required": false }
+                            }
                         }
                     },
                     "storage": {

--- a/linchpin/provision/roles/ovirt/files/schema.json
+++ b/linchpin/provision/roles/ovirt/files/schema.json
@@ -26,36 +26,45 @@
                     "type": "list",
                     "required": false,
                     "schema": {
-                        "name": {"type": "string", "required": true },
-                        "profile_name": {"type": "string", "required": false },
-                        "interface": {"type": "string", "required": false },
-                        "mac_address": {"type": "string", "required": false }
+                        "type": "dict",
+                        "schema": {
+                            "name": {"type": "string", "required": true },
+                            "profile_name": {"type": "string", "required": false },
+                            "interface": {"type": "string", "required": false },
+                            "mac_address": {"type": "string", "required": false }
+                        }
                     }
                 },
                 "disks": {
                     "type": "list",
                     "required": false,
                     "schema": {
-                        "name": { "type": "string", "required": true },
-                        "size": { "type": "string", "required": true },
-                        "format": { "type": "string", "required": true },
-                        "storage_domain": { "type": "string", "required": true },
-                        "id": { "type": "string", "required": false },
-                        "interface": { "type": "string", "required": false },
-                        "bootable": { "type": "string", "required": false }
+                        "type": "dict",
+                        "schema": {
+                            "name": { "type": "string", "required": true },
+                            "size": { "type": "string", "required": true },
+                            "format": { "type": "string", "required": true },
+                            "storage_domain": { "type": "string", "required": true },
+                            "id": { "type": "string", "required": false },
+                            "interface": { "type": "string", "required": false },
+                            "bootable": { "type": "string", "required": false }
+                        }
                     }
                 },
                 "cloud_init": {
                     "type": "list",
                     "required": false,
                     "schema": {
-                        "nic_name": { "type": "string", "required": true },
-                        "nic_ip": { "type": "string", "required": false },
-                        "nic_boot_protocol": { "type": "string", "required": false },
-                        "nic_netmask": { "type": "string", "required": false },
-                        "nic_gateway": { "type": "string", "required": false },
-                        "nic_on_boot": { "type": "string", "required": false },
-                        "hostname": { "type": "string", "required": false }
+                        "type": "dict",
+                        "schema": {
+                            "nic_name": { "type": "string", "required": true },
+                            "nic_ip": { "type": "string", "required": false },
+                            "nic_boot_protocol": { "type": "string", "required": false },
+                            "nic_netmask": { "type": "string", "required": false },
+                            "nic_gateway": { "type": "string", "required": false },
+                            "nic_on_boot": { "type": "string", "required": false },
+                            "hostname": { "type": "string", "required": false }
+                        }
                     }
                 }
             }

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -504,6 +504,38 @@ def journal(ctx, targets, fields, count, view,
         ctx.log_state(output)
 
 
+@runcli.command()
+@click.option('--old-schema', '-o', is_flag=True)
+@click.argument('targets', metavar='TARGETS', required=False,
+                nargs=-1)
+@pass_context
+def validate(ctx, targets, old_schema):
+    """
+    Validate topologies for the given target(s) in the given PinFile.
+
+    The data from the targets is obtained from the PinFile (default).
+
+    targets:    Validate ONLY the listed target(s). If omitted, ALL targets in
+    the appropriate PinFile will be validate
+
+    """
+
+    try:
+        return_code, results = lpcli.lp_validate(targets=targets,
+                                                 old_schema=old_schema)
+        for target, result in results.iteritems():
+            if result == "valid":
+                result = "topology for target '{0}' is valid". format(target)
+            elif result == "valid with old schema":
+                result = "topology for target '{0}' is valid under old schema"\
+                    .format(target)
+            ctx.log_state(result)
+        sys.exit(return_code)
+    except LinchpinError as e:
+        ctx.log_state(e)
+        sys.exit(1)
+
+
 def main():
     # print("entrypoint")
     pass

--- a/linchpin/utils/validator.py
+++ b/linchpin/utils/validator.py
@@ -1,0 +1,53 @@
+from cerberus import Validator
+from cerberus import errors
+
+
+class AnyofValidator(Validator):
+    def __init__(self, *args, **kwargs):
+        super(AnyofValidator, self).__init__(*args, **kwargs)
+
+    def _validate_anyof(self, definitions, field, value):
+        """ {'type': 'list', 'logical': 'anyof'} """
+        # print "definitions:", definitions
+
+        if 'role' not in definitions[0]['schema'].keys():
+            return super(AnyofValidator, self)._validate_anyof(definitions,
+                                                               field, value)
+
+        valids = 0
+        found_valid_role = False
+        _errors = errors.ErrorList()
+        valid_roles = []
+        for i, definition in enumerate(definitions):
+            valid_roles.extend(definition['schema']['role']['allowed'])
+            if value['role'] not in definition['schema']['role']['allowed']:
+                continue
+
+            found_valid_role = True
+
+            schema = {field: definition.copy()}
+            for rule in ('allow_unknown', 'type'):
+                if rule not in schema[field] and rule in self.schema[field]:
+                    schema[field][rule] = self.schema[field][rule]
+            if 'allow_unknown' not in schema[field]:
+                schema[field]['allow_unknown'] = self.allow_unknown
+
+            validator = self._get_child_validator(
+                schema_crumb=(field, 'role', value['role']), schema=schema,
+                allow_unknown=True
+            )
+            if validator(self.document, update=self.update, normalize=False):
+                valids += 1
+            else:
+                _errors.extend(validator._errors)
+
+        if valids == 0:
+            if not found_valid_role:
+                role_error = errors.ValidationError(
+                    ("resource_definitions", 0, "role"),
+                    ("res_defs", "schema", "anyof", -1, "schema", "role"),
+                    0x44, "rule", valid_roles, value['role'], ""
+                )
+                self._error([role_error])
+            else:
+                self._error(validator._errors)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ansible>=2.3.1
 six>=1.10.0
 shade>=1.18.0,!=1.21.0
 naked
-Cerberus<=1.1
+Cerberus>=1.2
 tinydb
 requests>=2.14.2
 ipaddress>=1.0.17


### PR DESCRIPTION
`linchpin validate` validates topologies and provides a list of errors if the topology does not successfully validate.  This PR also fixes some schema errors that prevent validation and updates cerberus to version 1.2, which is required in order to validate lists inside of schemas.