### PR TITLE
Updated linchpin inventory generation to use relative/absolute paths

### DIFF
--- a/docs/source/examples/workspace/linchpin.conf
+++ b/docs/source/examples/workspace/linchpin.conf
@@ -169,7 +169,7 @@ generate_resources = False
 #default_layouts_path = {{ lp_path }}/defaults/%(layouts_folder)s
 
 # The default path for outputting ansible static inventories
-#default_inventories_path = {{ lp_path }}/defaults/%(inventories_folder)s
+#default_inventories_path = {{ workspace }}/inventories/
 
 # The default path to the ansible roles which control the providers
 #default_roles_path = {{ lp_path }}/%(playbooks_folder)s/%(roles_folder)s

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -144,8 +144,10 @@ class LinchpinCli(LinchpinAPI):
                             # if its not absolute path make path
                             # relative to workspace
                             if not os.path.isabs(i_path):
-                                i_path = "{0}/{1}".format(self.ctx.workspace,
-                                                          i_path)
+                                i_path = "{0}/{1}/{2}".format(
+                                        self.ctx.get_cfg('evars','workspace'),
+                                        self.ctx.get_cfg('evars','inventories_folder'),
+                                        i_path)
                         else:
                             i_path = targets[name]["outputs"]
                             i_path = i_path["inventory_path"][0]

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -11,6 +11,7 @@ import hashlib
 from random import randint
 from distutils import dir_util
 from collections import OrderedDict
+from jinja2 import Environment
 
 from linchpin import LinchpinAPI
 from linchpin.fetch import FETCH_CLASS
@@ -144,10 +145,13 @@ class LinchpinCli(LinchpinAPI):
                             # if its not absolute path make path
                             # relative to workspace
                             if not os.path.isabs(i_path):
-                                i_path = "{0}/{1}/{2}".format(
-                                        self.ctx.get_cfg('evars','workspace'),
-                                        self.ctx.get_cfg('evars','inventories_folder'),
-                                        i_path)
+                                # get default variable for inventories_path
+                                d_p = self.ctx.get_evar("default_inventories"
+                                                        "_path")
+                                d_p = Environment().from_string(d_p).render(
+                                    workspace=self.ctx.get_cfg('evars',
+                                                               'workspace'))
+                                i_path = "{0}/{1}".format(d_p, i_path)
                         else:
                             i_path = targets[name]["outputs"]
                             i_path = i_path["inventory_path"][0]

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -138,7 +138,18 @@ class LinchpinCli(LinchpinAPI):
                         lt_data = targets[name]["inputs"]["layout_data"]
                         t_data = targets[name]["inputs"]["topology_data"]
                         layout = lt_data["inventory_layout"]
-                        i_path = targets[name]["outputs"]["inventory_path"][0]
+                        # check whether inventory_file is mentioned in layout
+                        if layout.get("inventory_file", None):
+                            i_path = layout["inventory_file"]
+                            # if its not absolute path make path
+                            # relative to workspace
+                            if not os.path.isabs(i_path):
+                                i_path = "{0}/{1}".format(self.ctx.workspace,
+                                                          i_path)
+                        else:
+                            i_path = targets[name]["outputs"]
+                            i_path = i_path["inventory_path"][0]
+
                         if not os.path.exists(os.path.dirname(i_path)):
                             os.makedirs(os.path.dirname(i_path))
                         if inv_path and inv_file_count is not False:

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -51,7 +51,7 @@ playbooks_folder = provision
 default_schemas_path = {{ lp_path }}/defaults/%(schemas_folder)s
 default_topologies_path = {{ lp_path }}/defaults/%(topologies_folder)s
 default_layouts_path = {{ lp_path }}/defaults/%(layouts_folder)s
-default_inventories_path = {{ lp_path }}/defaults/%(inventories_folder)s
+default_inventories_path = {{ workspace }}/inventories/
 default_roles_path = {{ lp_path }}/%(playbooks_folder)s/%(roles_folder)s
 
 # default credentials data, this path doesn't automatically exist


### PR DESCRIPTION
Updated linchpin inventory generation to use relative/absolute paths if mentioned in layoutfile 
fixes #617 

Example workspace demonstrating the same:
https://github.com/samvarankashyap/linchpin_dummy_ws_demo_rel_path