### PR TITLE
Schema update to libvirt cloud_config

### DIFF
--- a/config/Dockerfiles/tests.d/libvirt/01_temp_general
+++ b/config/Dockerfiles/tests.d/libvirt/01_temp_general
@@ -12,7 +12,7 @@ DISTRO=${1}
 PROVIDER=${2}
 
 TARGETS="${PROVIDER}-new"
-TEST_NAME="${DISTRO}/${PROVIDER}/01_general"
+TEST_NAME="${DISTRO}/${PROVIDER}/01_temp_general"
 DESCRIPTION="Test ${PROVIDER} provider with a simple up/destroy"
 
 echo "Test Name: ${TEST_NAME}"

--- a/docs/source/examples/workspace/topologies/libvirt-new.yml
+++ b/docs/source/examples/workspace/topologies/libvirt-new.yml
@@ -22,5 +22,5 @@ resource_groups:
               gecos: Clint Savage
               groups: wheel
               sudo: ALL=(ALL) NOPASSWD:ALL
-              ssh-import-id: gh:herlo
+              ssh_import_id: gh:herlo
               lock_passwd: true

--- a/linchpin/InventoryFilters/GenericInventory.py
+++ b/linchpin/InventoryFilters/GenericInventory.py
@@ -45,8 +45,6 @@ class GenericInventory(InventoryFilter):
         layout_host_count = self.get_layout_hosts(layout)
         # generate hosts list based on the layout host count
         inven_hosts = self.get_hosts_by_count(host_ip_dict, layout_host_count)
-        # reverse the hosts list
-        inven_hosts.reverse()
         # adding sections to respective host groups
         host_groups = self.get_layout_host_groups(layout)
 

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -27,26 +27,36 @@
                     "network_bridge": { "type": "string", "required": false },
                     "ssh_key": { "type": "string", "required": false },
                     "cloud_config": {
-			"type": "dict", 
-			"required": false,
-			"schema": {
+                        "type": "dict",
+                        "required": false,
+                        "schema": {
                            "virt_type": { "type": "string", "required": false },
                            "run_script": { "type": "string", "required": false },
                            "run_commands": { "type": "list", "required": false },
-                           "users": { 
-		               "type": "list",
-			       "required": false,
-			       "schema": {
-                                   "name": { "type": "string", "required": true },
-                                   "gecos": { "type": "string", "required": false },
-                                   "password": { "type": "string", "required": false },
-                                   "inject_ssh_keys": { "type": "string", "required": false }
-                               }
-			   },
-			   "root_password": { "type": "string", "required": false },
-                           "packages": { "type": "list", "required": false }
+                           "users": {
+                                "type": "list",
+                                "required": false,
+                                "schema": {
+                                    "type": "dict",
+                                    "required": false,
+                                    "schema": {
+                                        "name": { "type": "string", "required": true },
+                                        "gecos": { "type": "string", "required": false },
+                                        "primary_group": { "type": "string", "required": false },
+                                        "groups": { "type": "string", "required": false },
+                                        "sudo": { "type": "string", "required": false },
+                                        "passwd": { "type": "string", "required": false },
+                                        "lock_passwd": { "type": "boolean", "required": false },
+                                        "ssh_import_id": { "type": "string", "required": false },
+                                        "ssh_authorized_keys": { "type": "list", "required": false },
+                                        "inject_ssh_keys": { "type": "string", "required": false }
+                                    }
+                                }
+                            },
+                            "root_password": { "type": "string", "required": false },
+                            "packages": { "type": "list", "required": false }
                         }
-		    },
+                    },
                     "networks": {
                         "type": "list",
                         "required": false,

--- a/linchpin/provision/roles/libvirt/templates/cloud-config/user-data
+++ b/linchpin/provision/roles/libvirt/templates/cloud-config/user-data
@@ -12,9 +12,9 @@ users:
     {{ item.gecos | default('Admin User') }}
     {{ item.groups | default('wheel') }}
     {{ item.sudo | default('ALL=(ALL) NOPASSWD:ALL')}}
-    {{ item.ssh-import-id | default('None') }}
+    {{ item.ssh_import_id | default('None') }}
     {{ item.lock_passwd | default('true') }}
-    ssh-authorized-keys:
+    ssh_authorized_keys:
       - {{ pubkey["stdout"] }}
 {% endfor %}
 #users:
@@ -22,9 +22,9 @@ users:
 #    gecos: Admin User
 #    groups: wheel
 #    sudo: ALL=(ALL) NOPASSWD:ALL
-#    ssh-import-id: None
+#    ssh_import_id: None
 #    lock_passwd: true
-#    ssh-authorized-keys:
+#    ssh_authorized_keys:
 #      - {{ pubkey["stdout"] }}
 
 timezone: UTC

--- a/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-fixed
+++ b/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-fixed
@@ -10,9 +10,9 @@ users:
     gecos: Admin User
     groups: wheel
     sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh-import-id: None
+    ssh_import_id: None
     lock_passwd: true
-    ssh-authorized-keys:
+    ssh_authorized_keys:
       - {{ pubkey["stdout"] }}
 
 timezone: UTC

--- a/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-fixed-local
+++ b/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-fixed-local
@@ -10,9 +10,9 @@ users:
     gecos: Admin User
     groups: wheel
     sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh-import-id: None
+    ssh_import_id: None
     lock_passwd: true
-    ssh-authorized-keys:
+    ssh_authorized_keys:
       - {{ pubkey_local["stdout"] }}
 
 timezone: UTC

--- a/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-fixed-remote
+++ b/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-fixed-remote
@@ -10,9 +10,9 @@ users:
     gecos: Admin User
     groups: wheel
     sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh-import-id: None
+    ssh_import_id: None
     lock_passwd: true
-    ssh-authorized-keys:
+    ssh_authorized_keys:
       - {{ pubkey_remote["stdout"] }}
 
 timezone: UTC

--- a/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-local
+++ b/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-local
@@ -13,7 +13,7 @@ users:
     gecos: {{ item['gecos'] | default('Admin User') }}
     groups: {{ item['groups'] | default('wheel') }}
     sudo: {{ item['sudo'] | default('ALL=(ALL) NOPASSWD:ALL')}}
-    ssh-import-id: {{ item['ssh-import-id'] | default('None') }}
+    ssh_import_id: {{ item['ssh_import_id'] | default('None') }}
     lock_passwd: {{ item['lock_passwd'] | default('true') }}
     ssh-authorized-keys:
       - {{ pubkey_local['stdout'] }}

--- a/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-remote
+++ b/linchpin/provision/roles/libvirt/templates/cloud-config/user-data-remote
@@ -1,4 +1,4 @@
-#cloud-config
+_cloud-config
 #password: fedora
 #chpasswd: {expire: False}
 #ssh_pwauth: True
@@ -13,9 +13,9 @@ users:
     gecos: {{ item['gecos'] | default('Admin User') }}
     groups: {{ item['groups'] | default('wheel') }}
     sudo: {{ item['sudo'] | default('ALL=(ALL) NOPASSWD:ALL')}}
-    ssh-import-id: {{ item['ssh-import-id'] | default('None') }}
+    ssh_import_id: {{ item['ssh_import_id'] | default('None') }}
     lock_passwd: {{ item['lock_passwd'] | default('true') }}
-    ssh-authorized-keys:
+    ssh_authorized_keys:
       - {{ pubkey_remote['stdout'] }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
The new validation structures require a dict for this schema instead of just a list. Cerberus 1.2 is a bit more strict about these things.

The rest of the updates were to match the [cloud_config documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html#including-users-and-groups) for users and groups.