### PR TITLE
Add support to os_router in linchpin topologies

### DIFF
--- a/config/Dockerfiles/tests.d/openstack/07_os-router
+++ b/config/Dockerfiles/tests.d/openstack/07_os-router
@@ -1,0 +1,26 @@
+#!/bin/bash -xe
+
+# Verify the openstack router provisioning
+# distros.exclude: none
+# providers.include: openstack
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+
+TARGET="os-router"
+TEMPLATE_DATA="{\"distro\": \"${DISTRO}-\"}"
+TMP_FILE=$(mktemp)
+
+function clean_up {
+    set +e
+    linchpin -w . -v destroy "${TARGET}"
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+pushd docs/source/examples/workspaces/${PROVIDER}
+
+linchpin -w . -v up "${TARGET}"
+
+# cleanup the network
+linchpin -w . -v destroy "${TARGET}"

--- a/docs/source/examples/workspaces/openstack/PinFile
+++ b/docs/source/examples/workspaces/openstack/PinFile
@@ -83,3 +83,17 @@ os-network:
         credentials:
           filename: clouds.yaml
           profile: ci-rhos
+
+os-router:
+  topology:
+    topology_name: os_router
+    resource_groups:
+      - resource_group_name: ex_group
+        resource_group_type: openstack
+        resource_definitions:
+          - name: trouter_example
+            role: os_router
+            unique: true
+        credentials:
+          filename: clouds.yaml
+          profile: ci-rhos

--- a/docs/source/examples/workspaces/openstack/topologies/os-router.yml
+++ b/docs/source/examples/workspaces/openstack/topologies/os-router.yml
@@ -1,0 +1,12 @@
+---
+topology_name: os_router
+resource_groups:
+  - resource_group_name: ex_group
+    resource_group_type: openstack
+    resource_definitions:
+      - name: trouter_example
+        role: os_router
+        unique: true
+    credentials:
+      filename: clouds.yaml
+      profile: ci-rhos

--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -89,6 +89,13 @@ Openstack networks can be provisioned using this resource.
 * :docs1.5:`Topology Example <workspace/topologies/os-network.yml>`
 * `Ansible os_network module <https://docs.ansible.com/ansible/2.5/modules/os_network_module.html>`_
 
+os_router
+---------
+
+Openstack routers can be provisioned using this resource.
+* :docs1.5:`Topology Example <workspace/topologies/os-router.yml>`
+* `Ansible os_router module <https://docs.ansible.com/ansible/latest/modules/os_router_module.html>`_
+
 Additional Dependencies
 -----------------------
 

--- a/linchpin/provision/roles/openstack/files/schema.json
+++ b/linchpin/provision/roles/openstack/files/schema.json
@@ -154,9 +154,39 @@
                     "timeout": { "type": "number", "required": false },
                     "unique": { "type": "boolean", "required": false }
                 }
+            },
+            {
+                "type": "dict",
+                "schema": {
+                    "role": {
+                        "type": "string",
+                        "required": true,
+                        "allowed": ["os_router"] },
+                    "admin_state_up": { "type": "boolean", "required": false},
+                    "api_timeout": { "type": "number", "required": false},
+                    "external_fixed_ips": {
+                        "type": "list",
+                        "required": false,
+                        "schema": { "type": "string", "required": true }
+                    },
+                    "interfaces": {
+                        "type": "list",
+                        "required": false,
+                        "schema": { "type": "string", "required": true }
+                    },
+                    "network": { "type": "string", "required": false },
+                    "enable_snat": { "type": "boolean", "required": false},
+                    "external": { "type": "boolean", "required": false},
+                    "interface": { "type": "string", "required": false, "allowed": ["public", "internal", "admin"] },
+                    "key": { "type": "string", "required": false },
+                    "name": { "type": "string", "required": true},
+                    "project": { "type": "string", "required": false},
+                    "region_name": { "type": "string", "required": false},
+                    "timeout": { "type": "number", "required": false },
+                    "unique": { "type": "boolean", "required": false }
+                }
             }
 	    ]
         }
     }
 }
-

