### PR TITLE
Add support for os_subnet role in linchpin topologies

### DIFF
--- a/config/Dockerfiles/tests.d/openstack/08_os_subnet
+++ b/config/Dockerfiles/tests.d/openstack/08_os_subnet
@@ -1,0 +1,25 @@
+#!/bin/bash -xe
+
+# Verify the openstack router provisioning
+# distros.exclude: fedora28 fedora27
+# providers.include: openstack
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+
+TARGET="os-subnet"
+TMP_FILE=$(mktemp)
+
+function clean_up {
+    set +e
+    linchpin -w . -v destroy "${TARGET}"
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+pushd docs/source/examples/workspaces/${PROVIDER}
+
+linchpin -w . -v up "${TARGET}"
+
+# cleanup the network
+linchpin -w . -v destroy "${TARGET}"

--- a/docs/source/examples/workspaces/openstack/PinFile
+++ b/docs/source/examples/workspaces/openstack/PinFile
@@ -105,7 +105,7 @@ os-subnet:
       - resource_group_name: ex_os_subnet
         resource_group_type: openstack
         resource_definitions:
-          - name: test_network_sk
+          - name: test_network_ex
             role: os_network
             unique: false
           - name: test_subnet_ex

--- a/docs/source/examples/workspaces/openstack/PinFile
+++ b/docs/source/examples/workspaces/openstack/PinFile
@@ -97,3 +97,22 @@ os-router:
         credentials:
           filename: clouds.yaml
           profile: ci-rhos
+
+os-subnet:
+  topology:
+    topology_name: os-subnet
+    resource_groups:
+      - resource_group_name: ex_os_subnet
+        resource_group_type: openstack
+        resource_definitions:
+          - name: test_network_sk
+            role: os_network
+            unique: false
+          - name: test_subnet_ex
+            role: os_subnet
+            network_name: test_network_ex
+            unique: false
+            cidr: 192.167.128.0/24
+        credentials:
+          filename: clouds.yaml
+          profile: ci-rhos

--- a/docs/source/examples/workspaces/openstack/topologies/os-subnet.yml
+++ b/docs/source/examples/workspaces/openstack/topologies/os-subnet.yml
@@ -1,0 +1,17 @@
+---
+topology_name: os-subnet
+resource_groups:
+  - resource_group_name: ex_os_subnet
+    resource_group_type: openstack
+    resource_definitions:
+      - name: test_network_sk
+        role: os_network
+        unique: false
+      - name: test_subnet_ex
+        role: os_subnet
+        network_name: test_network_ex
+        unique: false
+        cidr: 192.167.128.0/24
+    credentials:
+      filename: clouds.yaml
+      profile: ci-rhos

--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -96,6 +96,14 @@ Openstack routers can be provisioned using this resource.
 * :docs1.5:`Topology Example <workspace/topologies/os-router.yml>`
 * `Ansible os_router module <https://docs.ansible.com/ansible/latest/modules/os_router_module.html>`_
 
+os_subnet
+---------
+
+Openstack subnets can be provisioned using this resource.
+* :docs1.5:`Topology Example <workspace/topologies/os-subnet.yml>`
+* `Ansible os_router module <https://docs.ansible.com/ansible/latest/modules/os_subnet_module.html>`_
+
+
 Additional Dependencies
 -----------------------
 

--- a/linchpin/provision/roles/openstack/files/schema.json
+++ b/linchpin/provision/roles/openstack/files/schema.json
@@ -151,8 +151,8 @@
                     "provider_segmentation_id": { "type": "string", "required": false},
                     "region_name": { "type": "string", "required": false},
                     "shared": { "type": "boolean", "required": false},
-		    "timeout": { "type": "number", "required": false },
-		    "unique": { "type": "boolean", "required": false } 
+                    "timeout": { "type": "number", "required": false },
+                    "unique": { "type": "boolean", "required": false }
                 }
             },
             {

--- a/linchpin/provision/roles/openstack/files/schema.json
+++ b/linchpin/provision/roles/openstack/files/schema.json
@@ -151,8 +151,8 @@
                     "provider_segmentation_id": { "type": "string", "required": false},
                     "region_name": { "type": "string", "required": false},
                     "shared": { "type": "boolean", "required": false},
-                    "timeout": { "type": "number", "required": false },
-                    "unique": { "type": "boolean", "required": false }
+		    "timeout": { "type": "number", "required": false },
+		    "unique": { "type": "boolean", "required": false } 
                 }
             },
             {
@@ -164,12 +164,12 @@
                         "allowed": ["os_router"] },
                     "admin_state_up": { "type": "boolean", "required": false},
                     "api_timeout": { "type": "number", "required": false},
