### PR TITLE
Linchpin setup and Adding error handling messages beaker and libvirt

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -236,3 +236,18 @@ As an alternative, LinchPin can be installed via github. This may be done in ord
     ..snip..
     (linchpin) $ pip install file://$PWD/linchpin
 
+linchpin setup : Automatic Dependency installation:
+---------------------------------------------------
+From version 1.6.5 linchpin includes linchpin setup commandline option to automate installations of linchpin dependencies. 
+linchpin setup uses built in ansible-playbooks to carryout the installations. 
+
+Usage: 
+.. code-block:: bash
+    $ linchpin setup    # by default linchpin installs all the dependencies
+
+.. code-block:: bash
+    $ linchpin setup [dependency1] [dependency2] ..    # 
+    $ linchpin setup beaker docs
+
+.. code-block:: bash
+   $ linchpin setup libvirt --ask-sudo-pass    # Also supports ask-sudo-pass parameter when installing dnf related dependencies

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -1019,7 +1019,7 @@ class LinchpinAPI(object):
         module_paths = []
         module_folder = self.get_cfg('lp',
                                      'module_folder',
-                                         default='library')
+                                     default='library')
         for path in reversed(self.pb_path):
             module_paths.append('{0}/{1}/'.format(path, module_folder))
         return module_paths
@@ -1036,7 +1036,8 @@ class LinchpinAPI(object):
                                           console=console)
         return return_code, res
 
-    def _invoke_playbooks(self, resources={}, action='up', console=True,  providers=[]):
+    def _invoke_playbooks(self, resources={}, action='up', console=True,
+                          providers=[]):
         """
         Uses the Ansible API code to invoke the specified linchpin playbook
 
@@ -1065,12 +1066,14 @@ class LinchpinAPI(object):
         if action == 'destroy':
             self.set_evar('state', 'absent')
 
+        inventory_src = '{0}/localhost'.format(self.workspace)
+
         for resource in resources:
             self.set_evar('resources', resource)
             playbook = resource.get('resource_group_type')
-            return_code, res = _find_n_run_pb(playbook,
-                                              inventory_src,
-                                              console=console)
+            return_code, res = self._find_n_run_pb(playbook,
+                                                   inventory_src,
+                                                   console=console)
             if res:
                 results.append(res)
 

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -1015,9 +1015,28 @@ class LinchpinAPI(object):
             latest_run_data[k]["targets"] = [target_group]
         return latest_run_data
 
+    def _get_module_path(self):
+        module_paths = []
+        module_folder = self.get_cfg('lp',
+                                     'module_folder',
+                                         default='library')
+        for path in reversed(self.pb_path):
+            module_paths.append('{0}/{1}/'.format(path, module_folder))
+        return module_paths
 
+    def _find_n_run_pb(self, pb_name, inv_src, console=True):
+        pb_path = self._find_playbook_path(pb_name)
+        playbook_path = '{0}/{1}{2}'.format(pb_path, pb_name, self.pb_ext)
+        extra_vars = self.get_evar()
+        return_code, res = ansible_runner(playbook_path,
+                                          self._get_module_path(),
+                                          extra_vars,
+                                          inventory_src=inv_src,
+                                          verbosity=self.ctx.verbosity,
+                                          console=console)
+        return return_code, res
 
-    def _invoke_playbooks(self, resources, action='up', console=True):
+    def _invoke_playbooks(self, resources={}, action='up', console=True,  providers=[]):
         """
         Uses the Ansible API code to invoke the specified linchpin playbook
 
@@ -1032,37 +1051,28 @@ class LinchpinAPI(object):
         self.set_evar('_action', action)
         self.set_evar('state', 'present')
 
+        if action == 'setup' or action == 'ask_sudo_setup':
+            self.set_evar('setup_providers', providers)
+            return_code, res = self._find_n_run_pb(action,
+                                                   "localhost",
+                                                   console=console)
+            if res:
+                results.append(res)
+            if not len(results):
+                results = None
+            return (return_code, results)
+
         if action == 'destroy':
             self.set_evar('state', 'absent')
 
         for resource in resources:
             self.set_evar('resources', resource)
             playbook = resource.get('resource_group_type')
