### PR TITLE
Make validation functions public

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -863,8 +863,7 @@ class LinchpinAPI(object):
                     self._convert_topology(topology_data)
                     self.validate_topology(topology_data)
                 except SchemaError as s:
-                    error = "[ERROR]"
-                    error += """Topology for target '{0}' does not validate
+                    error = """Topology for target '{0}' does not validate
 topology: '{1}'
 errors:
 """.format(target, topology_data)

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -398,7 +398,7 @@ class LinchpinAPI(object):
         return layout_json
 
 
-    def _validate_topology(self, topology):
+    def validate_topology(self, topology):
         """
         Validate the provided topology against the schema
 
@@ -473,7 +473,7 @@ class LinchpinAPI(object):
             return msg
 
 
-    def _validate_layout(self, layout):
+    def validate_layout(self, layout):
         """
         Validate the provided layout against the schema
 
@@ -690,12 +690,12 @@ class LinchpinAPI(object):
 
             # if validation fails the first time, convert topo from old -> new
             try:
-                resources = self._validate_topology(topology_data)
+                resources = self.validate_topology(topology_data)
             except (SchemaError, KeyError):
                 # if topology fails, try converting from old to new style
                 try:
                     self._convert_topology(topology_data)
-                    resources = self._validate_topology(topology_data)
+                    resources = self.validate_topology(topology_data)
                 except SchemaError:
                     raise ValidationError("Topology '{0}' does not validate."
                                           "For more information run `linchpin"
@@ -715,7 +715,7 @@ class LinchpinAPI(object):
             if provision_data[target].get('layout', None):
                 l_data = provision_data[target]['layout']
                 try:
-                    self._validate_layout(l_data)
+                    self.validate_layout(l_data)
                 except SchemaError:
                     raise ValidationError("Layout '{0}' does not"
                                           " validate".format(l_data))
@@ -856,12 +856,12 @@ class LinchpinAPI(object):
             topology_data = provision_data[target].get('topology')
 
             try:
-                self._validate_topology(topology_data)
+                self.validate_topology(topology_data)
             except (SchemaError, KeyError) as e:
                 # try to validate against old schema
                 try:
                     self._convert_topology(topology_data)
-                    self._validate_topology(topology_data)
+                    self.validate_topology(topology_data)
                 except SchemaError as s:
                     error = "[ERROR]"
                     error += """Topology for target '{0}' does not validate
@@ -895,7 +895,7 @@ errors:
                 l_data = provision_data[target]['layout']
 
                 try:
-                    self._validate_layout(l_data)
+                    self.validate_layout(l_data)
                 except SchemaError as e:
                     error = """
 Layout for target '{0}' does  not validate

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -582,13 +582,16 @@ def validate(ctx, targets, old_schema):
         return_code, results = lpcli.lp_validate(targets=targets,
                                                  old_schema=old_schema)
         for target, result in results.iteritems():
-            if result == "valid":
+            if result == "topology valid":
                 result = "[SUCCESS] Topology for target '{0}' is "\
                          "valid".format(target)
-            elif result == "valid with old schema":
+            elif result == "topology valid with old schema":
                 old_schema = True
                 result = "[SUCCESS] Topology for target '{0}' is valid under "\
                          "old schema".format(target)
+            elif result == "layout valid":
+                result = "[SUCCESS] Layout for target '{0} is "\
+                         "valid".format(target)
             else:
                 result = "[ERROR] " + result
             ctx.log_state(result)

--- a/linchpin/tests/test_init_pass.py
+++ b/linchpin/tests/test_init_pass.py
@@ -192,7 +192,7 @@ def test_validate_topology():
     success = False
     topo = provision_data.get(provider).get('topology')
     try:
-        resources = lpa._validate_topology(topo)
+        resources = lpa.validate_topology(topo)
         success = len(resources)
     except Exception:
         pass


### PR DESCRIPTION
Make _validate_topology and _validate_layout public so that they can be used via linchpin as an API.  Dependent of #662 