### PR TITLE
Make 'linchpin init' use 'linchpin fetch'

### DIFF
--- a/docs/source/examples/workspaces/linchpin.conf
+++ b/docs/source/examples/workspaces/linchpin.conf
@@ -212,6 +212,21 @@ generate_resources = False
 # formal name of the generated PinFile. Can be changed as desired.
 #pinfile = PinFile
 
+# default remote to pull workspaces from
+#remote = git://github.com/CentOS-PaaS-SIG/linchpin
+
+# git ref to use
+#fetch_ref = master
+
+# location in the above remote to copy to workspace
+#root = workspaces/dummy
+
+# what part of the workspace to pull (likely only workspace)
+#fetch_type = workspace
+
+# whether to cache the remote (default: always pull updates)
+#nocache = True
+
 # This section covers settings for the `linchpin fetch` command
 #[fetch]
 

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -44,8 +44,10 @@ class FetchGit(Fetch):
     def call_clone(self, fetch_dir=None):
 
         ref = None
+        src = self.src
         if self.ref:
             ref = self.ref
+            src = '{0}@{1}'.format(self.src, ref)
 
         if fetch_dir and os.path.exists(fetch_dir):
             cmd = ['git', '-C', fetch_dir, 'pull', '--quiet']
@@ -58,11 +60,12 @@ class FetchGit(Fetch):
             cmd = ['git', 'clone', '--quiet', self.src]
             if ref:
                 cmd.extend(['-b', ref])
+
             cmd.append(fetch_dir)
 
             retval = subprocess.call(cmd, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
 
         if retval != 0:
-            raise LinchpinError("Unable to clone {0}".format(self.src))
+            raise LinchpinError("Unable to clone {0}".format(src))
         return fetch_dir

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -71,6 +71,12 @@ generate_resources = True
 source = templates/
 pinfile = PinFile
 
+remote = git://github.com/CentOS-PaaS-SIG/linchpin
+fetch_ref = master
+root = workspaces/dummy
+fetch_type = workspace
+nocache = True
+
 [distiller]
 bkr_server = id,url,system,name
 dummy_node: hosts

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -183,20 +183,41 @@ def help(ctx):
 
 
 @runcli.command('init', short_help='Initializes a linchpin project.')
+@click.argument('provider', metavar='PROVIDER', required=False, nargs=1)
 @pass_context
-def init(ctx):
+def init(ctx, provider):
     """
     Initializes a linchpin project, which generates an example PinFile, and
     creates the necessary directory structure for topologies and layouts.
 
+    Utilizes lp_fetch with the following parameters:
+
+    remote:         git://github.com/CentOS-PaaS-SIG/linchpin
+    root:           workspaces
+    fetch_type:     workspace
+    fetch_protocol: FetchGit
+    fetch_ref:      master
+    dest_ws:        Unused, will use workspace/provider
+    nocache:        True
+
+
     """
 
-    # add a providers option someday
-    providers = None
+    remote = ctx.get_cfg('init', 'remote',
+                         default='git://github.com/CentOS-PaaS-SIG/linchpin')
+    root = ctx.get_cfg('init', 'root', default='workspaces/dummy')
+    fetch_type = ctx.get_cfg('init', 'fetch_type', default='workspace')
+    fetch_proto = 'FetchGit'
+    fetch_ref = ctx.get_cfg('init', 'fetch_ref', default='master')
+    nocache = ast.literal_eval(ctx.get_cfg('init', 'nocache', default='True'))
+
+    if provider:
+        root = 'workspaces/{0}'.format(provider)
 
     try:
-        # lpcli.lp_init(pf_w_path, targets) # TODO implement targets option
-        lpcli.lp_init(providers=providers)
+        lpcli.lp_fetch(remote, root=root, fetch_type=fetch_type,
+                       fetch_protocol=fetch_proto, fetch_ref=fetch_ref,
+                       dest_ws=None, nocache=nocache)
     except LinchpinError as e:
         ctx.log_state(e)
         sys.exit(1)


### PR DESCRIPTION
For the purposes of documenting the new tutorial, I wanted to use linchpin init with some specific arguments. In this case, it was easier to modify `linchpin init` to allow it to use `lp_fetch()` to clone the git repository and use the workspaces that already exist there.

The `linchpin init` command will create a subdirectory, clone this repository (master branch by default) and copy the appropriate workspace to the subdirectory.

This PR allows a user to do the following:

```
[/tmp]$ linchpin init
Created destination workspace: /tmp/dummy

[/tmp]$ ls dummy
PinFile  PinFile.json  README.rst

[/tmp]$ cat dummy/PinFile
$ cat dummy/PinFile
---
dummy-new:
  topology:
    topology_name: "dummy_cluster" # topology name
    resource_groups:
      - resource_group_name: "dummy"
        resource_group_type: "dummy"
        resource_definitions:
          - name: "{{ distro | default('') }}web"
            role: "dummy_node"
            count: 3
          - name: "{{ distro | default('') }}test"
            role: "dummy_node"
            count: 1
  layout:
   .. snip ..
```

If someone wants to use a different workspace from this repository, that is also possible:

```
$ linchpin init libvirt
Created destination workspace: /tmp/libvirt

$ cd /tmp/libvirt
$ ls
PinFile  README.rst
$ cat PinFile
---
libvirt-new:
  topology:
    topology_name: libvirt-new
    resource_groups:
      - resource_group_name: libvirt-new
        resource_group_type: libvirt
        resource_definitions:
          - role: libvirt_node
            name: centos71
            uri: qemu:///system
            count: 1
            image_src: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1608.qcow2.xz
            memory: 2048
            vcpus: 1
            arch: x86_64
            ssh_key: libvirt
            networks:
              - name: default
            additional_storage: 10G
            cloud_config:
              users:
                - name: herlo
                  gecos: Clint Savage
                  groups: wheel
                  sudo: ALL=(ALL) NOPASSWD:ALL
                  ssh_import_id: gh:herlo
                  lock_passwd: true
  layout:
    inventory_layout:
      vars:
        hostname: __IP__
      hosts:
        example-node:
          count: 1
          host_groups:
            - example

.. snip ..
```
