### PR TITLE
Make linchpin validate stop printing [ERROR] on success

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -863,10 +863,7 @@ class LinchpinAPI(object):
                     self._convert_topology(topology_data)
                     self.validate_topology(topology_data)
                 except SchemaError as s:
-                    error = """Topology for target '{0}' does not validate
-topology: '{1}'
-errors:
-""".format(target, topology_data)
+                    error = "errors:\n".format(target, topology_data)
                     if old_schema:
                         # there's an inline way of doing this with join() but
                         # this looks cleaner
@@ -880,14 +877,15 @@ errors:
                             for line in iter(str(e).splitlines(True)):
                                 error += "\t" + line
 
-                    results[target] = error
+                    results[target]['topology'] = error
                     return_code += 1
                 else:
-                    results[target] = "topology valid with old schema"
+                    results[target]['topology'] = "topology valid under old "\
+                                                  "schema"
 
 
             else:
-                results[target] = "topology valid"
+                results[target]['topology'] = "valid"
 
             # validate layout
             if provision_data[target].get('layout', None):
@@ -896,18 +894,14 @@ errors:
                 try:
                     self.validate_layout(l_data)
                 except SchemaError as e:
-                    error = """
-Layout for target '{0}' does  not validate
-layout: '{1}'
-errors:
-""".format(target, l_data)
+                    error = "errors:".format(target, l_data)
                     for line in iter(str(e).splitlines(True)):
                         error += "\t" + line
 
-                    results[target] += "\n" + error + "\n"
+                    results[target]['layout'] = error + "\n"
 
                 else:
-                    results[target] += "\nlayout valid"
+                    results[target]['layout'] = "valid"
 
 
         return return_code, results

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -581,19 +581,15 @@ def validate(ctx, targets, old_schema):
         old_schema = False
         return_code, results = lpcli.lp_validate(targets=targets,
                                                  old_schema=old_schema)
-        for target, result in results.iteritems():
-            if result == "topology valid":
-                result = "[SUCCESS] Topology for target '{0}' is "\
-                         "valid".format(target)
-            elif result == "topology valid with old schema":
-                old_schema = True
-                result = "[SUCCESS] Topology for target '{0}' is valid under "\
-                         "old schema".format(target)
-            elif result == "layout valid":
-                result = "[SUCCESS] Layout for target '{0} is "\
-                         "valid".format(target)
-            else:
-                result = "[ERROR] " + result
+        for target, item in results.iteritems():
+            result = ""
+            for kind, outcome in item.iteritems():
+                if outcome == "valid" or outcome == "valid under old schema":
+                    result = "[SUCCESS] {0} for target '{1}' is "\
+                             "{2}".format(kind, target, outcome)
+                else:
+                    result = "[ERROR] {0} for target '{1}' does not "\
+                             "validate\n{3}".format(kind, target, outcome)
             ctx.log_state(result)
 
         if old_schema:


### PR DESCRIPTION
If a layout and topology exist for a given schema, linchpin would prepend the message with [ERROR] instead of [SUCCESS].  This PR fixes that
