### PR TITLE
use gitHubAPI to do the merge

### DIFF
--- a/config/Dockerfiles/JenkinsfileGHPRMerge
+++ b/config/Dockerfiles/JenkinsfileGHPRMerge
@@ -25,6 +25,9 @@ library identifier: "cico-pipeline-library@master",
         retriever: modernSCM([$class: 'GitSCMSource',
                               remote: "https://github.com/CentOS/cico-pipeline-library"])
 
+@Library('contra-lib')
+import org.centos.contra.pipeline.GitHubAPI
+
 properties([
   buildDiscarder(logRotator(artifactNumToKeepStr: '20', numToKeepStr: '20')),
   [$class: 'GithubProjectProperty', displayName: '', projectUrlStr: 'https://github.com/CentOS-PaaS-SIG/linchpin/'],
@@ -64,8 +67,18 @@ pipeline {
                             // build step and it assumes the build is complete.
                             currentBuild.result = 'SUCCESS'
                         }
-                        step([$class: 'GhprbPullRequestMerge', allowMergeWithoutTriggerPhrase: false, deleteOnMerge: false, disallowOwnCode: false, failOnNonMerge: false, mergeComment: ' ', onlyAdminsMerge: false])
                         script {
+                            withCredentials([string(credentialsId: 'paas-bot', variable: 'GH_TOKEN')]) {
+                                def github = new GitHubAPI(username: 'paas-bot',
+                                                           password: GH_TOKEN,
+                                                           repo: env.ghprbGhRepository)
+                                int pull_id = env.ghprbPullId as Integer
+                                merge_commit_sha = github.mergePRByNumber(pull_id,
+                                                                      'Merged by Jenkins')
+                            }
+                        }
+                        script {
+                            println "merge_commit_sha=${merge_commit_sha} ghprbActualCommit=${env.ghprbActualCommit}"
                             mTopic = "${topic}.ci.linchpin.pr_merge.queued"
                             mProperties = "topic=${topic}.ci.linchpin.pr_merge.queued\n" +
                                 "ghprbActualCommit=${env.ghprbActualCommit}\n" +
@@ -138,7 +151,7 @@ pipeline {
                                     build job: 'cd-linchpin-release',
                                         parameters: [
                                                 string(name: 'ghprbActualCommit',
-                                                       value: "${env.ghprbActualCommit}"),
+                                                       value: "${merge_commit_sha}"),
                                                 string(name: 'ghprbGhRepository',
                                                        value: "${env.ghprbGhRepository}"),
                                         ],


### PR DESCRIPTION
This library method gives us the merge commit so we can pass that to the next job.

Tested this locally and it works with the latest updates to contra-lib