### PR TITLE
bugfix to make LinchpinAPI work standalone

### DIFF
--- a/linchpin/hooks/__init__.py
+++ b/linchpin/hooks/__init__.py
@@ -114,7 +114,7 @@ class LinchpinHooks(object):
         that is being set. these parameters are based topology name.
         """
 
-        topo_data = self.api.get_evar('topo_data')
+        topo_data = self.api.get_evar('topo_data', {})
 
         workspace = self.api.get_evar('workspace')
         inv_folder = self.api.get_evar('inventories_folder')


### PR DESCRIPTION
I was trying to invoke linchpin by a sample API script 

```python
import linchpin
from linchpin import LinchpinAPI
from linchpin.context import LinchpinContext 
import yaml

pinfile = """
---
dummy_target:
  topology:
    topology_name: "dummy"
    resource_groups:
      - resource_group_name: "dummy"
        resource_group_type: "dummy"
        resource_definitions:
        - role: "dummy_node"
          name: "web"
          count: 1
  layout:
    inventory_layout:
      vars:
        hostname: __IP__
      hosts:
        example-node:
          count: 1
          host_groups:
            - example
"""
pinfile = yaml.load(pinfile)

ctx = LinchpinContext()
ctx.console = True
ctx.setup_logging()
ctx.evars = {}
workspace_path = "/home/srallaba/workspace/lp_ws/ex_hooks/workspace"
ctx.set_evar("workspace", workspace_path)
lp_obj = LinchpinAPI(ctx)
lp_obj.workspace = workspace_path
lp_obj.do_action(pinfile)

```

while doing it i encountered a bug Which is due to preup hook state. Which can be resolved by current PR.
