### PR TITLE
Remove linchpin validate from advanced topics

### DIFF
--- a/docs/source/advanced_topics.rst
+++ b/docs/source/advanced_topics.rst
@@ -13,4 +13,3 @@ features are covered here.
    advanced/rundb
    advanced/journal
    advanced/context_distiller
-   linchpin_validate


### PR DESCRIPTION
Fixes #676 

@14rcole, adding the above reference will automatically close the related ticket when this is merged. :smile: 