### PR TITLE
Fix validate output on success

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -863,7 +863,6 @@ class LinchpinAPI(object):
                     self._convert_topology(topology_data)
                     self._validate_topology(topology_data)
                 except SchemaError as s:
-                    error = "[ERROR]"
                     error += """Topology for target '{0}' does not validate
 topology: '{1}'
 errors:

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -582,13 +582,16 @@ def validate(ctx, targets, old_schema):
         return_code, results = lpcli.lp_validate(targets=targets,
                                                  old_schema=old_schema)
         for target, result in results.iteritems():
-            if result == "valid":
+            if result == "toplogy valid":
                 result = "[SUCCESS] Topology for target '{0}' is "\
                          "valid".format(target)
-            elif result == "valid with old schema":
+            elif result == "topology valid with old schema":
                 old_schema = True
                 result = "[SUCCESS] Topology for target '{0}' is valid under "\
                          "old schema".format(target)
+            elif result == "layout valid":
+                result = "[SUCCESS] Layout for target'{0}' is"\
+                         "valid".format(target)
             else:
                 result = "[ERROR] " + result
             ctx.log_state(result)


### PR DESCRIPTION
When linchpin validate successfully validates, it still puts [ERROR] at the beginning of the output.  Fix this