-            pb_path = self._find_playbook_path(playbook)
-            playbook_path = '{0}/{1}{2}'.format(pb_path, playbook, self.pb_ext)
-
-            module_paths = []
-            module_folder = self.get_cfg('lp',
-                                         'module_folder',
-                                         default='library')
-
-            for path in reversed(self.pb_path):
-                module_paths.append('{0}/{1}/'.format(path, module_folder))
-
-            extra_vars = self.get_evar()
-            inventory_src = '{0}/localhost'.format(self.workspace)
-
-            verbosity = self.ctx.verbosity
-            return_code, res = ansible_runner(playbook_path,
-                                              module_paths,
-                                              extra_vars,
-                                              inventory_src=inventory_src,
-                                              verbosity=verbosity,
+            return_code, res = _find_n_run_pb(playbook,
+                                              inventory_src,
                                               console=console)
-
             if res:
                 results.append(res)
-
 
         if not len(results):
             results = None

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -18,7 +18,6 @@ from linchpin.exceptions import ActionError
 from linchpin.exceptions import LinchpinError
 from linchpin.exceptions import TopologyError
 from linchpin.utils.dataparser import DataParser
-from linchpin.ansible_runner import ansible_runner
 
 
 

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -18,6 +18,8 @@ from linchpin.exceptions import ActionError
 from linchpin.exceptions import LinchpinError
 from linchpin.exceptions import TopologyError
 from linchpin.utils.dataparser import DataParser
+from linchpin.ansible_runner import ansible_runner
+
 
 
 class LinchpinCli(LinchpinAPI):
@@ -472,6 +474,24 @@ class LinchpinCli(LinchpinAPI):
             prov_data = provision_data
 
         return self.do_validation(prov_data, old_schema=old_schema)
+
+
+    def lp_setup(self, providers=("all")):
+        """
+        This function takes a list of providers, and setsup the dependencies
+        :param providers:
+            A tuple of providers to install dependencies
+        """
+        if self.ctx.get_evar("ask_sudo_pass"):
+            output = self._invoke_playbooks(providers=providers,
+                                            action="ask_sudo_setup")
+        else:
+            output = self._invoke_playbooks(providers=providers,
+                                            action="setup")
+
+        return output
+
+
 
 
     def lp_destroy(self, targets=(), run_id=None, tx_id=None):

--- a/linchpin/provision/ask_sudo_setup.yml
+++ b/linchpin/provision/ask_sudo_setup.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  vars_prompt:
+  - name: "ansible_become_pass"
+    prompt: "Sudo password"
+    private: yes
+  vars:
+    VENV_LIB_PATH: "lib/python2.7/site-packages"
+    PYTHON_LIB_PATH: "/usr/lib/python2.7/site-packages"
+    PYTHON_LIB64_PATH: "/usr/lib64/python2.7/site-packages"
+  roles:
+  - role: dependencies

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -1,20 +1,25 @@
 ---
-- name: "provision beaker systems"
-  bkr_server:
-    recipesets: "{{ res.recipesets }}"
-    state: present
-    # these values have defaults set in the bkr_server module
-    # if omitted, or they are not required
-    whiteboard: "{{ res.whiteboard | default('Provisioned by LinchPin') }}"
-    job_group: "{{ res.job_group | default(omit) }}"
-    cancel_message: "{{ res.cancel_message | default(omit) }}"
-    max_attempts: "{{ res.max_attempts | default(omit) }}"
-    attempt_wait_time: "{{ attempt_wait_time | default(omit) }}"
-  with_items: "{{ res_defs['resource_definitions'] }}"
-  # loop over res_defs even though there should be only one for beaker
-  loop_control:
-    loop_var: res
-  register: bkr
+- name: Provision beaker systems
+  block:
+  - name: "provision beaker systems"
+    bkr_server:
+      recipesets: "{{ res.recipesets }}"
+      state: present
+      # these values have defaults set in the bkr_server module
+      # if omitted, or they are not required
+      whiteboard: "{{ res.whiteboard | default('Provisioned by LinchPin') }}"
+      job_group: "{{ res.job_group | default(omit) }}"
+      cancel_message: "{{ res.cancel_message | default(omit) }}"
+      max_attempts: "{{ res.max_attempts | default(omit) }}"
+      attempt_wait_time: "{{ attempt_wait_time | default(omit) }}"
+    with_items: "{{ res_defs['resource_definitions'] }}"
+    # loop over res_defs even though there should be only one for beaker
+    loop_control:
+      loop_var: res
+    register: bkr
+    rescue:
+    - fail:
+        msg: 'Error caught in beaker module execution. Might be beacuse of unresolved beaker dependencies. Please run `linchpin setup beaker` or pip install linchpin[beaker] to install beaker dependencies'
 
 - name: "set bkr_rsets"
   set_fact:

--- a/linchpin/provision/roles/dependencies/tasks/beaker_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/beaker_deps.yml
@@ -1,0 +1,9 @@
+- name: Install pypi dependencies of beaker
+  pip:
+    name: "{{ bkr_pkg }}"
+  with_items:
+    - 'beaker-client>=23.3'
+    - 'python-krbV'
+    - 'bottle'
+  loop_control:
+    loop_var: bkr_pkg

--- a/linchpin/provision/roles/dependencies/tasks/docs_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/docs_deps.yml
@@ -1,0 +1,9 @@
+- name: Install pypi dependencies of docs
+  pip:
+    name: "{{ doc_pkg }}"
+  with_items:
+    - "docutils"
+    - "sphinx"
+    - "sphinx_rtd_theme"
+  loop_control:
+    loop_var: doc_pkg

--- a/linchpin/provision/roles/dependencies/tasks/libvirt_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/libvirt_deps.yml
@@ -1,0 +1,25 @@
+- name: Install dependencies
+  block:
+    - name: Install package dependencies
+      package:
+        name: "{{ libvirt_pkg }}"
+        state: latest
+      with_items:
+      - python2-dnf 
+      - libvirt-devel
+      - libguestfs-tools 
+      - python-libguestfs
+      become: true
+      loop_control: 
+        loop_var: libvirt_pkg
+    - name: Install pypi dependencies of libvirt
+      pip:
+        name: "{{ libvirt_pypi }}"
+      with_items:
+      - "libvirt-python>=3.0.0"
+      - "lxml"
+      loop_control: 
+        loop_var: libvirt_pypi
+  rescue:
+    - fail:
+        msg: 'Error installing the package dependencies! Please try adding password less priviledged sudo user or with --ask-sudo-pass'

--- a/linchpin/provision/roles/dependencies/tasks/libvirt_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/libvirt_deps.yml
@@ -2,16 +2,12 @@
   block:
     - name: Install package dependencies
       package:
-        name: "{{ libvirt_pkg }}"
-        state: latest
-      with_items:
-      - python2-dnf 
-      - libvirt-devel
-      - libguestfs-tools 
-      - python-libguestfs
+        name:
+          - python2-dnf 
+          - libvirt-devel
+          - libguestfs-tools 
+          - python-libguestfs
       become: true
-      loop_control: 
-        loop_var: libvirt_pkg
     - name: Install pypi dependencies of libvirt
       pip:
         name: "{{ libvirt_pypi }}"

--- a/linchpin/provision/roles/dependencies/tasks/main.yml
+++ b/linchpin/provision/roles/dependencies/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Debug for ask_sudo_pass
+  debug:
+    msg: "{{ setup_providers }}"
+
+
+- name: Install dependecies per provider
+  include_tasks: "{{ indv_prov }}_deps.yml"
+  with_items: "{{ setup_providers }}"
+  loop_control:
+    loop_var: indv_prov
+
+- name: Install all dependencies
+  include_tasks: "{{ setup_prov }}_deps.yml"
+  with_items:
+    - setup_dnf
+    - beaker
+    - libvirt
+    - docs
+    - test
+    - setup_selinux
+  when: setup_providers | length == 0
+  loop_control:
+    loop_var: setup_prov

--- a/linchpin/provision/roles/dependencies/tasks/setup_dnf_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/setup_dnf_deps.yml
@@ -1,0 +1,37 @@
+
+- name: Create links for selinux libraries
+  file:
+    src: "{{ PYTHON_LIB_PATH }}/dnf"
+    dest: "{{ lookup('env','VIRTUAL_ENV') }}/{{ VENV_LIB_PATH }}/dnf"
+    state: link
+
+# cp -r /usr/lib64/python2.7/site-packages/librepo ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/
+# cp -r /usr/lib64/python2.7/site-packages/libcomp ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/
+# cp -r /usr/lib64/python2.7/site-packages/gi ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/
+# cp -r /usr/lib64/python2.7/site-packages/hawkey ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/
+# cp -r /usr/lib64/python2.7/site-packages/smartcols* ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/
+# cp -r /usr/lib64/python2.7/site-packages/gpg ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/gpg
+# cp -r /usr/lib64/python2.7/site-packages/lzma.so ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/
+# pip install iniparse
+# cp -r /usr/lib64/python2.7/site-packages/rpm ~/.virtualenvs/lpdep14/lib/python2.7/site-packages/#
+
+- name: Create links for librepo
+  file:
+    src: "{{ PYTHON_LIB64_PATH }}/{{ dnf_pkg }}"
+    dest: "{{ lookup('env','VIRTUAL_ENV') }}/{{ VENV_LIB_PATH }}/{{ dnf_pkg }}"
+    state: link
+  with_items:
+    - "librepo"
+    - "libcomps"
+    - "gi"
+    - "hawkey"
+    - "smartcols.so"
+    - "gpg"
+    - "lzma.so"
+    - "rpm"
+  loop_control:
+    loop_var: dnf_pkg
+
+- name: Install iniparse
+  pip:
+    name: "iniparse"

--- a/linchpin/provision/roles/dependencies/tasks/setup_selinux_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/setup_selinux_deps.yml
@@ -1,0 +1,20 @@
+- name: Install dependencies
+  block:
+    - name: Install selinux dependencies
+      package:
+        name: "libselinux-python"
+      become: true
+    - name: Create links for selinux libraries
+      file:
+        src: "{{ PYTHON_LIB64_PATH }}/selinux"
+        dest: "{{ lookup('env','VIRTUAL_ENV') }}/{{ VENV_LIB_PATH }}/selinux"
+        state: link
+    - name: Create links for selinux libraries
+      file:
+        src: "{{ PYTHON_LIB64_PATH }}/_selinux.so"
+        dest: "{{ lookup('env','VIRTUAL_ENV') }}/{{ VENV_LIB_PATH }}/_selinux.so"
+        state: link
+  rescue:
+    - fail:
+        msg: 'Error installing the package dependencies! Please try adding password less priviledged sudo user or with --ask-sudo-pass'
+

--- a/linchpin/provision/roles/dependencies/tasks/test_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/test_deps.yml
@@ -1,0 +1,10 @@
+- name: Install pypi dependencies of linchpin tests
+  pip:
+    name: "{{ test_pkg }}"
+  with_items:
+    - "nose"
+    - "mock"
+    - "coverage" 
+    - "flake8"
+  loop_control:
+    loop_var: test_pkg

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -101,33 +101,38 @@
   delegate_to: "{{ uri_hostname }}"
   when: uri_hostname != 'localhost'
 
-- name: "Add additional storage"
-  command: "qemu-img resize {{ definition[1] }}/{{ definition[0] }}_{{ definition[4] }}.{{ definition[2] }} +{{ definition[3] }}"
-  with_nested:
+- name: Add additional storage
+  block:
+  - name: "Add additional storage"
+    command: "qemu-img resize {{ definition[1] }}/{{ definition[0] }}_{{ definition[4] }}.{{ definition[2] }} +{{ definition[3] }}"
+    with_nested:
     - ["{{ libvirt_resource_name }}"]
     - ["{{ libvirt_image_path | expanduser }}"]
     - ["{{ img_src_ext }}"]
     - ["{{ res_def['additional_storage'] | default('1G') }}"]
     - "{{ res_count.stdout }}"
-  loop_control:
-    loop_var: definition
-  become: "{{ libvirt_become }}"
-  when: res_def['additional_storage'] is defined and node_exists['failed'] is defined and uri_hostname == 'localhost'
+    loop_control:
+      loop_var: definition
+    become: "{{ libvirt_become }}"
+    when: res_def['additional_storage'] is defined and node_exists['failed'] is defined and uri_hostname == 'localhost'
 
-- name: "Add additional storage"
-  command: "qemu-img resize {{ definition[1] }}/{{ definition[0] }}_{{ definition[4] }}.{{ definition[2] }} +{{ definition[3] }}"
-  with_nested:
-    - ["{{ libvirt_resource_name }}"]
-    - ["{{ libvirt_image_path | expanduser }}"]
-    - ["{{ img_src_ext }}"]
-    - ["{{ res_def['additional_storage'] | default('1G') }}"]
-    - "{{ res_count.stdout }}"
-  loop_control:
-    loop_var: definition
-  become: "{{ libvirt_become }}"
-  remote_user: "{{ res_def['remote_user'] | default(ansible_user_id) }}"
-  delegate_to: "{{ uri_hostname }}"
-  when: res_def['additional_storage'] is defined and node_exists['failed'] is defined and uri_hostname != 'localhost'
+  - name: "Add additional storage"
+    command: "qemu-img resize {{ definition[1] }}/{{ definition[0] }}_{{ definition[4] }}.{{ definition[2] }} +{{ definition[3] }}"
+    with_nested:
+      - ["{{ libvirt_resource_name }}"]
+      - ["{{ libvirt_image_path | expanduser }}"]
+      - ["{{ img_src_ext }}"]
+      - ["{{ res_def['additional_storage'] | default('1G') }}"]
+      - "{{ res_count.stdout }}"
+    loop_control:
+      loop_var: definition
+    become: "{{ libvirt_become }}"
+    remote_user: "{{ res_def['remote_user'] | default(ansible_user_id) }}"
+    delegate_to: "{{ uri_hostname }}"
+    when: res_def['additional_storage'] is defined and node_exists['failed'] is defined and uri_hostname != 'localhost'
+  rescue:
+  - fail:
+      msg: 'Error running command qemu-img. Please make sure the dependencies are installed correctly . Try running `linchpin setup libvirt` to reinstall dependencies'
 
 - include_tasks: virt_customize.yml
   when: virt_type == "virt-customize"
@@ -226,9 +231,13 @@
   delegate_to: "{{ uri_hostname }}"
   when: node_exists['failed'] is defined and uri_hostname != 'localhost' and virt_type == "cloud-init"
 
-- name: "Install VM"
-  command: "virt-install --connect {{ definition[6] }} --import --name {{ definition[0] }}_{{ definition[7] }} --autostart --network bridge={{ definition[3] }},model=virtio --ram {{ definition[4] }} --disk path={{ definition[1] }}/{{ definition[0] }}_{{ definition[7] }}.{{ definition[2] }},format={{ definition[5] }},bus=virtio,cache=none --disk path=/tmp/vm-{{ definition[0] }}_{{ definition[7] }}.iso,device=cdrom --wait 10 --os-type=linux --nographics"
-  with_nested:
+- name: running virt-install to boot prepared image
+  block:
+  - debug:
+      msg: 'I execute normally'
+  - name: "Install VM"
+    command: "virt-install --connect {{ definition[6] }} --import --name {{ definition[0] }}_{{ definition[7] }} --autostart --network bridge={{ definition[3] }},model=virtio --ram {{ definition[4] }} --disk path={{ definition[1] }}/{{ definition[0] }}_{{ definition[7] }}.{{ definition[2] }},format={{ definition[5] }},bus=virtio,cache=none --disk path=/tmp/vm-{{ definition[0] }}_{{ definition[7] }}.iso,device=cdrom --wait 10 --os-type=linux --nographics"
+    with_nested:
     - ["{{ libvirt_resource_name }}"]
     - ["{{ libvirt_image_path | expanduser }}"]
     - ["{{ img_src_ext }}"]
@@ -237,11 +246,30 @@
     - ["{{ res_def['format'] | default('qcow2')  }}"]
     - ["{{ res_def['uri'] }}"]
     - "{{ res_count.stdout }}"
-  loop_control:
-    loop_var: definition
-  ignore_errors: yes
-  become: "{{ libvirt_become }}"
-  when: node_exists['failed'] is defined and res_def['cloud_config'] is defined
+    loop_control:
+      loop_var: definition
+    ignore_errors: yes
+    become: "{{ libvirt_become }}"
+    when: node_exists['failed'] is defined and res_def['cloud_config'] is defined
+  - name: "Install VM"
+    command: "virt-install --connect {{ definition[6] }} --import --name {{ definition[0] }}_{{ definition[7] }} --autostart --network bridge={{ definition[3] }},model=virtio --ram {{ definition[4] }} --disk path={{ definition[1] }}/{{ definition[0] }}_{{ definition[7] }}.{{ definition[2] }},format={{ definition[5] }},bus=virtio,cache=none --disk path=/tmp/vm-{{ definition[0] }}_{{ definition[7] }}.iso,device=cdrom --wait 10 --os-type=linux --nographics"
+    with_nested:
+    - ["{{ libvirt_resource_name }}"]
+    - ["{{ libvirt_image_path | expanduser }}"]
+    - ["{{ img_src_ext }}"]
+    - ["{{ res_def['network_bridge'] | default('virbr0')  }}"]
+    - ["{{ res_def['memory'] | default(1024)  }}"]
+    - ["{{ res_def['format'] | default('qcow2')  }}"]
+    - ["{{ res_def['uri'] }}"]
+    - "{{ res_count.stdout }}"
+    loop_control:
+      loop_var: definition
+    ignore_errors: yes
+    become: "{{ libvirt_become }}"
+    when: node_exists['failed'] is defined and res_def['cloud_config'] is defined
+  rescue:
+  - fail:
+      msg: 'Error running command virt-install. Please make sure the dependencies are installed correctly. Try running `linchpin setup libvirt` to reinstall dependencies'
 
 
 - name: "Remove cloud-init cdrom "
@@ -272,17 +300,22 @@
   when: node_exists['failed'] is defined
   ignore_errors: yes
 
-- name: "Create disk if it does not exist"
-  command: "qemu-img create -f qcow2 {{ libvirt_image_path }}/{{ libvirt_resource_name }}-{{ definition[1]['name'] }}.img {{ definition[1]['size'] }}{{ definition[1]['units'] }}"
-  with_nested:
+- name: Attempt and graceful roll back demo
+  block:
+  - name: "Create disk if it does not exist"
+    command: "qemu-img create -f qcow2 {{ libvirt_image_path }}/{{ libvirt_resource_name }}-{{ definition[1]['name'] }}.img {{ definition[1]['size'] }}{{ definition[1]['units'] }}"
+    with_nested:
     - ["{{ res_def['name'] }}"]
     - ["{{ res_def['storage'] }}"]
-  loop_control:
-    loop_var: definition
-  when:
+    loop_control:
+      loop_var: definition
+    when:
     - res_def['storage'] is defined
     - definition[1].source is not defined
-  become: "{{ libvirt_become }}"
+    become: "{{ libvirt_become }}"
+  rescue:
+  - fail:
+      msg: 'Error running command qemu-img. Please make sure the dependencies are installed correctly. Try running `linchpin setup libvirt` to reinstall dependencies'
 
 - name: "Start VM"
   virt:

--- a/linchpin/provision/roles/libvirt/tasks/virt_customize.yml
+++ b/linchpin/provision/roles/libvirt/tasks/virt_customize.yml
@@ -63,14 +63,19 @@
   set_fact:
     virt_args: "{{ virt_args }} --selinux-relabel "
 
-- name: "Run virt-customize commands"
-  command: "virt-customize -v -x -a {{ definition[1] }}/{{ definition[0] }}_{{ definition[4] }}.{{ definition[2] }} {{ definition[3] }}"
-  with_nested:
+- name: Run prepared virt-customized commands 
+  block:
+  - name: "Run virt-customize commands"
+    command: "virt-customize -v -x -a {{ definition[1] }}/{{ definition[0] }}_{{ definition[4] }}.{{ definition[2] }} {{ definition[3] }}"
+    with_nested:
     - ["{{ libvirt_resource_name }}"]
     - ["{{ libvirt_image_path | expanduser }}"]
     - ["{{ img_src_ext }}"]
     - ["{{ virt_args }}"]
     - "{{ res_count.stdout }}"
-  loop_control:
-    loop_var: definition
-  become: "{{ libvirt_become }}"
+    loop_control:
+      loop_var: definition
+    become: "{{ libvirt_become }}"
+  rescue:
+  - fail:
+      msg: 'Error running command virt-customize. Please make sure the dependencies are installed correctly . Try running `linchpin setup libvirt` to reinstall dependencies'

--- a/linchpin/provision/setup.yml
+++ b/linchpin/provision/setup.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  vars:
+    VENV_LIB_PATH: "lib/python2.7/site-packages"
+    PYTHON_LIB_PATH: "/usr/lib/python2.7/site-packages"
+    PYTHON_LIB64_PATH: "/usr/lib64/python2.7/site-packages"
+  roles:
+  - role: dependencies

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -627,6 +627,7 @@ It is suggested to update any of the following:
         ctx.log_state(e)
         sys.exit(1)
 
+
 @runcli.command()
 @click.argument('providers', metavar='PROVIDERS', required=False,
                 nargs=-1)
@@ -643,6 +644,7 @@ def setup(ctx, providers, ask_sudo_pass):
     lpcli.ctx.set_evar("ask_sudo_pass", ask_sudo_pass)
     return_code, output = lpcli.lp_setup(providers)
     return sys.exit(return_code)
+
 
 def main():
     # print("entrypoint")

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -627,6 +627,22 @@ It is suggested to update any of the following:
         ctx.log_state(e)
         sys.exit(1)
 
+@runcli.command()
+@click.argument('providers', metavar='PROVIDERS', required=False,
+                nargs=-1)
+@click.option('--ask-sudo-pass', is_flag=True, default=False,
+              help='Prompts for sudo password for package installations')
+@pass_context
+def setup(ctx, providers, ask_sudo_pass):
+    """
+    Validate topologies for the given target(s) in the given PinFile.
+    The data from the targets is obtained from the PinFile (default).
+    targets:    Validate ONLY the listed target(s). If omitted, ALL targets in
+    the appropriate PinFile will be validate
+    """
+    lpcli.ctx.set_evar("ask_sudo_pass", ask_sudo_pass)
+    return_code, output = lpcli.lp_setup(providers)
+    return sys.exit(return_code)
 
 def main():
     # print("entrypoint")


### PR DESCRIPTION
Introducing linchpin setup command which are used to automate linchpin external dependency installations 

command: 
```
linchpin setup [dependency_list]
```
example usage: 
```
# by default linchpin setup installs all dependencies 
# test , docs , libvirt, beaker, selinux etc 
linchpin setup
```
```
# one can always specify set of dependencies
linchpin setup beaker libvirt
```


Further current PR adds debug fail messages to beaker and libvirt when something goes wrong with the provisioning process. It works both in virtualenv.
Some of the dependencies might need  sudo permissions which can either be done using 
```
linchpin setup --ask-sudo-pass 
```
or running linchpin with sudo 
```
sudo linchpin setup
```
or running linchpin under a privileged sudo user 
```
linchpin setup
```

fixes: #419 