### PR TITLE
Fix spelling errors in linchpin up output

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -697,8 +697,8 @@ class LinchpinAPI(object):
                     self._convert_topology(topology_data)
                     resources = self._validate_topology(topology_data)
                 except SchemaError:
-                    raise ValidationError("Topology '{0}' does not validate."
-                                          "For more information run `linchpin"
+                    raise ValidationError("Topology '{0}' does not validate.  "
+                                          "For more information run `linchpin "
                                           "validate`".format(topology_data))
 
 


### PR DESCRIPTION
If topology does not validate, the `linchpin up` output telling the user to run `linchpin validate` had some spelling errors