### PR TITLE
Fix Typos in Getting Started Docs

### DIFF
--- a/docs/source/examples/workspaces/dummy/PinFile
+++ b/docs/source/examples/workspaces/dummy/PinFile
@@ -1,5 +1,5 @@
 ---
-dummy:
+dummy-new:
   topology:
     topology_name: "dummy_cluster" # topology name
     resource_groups:

--- a/docs/source/simple_pinfile.rst
+++ b/docs/source/simple_pinfile.rst
@@ -3,7 +3,7 @@ PinFile
 
 A :term:`PinFile` takes a :term:`topology` and an optional :term:`layout`, among other options, as a combined set of configurations as a resource for provisioning. An example :term:`Pinfile` is shown.
 
-The *simple* PinFile is shown below
+The PinFile in the *simple* workspace is shown below.
 
 .. code-block:: yaml
 
@@ -34,7 +34,7 @@ A target will have subcomponents, which tell `linchpin` what it should do and ho
 Topology
 ++++++++
 
-A topology\ :sup:`3`\  consists of several items. First and foremost is the topology_name\ :sup:`4`\, followed by one or more resource_groups\ :sup:`5`\. In the *simple* example, there is only one resource group.
+A topology\ :sup:`3`\  consists of several items. First and foremost is the topology_name\ :sup:`4`\, followed by one or more resource_groups\ :sup:`5`\. In this PinFile, there is only one resource group.
 
 Resource Group
 ++++++++++++++
@@ -44,9 +44,9 @@ A resource group contains several items, minimally, it will have a resource_grou
 Resource Definitions
 ++++++++++++++++++++
 
-Within a resource group, multiple resource definitions can exist. In many cases, there are desires for two different resources to be provisioned within a resource group. In this example, there is only one. Each provider has its own constraints for what is required. There are some common fields, however. In the example above, there is name\ :sup:`9`\ and role\ :sup:`10`\, and count\ :sup:`11`\.
+Within a resource group, multiple resource definitions can exist. In many cases, there are desires for two different resources to be provisioned within a resource group. In this example, there is only one. Each provider has its own constraints for what is required. There are some common fields, however. In the example above, there is name\ :sup:`9`\, role\ :sup:`10`\, and count\ :sup:`11`\.
 
-.. note:: The role relates to the ansible role used to perform provisioning. In this case, that's the *dummy_node* role. But many providers have multiple roles within a resource.
+.. note:: The role relates to the ansible role used to perform provisioning. In this case, that's the *dummy_node* role. But many providers have multiple roles.
 
 Definitions help, but lets see it in :doc:`action <simple_up>`.
 

--- a/docs/source/simple_up.rst
+++ b/docs/source/simple_up.rst
@@ -6,7 +6,7 @@ It's time to provision your first LinchPin resources.
 .. code-block:: bash
 
     1   [/tmp/simple]$ linchpin up
-    2    [WARNING]: Unable to parse /tmp/dummy/simple/localhost as an inventory source
+    2    [WARNING]: Unable to parse /tmp/simple/localhost as an inventory source
 
     3    [WARNING]: No inventory was parsed, only implicit localhost is available
 
@@ -36,23 +36,20 @@ Upon completion of every action, there is a summary that is provided. This summa
 uHash
 +++++
 
-The Unique-ish Hash, or uHash\ :sup:`8`\ provides a way for each instance to be unique within a set of resources.The uHash is used throughout LinchPin with reporting, idempotency, inventories, etc. The uHash is configurable, but currently is a sha256 hash of some unique data, trimmed to 6 characters.
+The Unique-ish Hash, or uHash\ :sup:`8` provides a way for each instance to be unique within a set of resources. The uHash is used throughout LinchPin with reporting, idempotency, inventories, etc. The uHash is configurable, but defaults to a sha256 hash of some unique data, trimmed to 6 characters.
 
 Run ID
 ++++++
 
