### PR TITLE
The auth_var is never undefined, change conditional tests

### DIFF
--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -14,7 +14,7 @@
 
 - name: Provision additional volumes
   os_volume:
-    state: "{{ state }}" 
+    state: "{{ state }}"
     auth: "{{ auth_var }}"
     name: "{{ prov_vol['name'] }}"
     region_name: "{{ res_def['region_name'] | default(omit) }}"
@@ -25,7 +25,7 @@
   loop_control:
     loop_var: prov_vol
 
-- name: Detach addtional volumes
+- name: Detach additional volumes
   os_server_volume:
     state: "{{ state }}"
     auth: "{{ auth_var }}"
@@ -89,7 +89,9 @@
     auto_ip: "{{ res_def['auto_ip'] | default(omit) }}"
   register: res_def_output
   loop: "{{ res_def_names }}"
-  when: not async and auth_var is defined
+  when:
+    - auth_var != ""
+    - not async
   no_log: "{{ not debug_mode }}"
   loop_control:
     loop_var: prov_inst
@@ -109,12 +111,12 @@
 - name: "Transform outputs to match the distiller format"
   set_fact:
     res_def_output: "{{ res_def_output | transform_os_server_output  }}"
-  when: not async and auth_var is defined
+  when: not async and auth_var != ""
 
 - name: "Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server + [res_def_output] }}"
-  when: not async and auth_var is defined
+  when: not async and auth_var != ""
 
 - name: "provision/teardown os_server resources when auth not defined"
   os_server:
@@ -150,19 +152,26 @@
     auto_ip: "{{ res_def['auto_ip'] | default(omit) }}"
   register: res_def_output
   loop: "{{ res_def_names }}"
-  when: not async and auth_var is not defined
+  when:
+    - auth_var == ""
+    - not async
   loop_control:
     loop_var: prov_inst
 
 - name: "Transform outputs to match the distiller format"
   set_fact:
     res_def_output: "{{ res_def_output | transform_os_server_output  }}"
-  when: not async and auth_var is not defined
+  when:
+    - auth_var == ""
+    - not async
 
 - name: "Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server + [res_def_output] }}"
-  when: not async and auth_var is not defined and res_def_output['skipped'] is not defined
+  when:
+    - auth_var == ""
+    - not async
+    - res_def_output['skipped'] is not defined
 
 - name: "Async:: provision/teardown os_server resources with provided auth"
   os_server:
@@ -199,7 +208,9 @@
     auto_ip: "{{ res_def['auto_ip'] | default(omit) }}"
   register: res_def_output
   loop: "{{ res_def_names }}"
-  when: async and auth_var is defined
+  when:
+    - async
+    - auth_var != ""
   loop_control:
     loop_var: prov_inst
   async: "{{ async_timeout | default(1000) }}"
@@ -208,9 +219,14 @@
 - name: "Transform outputs to match the distiller format"
   set_fact:
     res_def_output: "{{ res_def_output | transform_os_server_output  }}"
-  when: async and auth_var is defined
+  when:
+    - async
+    - auth_var != ""
 
 - name: "Async:: Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server + [ res_def_output ] }}"
-  when: async and auth_var is defined and res_def_output['skipped'] is not defined
+  when:
+    - async
+    - auth_var != ""
+    - res_def_output['skipped'] is not defined

--- a/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -29,14 +29,15 @@
     cred_type: "openstack"
     cred_path: "{{ creds_path | default(default_credentials_path) }}"
     driver: "file"
-  register: auth_var
+  register: auth_var_out
   ignore_errors: true
   no_log: "{{ not debug_mode }}"
 
 - name: "set auth_var"
   set_fact:
-    auth_var: "{{ auth_var['output']['clouds'][cred_profile]['auth'] }}"
+    auth_var: "{{ auth_var_out['output']['clouds'][cred_profile]['auth'] }}"
   ignore_errors: true
+  when: auth_var_out['output'] is defined
   no_log: "{{ not debug_mode }}"
 
 - name: "provisioning resource definitions of current group"


### PR DESCRIPTION
During the openstack playbooks, the plays were checking for an undefined
auth_var, but `auth_var = ""` by default.

Adjusted the tests to verify the `auth_var` was indeed empty, rather than undefined.

Fixes #682