### PR TITLE
[POC]: Introducing Dummy domain as a parameter to generate fake inventories

### DIFF
--- a/linchpin/provision/library/dummy.py
+++ b/linchpin/provision/library/dummy.py
@@ -82,7 +82,7 @@ class Dummy:
 #        return host_str
 
 
-    def allocate(self, name, count=1, domain=".example.net"):
+    def allocate(self, name, count=1, domain=""):
         """
         Create some dummy host as if these systems existed.
         Write the host out to the dummy.hosts temporary file to avoid
@@ -113,7 +113,7 @@ class Dummy:
         return (changed, hosts)
 
 
-    def deallocate(self, name, count=1, domain=".example.net"):
+    def deallocate(self, name, count=1, domain=""):
         """
         Deallocate some dummy host.
         Remove the host from the dummy.hosts temporary file.

--- a/linchpin/provision/library/dummy.py
+++ b/linchpin/provision/library/dummy.py
@@ -102,7 +102,7 @@ class Dummy:
             hosts.append(host)
         elif count > 1:
             for i in range(count):
-                #host = '{0}-{1}.example.net'.format(name, i)
+                # host = '{0}-{1}.example.net'.format(name, i)
                 host = '{0}-{1}{2}'.format(name, i, domain)
                 with open(self.DUMMY_FILE, 'a+') as f:
                     if not any('{0}\n'.format(host) in line for line in f):
@@ -149,8 +149,6 @@ class Dummy:
         name = module.params['name']
         state = module.params['state']
         count = module.params['count']
-        if count:
-            open("/tmp/count.txt","w").write(str(count))
         domain = module.params['domain']
 
         # allocate some systems if state is 'present' :)

--- a/linchpin/provision/library/dummy.py
+++ b/linchpin/provision/library/dummy.py
@@ -128,7 +128,7 @@ class Dummy:
 
         with open(self.DUMMY_FILE, 'r+') as f:
             lines = f.readlines()
-            hostre = '^{0}-\d{1}'.format(name, domain)
+            hostre = r'^{0}-\d{1}'.format(name, domain)
             for line in lines:
                 if re.search(hostre, line):
                     hosts_to_del.append(line)

--- a/linchpin/provision/roles/dummy/files/schema.json
+++ b/linchpin/provision/roles/dummy/files/schema.json
@@ -10,6 +10,7 @@
                    "allowed": ["dummy_node"]
                },
                "name": { "type": "string", "required": true },
+               "domain": { "type": "string", "required": true },
                "count": { "type": "integer", "required": false }
             }
         }

--- a/linchpin/provision/roles/dummy/files/schema.json
+++ b/linchpin/provision/roles/dummy/files/schema.json
@@ -10,7 +10,7 @@
                    "allowed": ["dummy_node"]
                },
                "name": { "type": "string", "required": true },
-               "domain": { "type": "string", "required": true },
+               "domain": { "type": "string", "required": false },
                "count": { "type": "integer", "required": false }
             }
         }

--- a/linchpin/provision/roles/dummy/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/dummy/tasks/provision_res_defs.yml
@@ -13,7 +13,7 @@
     state: present
     name: "{{ dummy_name }}"
     count: "{{ res_def['count'] | default(1) }}"
-    domain: "{{ res_def['domain'] | default('.example.net') }}"
+    domain: "{{ res_def['domain'] | default('') }}"
   register: outputitem
 
 - name: "set tmp var"

--- a/linchpin/provision/roles/dummy/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/dummy/tasks/provision_res_defs.yml
@@ -13,6 +13,7 @@
     state: present
     name: "{{ dummy_name }}"
     count: "{{ res_def['count'] | default(1) }}"
+    domain: "{{ res_def['domain'] | default('.example.net') }}"
   register: outputitem
 
 - name: "set tmp var"


### PR DESCRIPTION
POC w.r.to : #738 
Introduces domain parameter 
Further , eliminates the count appending to instance name when running for single instance
with uhash=False in linchpin.conf

Example workspace:
https://github.com/samvarankashyap/linchpin_dummy_domain