-The Run ID\:sup:`8`\ can be used for idempotency. The Run ID is used for a specific target.
-
-ID
-++
-
-Similar to the Run ID explained above, the ID\ :sup:`5`\, or Transaction ID, is provided for idempotency. If desired, the entire transaction can be repeated using this value. Unlike the Run ID, however, the Transaction ID can be used to repeat the entire transaction (multiple targets).
+The Run ID\ :sup:`8` can be used for idempotency. The Run ID is used for a specific target. Passing ``-r <run-id>`` to ``linchpin up`` or ``linchpin destroy`` along with the target will provide an idempotent up or destroy action.
 
 .. code-block:: bash
 
-    $ linchpin up --tx-id 10
+    $ linchpin up --run-id 2 simple
 
     .. snip ..
+
+    Action 'up' on Target 'simple' is complete
 
     ID: 11
     Action: up
@@ -62,6 +59,26 @@ Similar to the Run ID explained above, the ID\ :sup:`5`\, or Transaction ID, is 
     simple              	     3	3a4038	        0
 
 The thing to notice here is that the uHash is the same here as in the original *up* action above. This provides idempotency when provisioning.
+
+ID
+++
+
+Similar to the Run ID explained above, the Transaction ID, or ID\ :sup:`5`\, is provided for idempotency. If desired, the entire transaction can be repeated using this value. Unlike the Run ID, however, the Transaction ID can be used to repeat the entire transaction (multiple targets). As with Run ID, passing ``-t <tx-id>`` will provide idempotent an idempotent up or destroy action.
+
+.. code-block:: bash
+
+    $ linchpin up --tx-id 10
+
+    .. snip ..
+
+    ID: 12
+    Action: up
+
+    Target              	Run ID	uHash	Exit Code
+    -------------------------------------------------
+    simple              	     4	3a4038	        0
+
+.. note:: All targets are executed when using ``-t/--tx-id``. This differs from ``-r/--run-id`` where only one target can be supplied per Run ID. This is useful when multiple targets are executed from the PinFile.
 
 
 Exit Code
@@ -78,13 +95,13 @@ To destroy the previously provisioned resources, use ``linchpin destroy``.
 .. code-block:: bash
 
     $ linchpin destroy
-     [WARNING]: Unable to parse /tmp/dummy/simple/localhost as an inventory source
+     [WARNING]: Unable to parse /tmp/simple/localhost as an inventory source
 
      [WARNING]: No inventory was parsed, only implicit localhost is available
 
     Action 'destroy' on Target 'simple' is complete
 
-    ID: 12
+    ID: 13
     Action: destroy
 
     Target              	Run ID	uHash	Exit Code

--- a/docs/source/simple_workspace.rst
+++ b/docs/source/simple_workspace.rst
@@ -3,16 +3,16 @@ Workspaces
 
 What is generated is commonly referred to as the :term:`workspace`. The workspace can live anywhere on the filesystem. The default is the current directory. The workspace can also be passed into the ``linchpin`` command line with the ``--workspace (--w)`` option, or it can be set with the ``$WORKSPACE`` environmental variable.
 
-In our `simple` example, the workspaces is `/tmp/dummy`.
+In our `simple` example, the workspaces is `/tmp/simple`.
 
 A workspace requires only one file, the `PinFile`. This file is the cornerstone to LinchPin provisioning. It's a YAML file, written with declarative syntax. This means the `PinFile` is written to explain how things should be provisioned *after* running `linchpin up`.
 
-Looking at the dummy workspace, you'll see that it has a few other items.
+Looking at the simple workspace, you'll see that it has a few other items.
 
 .. code-block:: bash
 
     $ pwd
-    /tmp/dummy
+    /tmp/simple
     $ ls
     inventories  PinFile  PinFile.json  README.rst  resources
 


### PR DESCRIPTION
An update to the new getting started guide. Fixes some typos, adds a couple of more examples and clarifies a few things.

After checking it out, go to the `docs` directory and run `make html`. Then open the `docs/build/html/index.html` in a browser and view the 'Getting Started` section.

