### PR TITLE
Add 'unique' field to os_network

### DIFF
--- a/linchpin/provision/roles/openstack/files/schema.json
+++ b/linchpin/provision/roles/openstack/files/schema.json
@@ -151,6 +151,7 @@
                     "interface": { "type": "string", "required": false, "allowed": ["public", "internal", "admin"] },
                     "key": { "type": "string", "required": false },
                     "name": { "type": "string", "required": true},
+                    "unique": { "type": "boolean", "required": false},
                     "project": { "type": "string", "required": false},
                     "provider_network_type": { "type": "string", "required": false},
                     "provider_physical_network": { "type": "string", "required": false},


### PR DESCRIPTION
The `unique` field, which exists for all other openstack resources, was omitted from the os_network schema.  Adding this back in fixes the validation error preventing upshift tests in #866 from passing