### PR TITLE
Fix workspaces/duffy PinFile

### DIFF
--- a/docs/source/examples/workspaces/duffy/PinFile
+++ b/docs/source/examples/workspaces/duffy/PinFile
@@ -11,7 +11,7 @@ duffy-new:
             version: 7
             arch: x86_64
             count: 1
-    credentials: duffy.key
+        credentials: duffy.key
   layout:
     inventory_layout:
       vars:


### PR DESCRIPTION
The indentation of the workspaces/duffy PinFile was incorrect, and the credentials file could not be found as a result