-                    "external_fixed_ips": {
+		    "external_fixed_ips": {
                         "type": "list",
                         "required": false,
                         "schema": { "type": "string", "required": true }
                     },
-                    "interfaces": {
+		    "interfaces": {
                         "type": "list",
                         "required": false,
                         "schema": { "type": "string", "required": true }
@@ -185,8 +185,54 @@
                     "timeout": { "type": "number", "required": false },
                     "unique": { "type": "boolean", "required": false }
                 }
+            },
+	    {
+                "type": "dict",
+                "schema": {
+                    "role": {
+                        "type": "string",
+                        "required": true,
+                        "allowed": ["os_subnet"] },
+                    "allocation_pool_end": { "type": "string", "required": false },
+                    "allocation_pool_start": { "type": "string", "required": false },
+                    "api_timeout": { "type": "string", "required": false },
+                    "cidr": { "type": "string", "required": false },
+                    "dns_nameservers": {
+                        "type": "list",
+                        "required": false,
+                        "schema": { "type": "string", "required": true }
+                    },
+                    "enable_dhcp": { "type": "boolean", "required": false},
+		     "extra_specs": {
+                        "type": "dict",
+                        "required": false
+                    },
+                    "gateway_ip": { "type": "string", "required": false },
+                    "host_routes": {
+                        "type": "dict",
+                        "required": false,
+                        "schema": {
+                            "destination": { "type": "string", "required": false },
+                            "nexthop": { "type": "string", "required": false }
+                        }
+                    },
+                    "interface": { "type": "string", "required": false, "allowed": ["public", "internal", "admin"] },
+                    "ip_version": { "type": "number", "required": false },
+                    "ipv6_address_mode": { "type": "string", "required": false, "allowed": ["dhcpv6-stateful", "dhcpv6-stateless", "slaac"] },
+                    "ipv6_ra_mode": { "type": "string", "required": false, "allowed": ["dhcpv6-stateful", "dhcpv6-stateless", "slaac"] },
+                    "key": { "type": "string", "required": false },
+                    "name": { "type": "string", "required": true },
+                    "network_name": { "type": "string", "required": true },
+                    "no_gateway_ip": { "type": "boolean", "required": false},
+                    "use_default_subnetpool": { "type": "boolean", "required": false},
+                    "project": { "type": "string", "required": false},
+                    "region_name": { "type": "string", "required": false},
+                    "timeout": { "type": "number", "required": false },
+                    "unique": { "type": "boolean", "required": false }
+                }
             }
 	    ]
         }
     }
 }
+