--- a/linchpin/provision/roles/openstack/tasks/provision_os_router.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_router.yml
@@ -1,0 +1,127 @@
+---
+- name: "check if the name is unique or not"
+  set_fact:
+    is_unique: "{{ res_def['unique'] | default(false) }}"
+
+- name: "provision/deprovision os_router"
+  os_router:
+    admin_state_up: "{{ res_def['admin_state_up'] | default(omit) }}"
+    api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
+    auth: "{{ auth_var }}"
+    enable_snat: "{{ res_def['enable_snat'] | default(omit) }}"
+    external_fixed_ips: "{{ res_def['external_fixed_ips'] | default(omit) }}"
+    interface: "{{ res_def['interface'] | default(omit) }}"
+    interfaces: "{{ res_def['interfaces'] | default(omit) }}"
+    name: "{{ os_resource_name }}"
+    network: "{{ res_def['network'] | default(omit) }}"
+    key: "{{ res_def['key'] | default(omit) }}"
+    project: "{{ res_def['project'] | default(omit) }}"
+    region_name: "{{ res_def['region_name'] | default(omit) }}"
+    state: "{{ state }}"
+    timeout: "{{ res_def['timeout'] | default(600) }}"
+    verify: no
+    wait: yes
+  register: res_def_output_unique
+  no_log: "{{ not debug_mode }}"
+  when: 
+   - is_unique
+   - auth_var != ""
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_network: "{{ topology_outputs_os_network + [ res_def_output_unique ] }}"
+  when:
+    - is_unique
+    - auth_var != ""
+
+- name: "provision/deprovision os_router"
+  os_router:
+    admin_state_up: "{{ res_def['admin_state_up'] | default(omit) }}"
+    api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
+    enable_snat: "{{ res_def['enable_snat'] | default(omit) }}"
+    external_fixed_ips: "{{ res_def['external_fixed_ips'] | default(omit) }}"
+    interface: "{{ res_def['interface'] | default(omit) }}"
+    interfaces: "{{ res_def['interfaces'] | default(omit) }}"
+    name: "{{ os_resource_name }}"
+    network: "{{ res_def['network'] | default(omit) }}"
+    key: "{{ res_def['key'] | default(omit) }}"
+    project: "{{ res_def['project'] | default(omit) }}"
+    region_name: "{{ res_def['region_name'] | default(omit) }}"
+    state: "{{ state }}"
+    timeout: "{{ res_def['timeout'] | default(600) }}"
+    verify: no
+    wait: yes
+  register: res_def_output_unique
+  no_log: "{{ not debug_mode }}"
+  when:
+   - is_unique
+   - auth_var == ""
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_network: "{{ topology_outputs_os_network + [ res_def_output_unique ] }}"
+  when:
+    - is_unique
+    - auth_var == ""
+
+- name: "provision/deprovision os_router"
+  os_router:
+    admin_state_up: "{{ res_def['admin_state_up'] | default(omit) }}"
+    api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
+    auth: "{{ auth_var }}"
+    enable_snat: "{{ res_def['enable_snat'] | default(omit) }}"
+    external_fixed_ips: "{{ res_def['external_fixed_ips'] | default(omit) }}"
+    interface: "{{ res_def['interface'] | default(omit) }}"
+    interfaces: "{{ res_def['interfaces'] | default(omit) }}"
+    name: "{{ res_def['name'] }}"
+    network: "{{ res_def['network'] | default(omit) }}"
+    key: "{{ res_def['key'] | default(omit) }}"
+    project: "{{ res_def['project'] | default(omit) }}"
+    region_name: "{{ res_def['region_name'] | default(omit) }}"
+    state: "{{ state }}"
+    timeout: "{{ res_def['timeout'] | default(600) }}"
+    verify: no
+    wait: yes
+  register: res_def_output_not_unique
+  no_log: "{{ not debug_mode }}"
+  when:
+    - not is_unique
+    - auth_var != ""
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_network: "{{ topology_outputs_os_network + [ res_def_output_not_unique ] }}"
+  when: 
+    - not is_unique
+    - auth_var != ""
+
+- name: "provision/deprovision os_router"
+  os_router:
+    admin_state_up: "{{ res_def['admin_state_up'] | default(omit) }}"
+    api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
+    auth: "{{ auth_var }}"
+    enable_snat: "{{ res_def['enable_snat'] | default(omit) }}"
+    external_fixed_ips: "{{ res_def['external_fixed_ips'] | default(omit) }}"
+    interface: "{{ res_def['interface'] | default(omit) }}"
+    interfaces: "{{ res_def['interfaces'] | default(omit) }}"
+    name: "{{ res_def['name'] }}"
+    network: "{{ res_def['network'] | default(omit) }}"
+    key: "{{ res_def['key'] | default(omit) }}"
+    project: "{{ res_def['project'] | default(omit) }}"
+    region_name: "{{ res_def['region_name'] | default(omit) }}"
+    state: "{{ state }}"
+    timeout: "{{ res_def['timeout'] | default(600) }}"
+    verify: no
+    wait: yes
+  register: res_def_output_not_unique
+  no_log: "{{ not debug_mode }}"
+  when:
+    - not is_unique
+    - auth_var == ""
+ 
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_network: "{{ topology_outputs_os_network + [ res_def_output_not_unique ] }}"
+  when:
+    - not is_unique
+    - auth_var == ""


### PR DESCRIPTION
Summary:
- Updated examples and documentation for os_router role
- Added test for os_router
- Updated playbooks to support os_router ansible module
- Updated schema to support os_router module

fixes #819 