### PR TITLE
Update openshift role to fetch creds from --creds-path

### DIFF
--- a/docs/source/examples/workspace/topologies/openshift-new.yml
+++ b/docs/source/examples/workspace/topologies/openshift-new.yml
@@ -33,8 +33,8 @@ resource_groups:
                   securityPolicy:
                     runAsUser: 1000090000
     credentials:
-      api_endpoint: example.com:8443/
-      api_token: mytokentextrighthere
+      filename: name_of_credsfile.yaml  # fetched from --creds-path is provided
+      profile: name_of_profile # defaults to 'default' profile in cred_file
       # alternative way when using --cred-path
       #filename: openshift.yaml
       #profile: test

--- a/docs/source/examples/workspace/topologies/openshift-new.yml
+++ b/docs/source/examples/workspace/topologies/openshift-new.yml
@@ -35,3 +35,6 @@ resource_groups:
     credentials:
       api_endpoint: example.com:8443/
       api_token: mytokentextrighthere
+      # alternative way when using --cred-path
+      #filename: openshift.yaml
+      #profile: test

--- a/docs/source/examples/workspaces/openshift/PinFile
+++ b/docs/source/examples/workspaces/openshift/PinFile
@@ -35,8 +35,5 @@ openshift-new:
                       securityPolicy:
                         runAsUser: 1000090000
     credentials:
-      api_endpoint: example.com:8443/
-      api_token: mytokentextrighthere
-      # alternative way when --creds-path is used 
-      #filename: openshift.yaml
-      #profile: test
+      filename: name_of_credsfile.yaml  # fetched from --creds-path is provided
+      profile: name_of_profile # defaults to 'default' profile in cred_file

--- a/docs/source/examples/workspaces/openshift/PinFile
+++ b/docs/source/examples/workspaces/openshift/PinFile
@@ -37,3 +37,6 @@ openshift-new:
     credentials:
       api_endpoint: example.com:8443/
       api_token: mytokentextrighthere
+      # alternative way when --creds-path is used 
+      #filename: openshift.yaml
+      #profile: test

--- a/docs/source/openshift.rst
+++ b/docs/source/openshift.rst
@@ -37,6 +37,18 @@ Credentials Management
 An openshift topology can have a ``credentials`` section for each
 :term:`resource_group`, which requires the `api_endpoint`, and the `api_token`
 values.
+Further, Openshift also honours --creds-path in linchpin. The credential file
+passed needs to be formatted as follows
+
+.. code-block:: yaml
+
+   ---
+   testprofile:
+       api_endpoint: example.com:8443/
+       api_token: mytokentextrighthere
+   default:
+       api_endpoint: testexample.com:8443/
+       api_token: someothertoken
 
 
 .. code-block:: yaml
@@ -56,4 +68,5 @@ values.
         credentials:
           api_endpoint: example.com:8443/
           api_token: mytokentextrighthere
-
+          # filename: name_of_credsfile.yaml  --> when --creds-path is provided
+          # profile: name_of_profile --> defaults to 'default' profile in cred_file

--- a/docs/source/openshift.rst
+++ b/docs/source/openshift.rst
@@ -18,7 +18,7 @@ The ansible module for openshift is written and bundled as part of LinchPin.
 .. note:: The `oc <https://docs.ansible.com/ansible/2.4/oc_module.html`_ module
    was included into ansible after the above openshift module was created and
    included with LinchPin. The future may see the oc module used.
-
+ 
 openshift_external
 ------------------
 
@@ -37,7 +37,7 @@ Credentials Management
 An openshift topology can have a ``credentials`` section for each
 :term:`resource_group`, which requires the `api_endpoint`, and the `api_token`
 values.
-Further, Openshift also honours --creds-path in linchpin. The credential file
+Further, Openshift also honors --creds-path in linchpin. The credential file
 passed needs to be formatted as follows
 
 .. code-block:: yaml
@@ -66,7 +66,5 @@ passed needs to be formatted as follows
           .. snip ..
 
         credentials:
-          api_endpoint: example.com:8443/
-          api_token: mytokentextrighthere
-          # filename: name_of_credsfile.yaml  --> when --creds-path is provided
-          # profile: name_of_profile --> defaults to 'default' profile in cred_file
+          filename: name_of_credsfile.yaml  # fetched from --creds-path is provided
+          profile: name_of_profile # defaults to 'default' profile in cred_file

--- a/linchpin/provision/roles/openshift/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/openshift/tasks/provision_res_defs.yml
@@ -1,22 +1,8 @@
 ---
-#- name: debug res_def
-#  debug:
-#    var: def_item
-#  with_items: "{{ res_def }}"
-#  loop_control:
-#    loop_var: def_item
-
-- name: debug res_def['data']
-  debug:
-    var: def_item
-  with_items: "{{ res_def['data'] }}"
-  loop_control:
-    loop_var: def_item
-
 - name: "call OpenShift with filename"
   openshift:
-    api_endpoint: "{{ openshift_api_endpoint }}"
-    api_token: "{{ openshift_api_token | default(omit) }}"
+    api_endpoint: "{{ auth_var['openshift_api_endpoint'] }}"
+    api_token: "{{ auth_var['openshift_api_token'] | default(omit) }}"
     insecure: "{{ def_item['insecure'] | default(omit) }}"
     file_reference: "{{ def_item['filename'] }}"
     state: "{{ state }}"
@@ -35,8 +21,8 @@
 
 - name: "call OpenShift with inline data"
   openshift:
-    api_endpoint: "{{ openshift_api_endpoint }}"
-    api_token: "{{ openshift_api_token | default(omit) }}"
+    api_endpoint: "{{ auth_var['openshift_api_endpoint'] }}"
+    api_token: "{{ auth_var['openshift_api_token'] | default(omit) }}"
     insecure: "{{ def_item['insecure'] | default(omit) }}"
     inline_data: "{{ def_item }}"
     state: "{{ state }}"

--- a/linchpin/provision/roles/openshift/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openshift/tasks/provision_resource_group.yml
@@ -1,9 +1,51 @@
 ---
-- name: "Set cred filename"
+- name: "Unset the authvar from previous run"
   set_fact:
-    openshift_api_endpoint: "{{ res_grp['credentials']['api_endpoint'] | default('') }}"
-    openshift_api_token: "{{ res_grp['credentials']['api_token'] | default('') }}"
-  when: res_grp['credentials'] is defined
+    auth_var: ""
+
+- name: "set default_cred_profile when res_grp[credentials] is undefined"
+  set_fact:
+    cred_profile: 'default'
+  when: res_grp['credentials'] is not defined
+
+- name: "set default_cred_filename when res_grp[credentials] is undefined"
+  set_fact:
+    cred_filename: 'openshift.yaml'
+  when: res_grp['credentials'] is not defined
+
+- name: "set default_cred_filename when res_grp[credentials] is undefined"
+  set_fact:
+    cred_profile: "{{ res_grp['credentials']['profile'] }}"
+  when: res_grp['credentials'] is defined and res_grp['credentials']['profile'] is defined
+
+- name: "set default_cred_filename when res_grp[credentials] is defined"
+  set_fact:
+    cred_filename: "{{ res_grp['credentials']['filename'] }}"
+  when: res_grp['credentials'] is defined and res_grp['credentials']['filename'] is defined
+
+- name: "Get creds from auth driver"
+  auth_driver:
+    filename: "{{ cred_filename }}"
+    cred_type: "openshift"
+    cred_path: "{{ creds_path | default(default_credentials_path) }}"
+    driver: "file"
+  register: auth_var_out
+  ignore_errors: true
+  no_log: "{{ not debug_mode }}"
+  when: res_grp['credentials'] is defined and res_grp['credentials']['filename'] is defined
+
+- name: "set auth_var"
+  set_fact:
+    auth_var: "{{ auth_var_out['output'][cred_profile] }}"
+  ignore_errors: true
+  when: auth_var_out['output'] is defined
+  no_log: "{{ not debug_mode }}"
+  when: res_grp['credentials'] is defined and res_grp['credentials']['filename'] is defined
+
+- name: "set auth_var when filename is not defined"
+  set_fact:
+    auth_var: "{{ res_grp['credentials'] }}"
+  when: res_grp['credentials'] is defined and res_grp['credentials']['filename'] is not defined
 
 - name: "Initiating Provision/Teardown of openshift resource group"
   include: provision_res_defs.yml res_def={{ res_item }}
@@ -11,4 +53,3 @@
     - "{{ res_grp['resource_definitions'] }}"
   loop_control:
     loop_var: res_item
-


### PR DESCRIPTION
Fixes: #675 

Updates the openshift role to read from both creds path and inline credentials 

openshift credential format is as follows:
```yaml
test:
  api_endpoint: profileexample.com:8443/
  api_token: thisisfromprofile
default:
  api_endpoint: profileexample.com:8443/
  api_token: thisisfromprofile
```

Update topology:
```yaml
---
topology_name: "dummy"
resource_groups:
  - resource_group_name: simple
    resource_group_type: openshift
    resource_definitions:
      - name: openshift
        role: openshift_inline
        data:
          - apiVersion: v1
            kind: ReplicationController
            metadata:
              name: jenkins-slave
              namespace: central-ci-test-ghelling
            spec:
              replicas: 1
              selector:
                name: jenkins-slave
              template:
                metadata:
                  labels:
                    name: jenkins-slave
                spec:
                  containers:
                    - image: redhatqecinch/jenkins_slave:latest
                      name: jenkins-slave
                      env:
                        - name: JENKINS_MASTER_URL
                          value: http://10.8.172.6/
                        - name: JSLAVE_NAME
                          value: mynode
                  restartPolicy: Always
                  securityPolicy:
                    runAsUser: 1000090000
    credentials:
      filename: openshift.yaml
      profile: test
      # inline creds follow the same format
      #api_endpoint: example.com:8443/
      #api_token: mytokentextrighthere
```