--- a/linchpin/provision/roles/openstack/tasks/provision_os_subnet.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_subnet.yml
@@ -1,0 +1,76 @@
+---
+- name: "provision/deprovision os_subnet"
+  os_subnet:
+    allocation_pool_end:  "{{ res_def['allocation_pool_end'] | default(omit) }}"
+    allocation_pool_start:  "{{ res_def['allocation_pool_start'] | default(omit) }}"
+    api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
+    auth: "{{ auth_var }}"
+    cidr:  "{{ res_def['cidr'] | default(omit) }}"
+    dns_nameservers:  "{{ res_def['dns_nameservers'] | default(omit) }}"
+    enable_dhcp: "{{ res_def['enable_dhcp'] | default(omit) }}"
+    extra_specs: "{{ res_def['extra_specs'] | default(omit) }}"
+    gateway_ip:  "{{ res_def['gateway_ip'] | default(omit) }}"
+    host_routes:  "{{ res_def['host_routes'] | default(omit) }}"
+    ip_version:  "{{ res_def['ip_version'] | default(omit) }}"
+    ipv6_address_mode:  "{{ res_def['ipv6_address_mode'] | default(omit) }}"
+    ipv6_ra_mode:  "{{ res_def['ipv6_ra_mode'] | default(omit) }}"
+    network_name:  "{{ res_def['network_name'] | default(omit) }}"
+    no_gateway_ip:  "{{ res_def['no_gateway_ip'] | default(omit) }}"
+    use_default_subnetpool:  "{{ res_def['use_default_subnetpool'] | default(omit) }}"
+    interface: "{{ res_def['interface'] | default(omit) }}"
+    name: "{{ os_resource_name }}"
+    key: "{{ res_def['key'] | default(omit) }}"
+    project: "{{ res_def['project'] | default(omit) }}"
+    region_name: "{{ res_def['region_name'] | default(omit) }}"
+    state: "{{ state }}"
+    timeout: "{{ res_def['timeout'] | default(600) }}"
+    verify: no
+    wait: yes
+  register: res_def_output_auth
+  no_log: "{{ not debug_mode }}"
+  when: 
+   - auth_var != ""
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_network: "{{ topology_outputs_os_network + [ res_def_output_auth ] }}"
+  when:
+    - auth_var != ""
+      
+- name: "provision/deprovision os_subnet"
+  os_subnet:
+    allocation_pool_end:  "{{ res_def['allocation_pool_end'] | default(omit) }}"
+    allocation_pool_start:  "{{ res_def['allocation_pool_start'] | default(omit) }}"
+    api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
+    auth: "{{ auth_var }}"
+    cidr:  "{{ res_def['cidr'] | default(omit) }}"
+    dns_nameservers:  "{{ res_def['dns_nameservers'] | default(omit) }}"
+    enable_dhcp: "{{ res_def['enable_dhcp'] | default(omit) }}"
+    extra_specs: "{{ res_def['extra_specs'] | default(omit) }}"
+    gateway_ip:  "{{ res_def['gateway_ip'] | default(omit) }}"
+    host_routes:  "{{ res_def['host_routes'] | default(omit) }}"
+    ip_version:  "{{ res_def['ip_version'] | default(omit) }}"
+    ipv6_address_mode:  "{{ res_def['ipv6_address_mode'] | default(omit) }}"
+    ipv6_ra_mode:  "{{ res_def['ipv6_ra_mode'] | default(omit) }}"
+    network_name:  "{{ res_def['network_name'] | default(omit) }}"
+    no_gateway_ip:  "{{ res_def['no_gateway_ip'] | default(omit) }}"
+    use_default_subnetpool:  "{{ res_def['use_default_subnetpool'] | default(omit) }}"
+    interface: "{{ res_def['interface'] | default(omit) }}"
+    name: "{{ os_resource_name }}"
+    key: "{{ res_def['key'] | default(omit) }}"
+    project: "{{ res_def['project'] | default(omit) }}"
+    region_name: "{{ res_def['region_name'] | default(omit) }}"
+    state: "{{ state }}"
+    timeout: "{{ res_def['timeout'] | default(600) }}"
+    verify: no
+    wait: yes
+  register: res_def_output_auth
+  no_log: "{{ not debug_mode }}"
+  when:
+   - auth_var == ""
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_os_network: "{{ topology_outputs_os_network + [ res_def_output_no_auth ] }}"
+  when:
+    - auth_var == ""

--- a/linchpin/provision/roles/openstack/tasks/provision_os_subnet.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_subnet.yml
@@ -42,7 +42,6 @@
     allocation_pool_end:  "{{ res_def['allocation_pool_end'] | default(omit) }}"
     allocation_pool_start:  "{{ res_def['allocation_pool_start'] | default(omit) }}"
     api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
-    auth: "{{ auth_var }}"
     cidr:  "{{ res_def['cidr'] | default(omit) }}"
     dns_nameservers:  "{{ res_def['dns_nameservers'] | default(omit) }}"
     enable_dhcp: "{{ res_def['enable_dhcp'] | default(omit) }}"


### PR DESCRIPTION
Summary:
- Updated examples and documentation for os_subnet role
- Added test for os_subnet
- Updated playbooks to support os_subnet ansible module
- Updated schema to support os_subnet module

fixes #820 