### PR TITLE
Fix error with aws teardown

### DIFF
--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -33,7 +33,7 @@
 
 - name: "set topo_output_resources fact"
   set_fact:
-    topo_output_resources: "{{ topo_output.output['content']['aws_ec2_res'][0] }}"
+    topo_output_resources: "{{ topo_output.output['content'] }}"
   when: generate_resources
 
 # patch for role to type translation


### PR DESCRIPTION
A variable in teardown_resource_group was being set to some_dict['content']['aws_ec2_res'][0], then later on, ansible would attempt to read variable['aws_ec2_res'].  I changed the variable to be equal to some_dict['content'], but if it's better practice to change the way the variable is being read later on, I can do that instead