### PR TITLE
Force relative imports to be explicit

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -10,6 +10,7 @@ import hashlib
 
 from uuid import getnode as get_mac
 from collections import OrderedDict
+from six import text_type
 
 from linchpin.ansible_runner import ansible_runner
 
@@ -655,9 +656,11 @@ class LinchpinAPI(object):
             uhash_length = self.get_cfg('lp', 'rundb_uhash_length')
             uhash_len = int(uhash_length)
             if not run_id:
-                uh = hashlib.new(self.rundb_hash,
-                                 ':'.join([target, str(tx_id),
-                                          str(rundb_id), str(st_uhash)]))
+                hash_str = ':'.join([target, str(tx_id), str(rundb_id),
+                                     str(st_uhash)])
+                if isinstance(hash_str, text_type):
+                    hash_str = hash_str.encode('utf-8')
+                uh = hashlib.new(self.rundb_hash, hash_str)
                 uhash = uh.hexdigest()[:uhash_len]
 
             if action == 'destroy' or run_id:

--- a/linchpin/context.py
+++ b/linchpin/context.py
@@ -67,9 +67,9 @@ class LinchpinContext(object):
         """
 
         try:
-            config = ConfigParser.SafeConfigParser()
+            config = ConfigParser.ConfigParser()
             f = open(path)
-            config.readfp(f)
+            config.read_file(f)
             f.close()
 
             for section in config.sections():

--- a/linchpin/fetch/__init__.py
+++ b/linchpin/fetch/__init__.py
@@ -1,5 +1,5 @@
-from fetch_http import FetchHttp
-from fetch_git import FetchGit
+from .fetch_http import FetchHttp
+from .fetch_git import FetchGit
 
 FETCH_CLASS = {
     "FetchHttp": FetchHttp,

--- a/linchpin/fetch/fetch_git.py
+++ b/linchpin/fetch/fetch_git.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import tempfile
 
-from fetch import Fetch
+from .fetch import Fetch
 from linchpin.exceptions import LinchpinError
 
 

--- a/linchpin/fetch/fetch_http.py
+++ b/linchpin/fetch/fetch_http.py
@@ -3,7 +3,7 @@ import subprocess
 import tempfile
 import requests
 
-from fetch import Fetch
+from .fetch import Fetch
 from linchpin.exceptions import LinchpinError
 
 

--- a/linchpin/tests/InventoryFilters/test_CFGInventoryFormatter_pass.py
+++ b/linchpin/tests/InventoryFilters/test_CFGInventoryFormatter_pass.py
@@ -7,6 +7,7 @@ import json
 import yaml
 
 from nose.tools import *
+from six import iteritems
 
 from linchpin.InventoryFilters import CFGInventoryFormatter
 
@@ -87,7 +88,7 @@ def test_set_vars():
     formatter.set_vars(inv)
 
     host_group='OSEv3'
-    for key, val in inv['host_groups'][host_group]['vars'].iteritems():
+    for key, val in iteritems(inv['host_groups'][host_group]['vars']):
         var = formatter.config.get("{0}:vars".format(host_group), key)
         assert_equal(var, str(val))
 

--- a/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
@@ -2,6 +2,7 @@
 
 # flake8: noqa
 
+from __future__ import print_function
 import os
 import json
 import yaml
@@ -168,5 +169,5 @@ def test_output_order():
     correct_lines = correct_inventory.splitlines(1)
     # if the assertion fails, this diff will display
     diff = difflib.unified_diff(inventory_lines, correct_lines)
-    print ''.join(diff)
+    print(''.join(diff))
     assert_equal(inventory, correct_inventory)

--- a/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
@@ -154,7 +154,7 @@ def test_output_order():
     # get res_output
     output_path = '{0}/{1}'.format(workspace, 'linchpin.benchmark')
     res_output = json.load(open(output_path))
-    res_output = res_output[res_output.keys()[0]]['targets'][0]['complex-inventory']['outputs']['resources']
+    res_output = res_output[list(res_output.keys())[0]]['targets'][0]['complex-inventory']['outputs']['resources']
 
     # call get_inventory and print the result
     inventory = filter.get_inventory(res_output, layout, topology, config)

--- a/linchpin/tests/InventoryFilters/test_InventoryFilter_pass.py
+++ b/linchpin/tests/InventoryFilters/test_InventoryFilter_pass.py
@@ -6,6 +6,7 @@ import os
 import json
 
 from nose.tools import *
+from six import iteritems
 
 import logging
 from unittest import TestCase
@@ -83,7 +84,7 @@ def test_set_vars():
     filter.set_vars(inv)
 
     host_group='OSEv3'
-    for key, val in inv['host_groups'][host_group]['vars'].iteritems():
+    for key, val in iteritems(inv['host_groups'][host_group]['vars']):
         var = filter.config.get("{0}:vars".format(host_group), key)
         assert_equal(var, str(val))
 

--- a/linchpin/tests/InventoryFilters/test_JSONInventoryFormatter_pass.py
+++ b/linchpin/tests/InventoryFilters/test_JSONInventoryFormatter_pass.py
@@ -4,6 +4,7 @@ import os
 import json
 
 from nose.tools import *
+from six import iteritems
 
 from linchpin.InventoryFilters import JSONInventoryFormatter
 
@@ -64,7 +65,7 @@ def test_set_vars():
 
     host_group='OSEv3'
     vars = formatter.config[host_group]['vars']
-    for key, val in inv['host_groups'][host_group]['vars'].iteritems():
+    for key, val in iteritems(inv['host_groups'][host_group]['vars']):
         assert_equal(val, vars[key])
 
 

--- a/linchpin/tests/cli/test_context_pass.py
+++ b/linchpin/tests/cli/test_context_pass.py
@@ -5,6 +5,11 @@
 import os
 
 from nose.tools import *
+try:
+    # Renamed in Python 3
+    from nose.tools import assert_regexp_matches as assertRegex
+except ImportError:
+    pass
 
 import logging
 from unittest import TestCase
@@ -156,7 +161,7 @@ def test_log_msg():
     with open(logfile) as f:
         line = f.readline()
 
-    assert_regexp_matches(line, regex)
+    assertRegex(line, regex)
 
 @with_setup(setup_context_data)
 def test_log_state():
@@ -176,7 +181,7 @@ def test_log_state():
     with open(logfile) as f:
         line = f.readline()
 
-    assert_regexp_matches(line, regex)
+    assertRegex(line, regex)
 
 @with_setup(setup_context_data)
 def test_log_info():
@@ -196,7 +201,7 @@ def test_log_info():
     with open(logfile) as f:
         line = f.readline()
 
-    assert_regexp_matches(line, regex)
+    assertRegex(line, regex)
 
 @with_setup(setup_context_data)
 def test_log_debug():
@@ -216,7 +221,7 @@ def test_log_debug():
     with open(logfile) as f:
         line = f.readline()
 
-    assert_regexp_matches(line, regex)
+    assertRegex(line, regex)
 
 
 def main():

--- a/linchpin/tests/mockdata/contextdata.py
+++ b/linchpin/tests/mockdata/contextdata.py
@@ -1,7 +1,7 @@
 import os
 
 import tempfile
-import ConfigParser
+from six.moves import configparser as ConfigParser
 
 from linchpin.exceptions import LinchpinError
 

--- a/linchpin/tests/mockdata/contextdata.py
+++ b/linchpin/tests/mockdata/contextdata.py
@@ -2,6 +2,7 @@ import os
 
 import tempfile
 from six.moves import configparser as ConfigParser
+from six import iteritems
 
 from linchpin.exceptions import LinchpinError
 
@@ -138,9 +139,9 @@ class ContextData(object):
 
         # we know that data is a dict, containing dicts
         try:
-            for k, v in config_data.iteritems():
+            for k, v in iteritems(config_data):
                 self.parser.add_section(k)
-                for kv, vv in v.iteritems():
+                for kv, vv in iteritems(v):
                     if type(vv) is not str:
                         vv = str(vv)
                     self.parser.set(k, kv, vv)

--- a/linchpin/tests/mockdata/contextdata.py
+++ b/linchpin/tests/mockdata/contextdata.py
@@ -14,7 +14,7 @@ Provide valid context data to test against.
 
 class ContextData(object):
 
-    def __init__(self, parser=ConfigParser.SafeConfigParser):
+    def __init__(self, parser=ConfigParser.ConfigParser):
 
 
         self.lib_path = '{0}'.format(os.path.dirname(
@@ -82,7 +82,7 @@ class ContextData(object):
         """
 
         try:
-            config = ConfigParser.SafeConfigParser()
+            config = ConfigParser.ConfigParser()
             f = open(path)
             config.readfp(f)
             f.close()


### PR DESCRIPTION
Python has long supported explicit relative imports and encouarged them
in the style guide. However, in the days of Python 3, this is now a
requirement of the language. This syntax still works in Python 2.

Addresses #853 