### PR TITLE
Add dummy provider clone `nummy`: Updated

### DIFF
--- a/linchpin/InventoryFilters/DummyInventory.py
+++ b/linchpin/InventoryFilters/DummyInventory.py
@@ -17,16 +17,14 @@ class DummyInventory(InventoryFilter):
         Ansible on the same host via the generated inventory file.
 
         :param topo:
-            linchpin Dummy resource data
+            linchpin Dummy/nummy resource data
 
         :param cfgs:
             map of config options from PinFile
         """
-
         host_data = {}
-        if res['resource_type'] != 'dummy_res':
-            return host_data
         var_data = cfgs.get('dummy', {})
+        var_data.update(cfgs.get('nummy', {}))
         if var_data is None:
             var_data = {}
             var_data['__IP__'] = '__SELF__'

--- a/linchpin/InventoryFilters/InventoryProviders.py
+++ b/linchpin/InventoryFilters/InventoryProviders.py
@@ -20,6 +20,7 @@ filter_classes = {
     "beaker_res": BeakerInventory,
     "duffy_res": DuffyInventory,
     "dummy_res": DummyInventory,
+    "nummy_res": DummyInventory,
     "gcloud_gce_res": GCloudInventory,
     "libvirt_res": LibvirtInventory,
     "os_server_res": OpenstackInventory,

--- a/linchpin/provision/nummy.yml
+++ b/linchpin/provision/nummy.yml
@@ -1,0 +1,20 @@
+---
+# This playbook provisions dummy topology.
+
+- name:  "schema check and Pre Provisioning Activities on topology_file"
+  hosts: localhost
+  gather_facts: False
+  roles:
+    - { role: 'common' }
+
+- name:  "Provisioning resources based on resource group type"
+  hosts: localhost
+  gather_facts: False
+  roles:
+    - { role: 'nummy' }
+
+- name: "Writing contents to file"
+  hosts: localhost
+  gather_facts: False
+  roles:
+    - { role: 'gather_resources' }

--- a/linchpin/provision/roles/gather_resources/tasks/main.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/main.yml
@@ -15,6 +15,11 @@
     topology_outputs: "{{ topology_outputs_dummy }}"
   when: topology_outputs_dummy is defined
 
+- name: "Add nummy_res"
+  set_fact:
+    topology_outputs: "{{ topology_outputs_nummy }}"
+  when: topology_outputs_nummy is defined
+
 - name: "Add os_server_res"
   set_fact:
     topology_outputs: "{{ topology_outputs_os_server }}"

--- a/linchpin/provision/roles/nummy/files/schema.json
+++ b/linchpin/provision/roles/nummy/files/schema.json
@@ -1,0 +1,19 @@
+{
+    "res_defs": {
+        "type": "list",
+        "schema": {
+            "type": "dict",
+            "schema": {
+               "role": {
+                   "type": "string",
+                   "required": true,
+                   "allowed": ["nummy_node"]
+               },
+               "name": { "type": "string", "required": true },
+               "domain": { "type": "string", "required": false },
+               "count": { "type": "integer", "required": false }
+            }
+        }
+    }
+}
+

--- a/linchpin/provision/roles/nummy/tasks/main.yml
+++ b/linchpin/provision/roles/nummy/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: "declaring output vars"
+  set_fact:
+    topology_outputs_nummy: []
+
+- name: "Initiating Provisioning of nummy resource group"
+  include: provision_resource_group.yml res_grp={{ item }}
+  with_items:
+    - "{{ resources }}"
+  when: state == "present"
+
+- name: "Initiating Teardown of nummy resource group"
+  include: teardown_resource_group.yml res_grp={{ item }}
+  with_items:
+    - "{{ resources }}"
+  when: state == "absent"

--- a/linchpin/provision/roles/nummy/tasks/provision_res_defs.yml
+++ b/linchpin/provision/roles/nummy/tasks/provision_res_defs.yml
@@ -1,0 +1,29 @@
+---
+- name: "Get the resource name"
+  set_fact:
+    nummy_name: "{{ res_def['name'] }}"
+
+- name: "Assign nummy name using uhash value"
+  set_fact:
+    nummy_name: "{{ nummy_name + '-' + uhash }}"
+  when: enable_uhash
+
+- name: "Provision nummy resources by looping on count"
+  dummy:
+    state: present
+    name: "{{ nummy_name }}"
+    count: "{{ res_def['count'] | default(1) }}"
+    domain: "{{ res_def['domain'] | default('') }}"
+  register: outputitem
+
+- name: "set tmp var"
+  set_fact:
+    tmp: ["{{ outputitem }}"]
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_nummy: "{{ topology_outputs_nummy + tmp }}"
+
+- name: "Add type to resource"
+  set_fact:
+    topology_outputs_nummy: "{{ topology_outputs_nummy | add_res_type('nummy_res') }}"

--- a/linchpin/provision/roles/nummy/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/nummy/tasks/provision_resource_group.yml
@@ -1,0 +1,35 @@
+---
+- name: "Unset the authvar from previous run"
+  set_fact:
+    auth_var: ""
+  when: res_grp['credentials'] is defined
+
+- name: "set default_cred_filename when res_grp[credentials] is defined"
+  set_fact:
+    cred_filename: "{{ res_grp['credentials']['filename'] }}"
+  when: res_grp['credentials'] is defined
+
+- name: "Get creds from auth driver"
+  auth_driver:
+    filename: "{{ cred_filename }}"
+    cred_type: "dummy"
+    cred_path: "{{ creds_path | default(default_credentials_path) }}"
+    driver: "file"
+    vault_enc: "{{ vault_encryption }}"
+    vault_pass: "{{ vault_pass }}"
+  register: auth_var
+  no_log: "{{ not debug_mode }}"
+  when: res_grp['credentials'] is defined
+
+- name: "Fail when auth_var is null"
+  fail:
+    msg: "Auth var not set"
+  when: res_grp['credentials'] is defined and auth_var == ""
+
+- name: "provisioning resource definitions of current group"
+  include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item

--- a/linchpin/provision/roles/nummy/tasks/teardown_res_defs.yml
+++ b/linchpin/provision/roles/nummy/tasks/teardown_res_defs.yml
@@ -1,0 +1,24 @@
+---
+- name: "Get the resource name"
+  set_fact:
+    nummy_name: "{{ res_def['name'] }}"
+
+- name: "Assign nummy name using uhash value"
+  set_fact:
+    nummy_name: "{{ nummy_name + '-' + uhash }}"
+  when: enable_uhash
+
+- name: "Teardown nummy resources by looping on count"
+  dummy:
+    state: absent
+    name: "{{ nummy_name }}"
+    count: "{{ res_def['count'] | default(1) }}"
+  register: outputitem
+
+- name: "set tmp var"
+  set_fact:
+    tmp: ["{{ outputitem }}"]
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_nummy: "{{ topology_outputs_nummy + tmp }}"

--- a/linchpin/provision/roles/nummy/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/nummy/tasks/teardown_resource_group.yml
@@ -1,0 +1,12 @@
+---
+#- name: debug res_grp
+#  debug:
+#    var: res_grp
+
+- name: "Teardown resource definitions of current group"
+  include: teardown_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item

--- a/linchpin/provision/roles/nummy/vars/duffy_creds.yml
+++ b/linchpin/provision/roles/nummy/vars/duffy_creds.yml
@@ -1,0 +1,3 @@
+---
+key_path: ~/duffy.key
+url_base: http://admin.ci.centos.org:8080

--- a/linchpin/provision/site.yml
+++ b/linchpin/provision/site.yml
@@ -12,6 +12,7 @@
   gather_facts: false
   roles:
     - { role: 'dummy', when: dummy_res_grps | length > 0 }
+    - { role: 'nummy', when: nummy_res_grps | length > 0 }
     - { role: 'openstack', when: os_res_grps | length > 0  }
     - { role: 'aws', when: aws_res_grps | length > 0 }
     - { role: 'gcloud', when: gcloud_res_grps | length > 0 }

--- a/linchpin/tests/InventoryFilters/test_InventoryProviders_pass.py
+++ b/linchpin/tests/InventoryFilters/test_InventoryProviders_pass.py
@@ -26,6 +26,7 @@ def test_get_all_drivers():
         "beaker_res": BeakerInventory,
         "duffy_res": DuffyInventory,
         "dummy_res": DummyInventory,
+        "nummy_res": DummyInventory,
         "gcloud_gce_res": GCloudInventory,
         "libvirt_res": LibvirtInventory,
         "os_server_res": OpenstackInventory,

--- a/linchpin/tests/mockdata/general/topo.json
+++ b/linchpin/tests/mockdata/general/topo.json
@@ -67,6 +67,12 @@
         "hosts": ["web-b3a49a-0.example.net", "web-b3a49a-1.example.net", "web-b3a49a-2.example.net"],
         "dummy_file": "/tmp/dummy.hosts"
     },
+    "nummy_res": [{
+        "failed": false,
+        "changed": true,
+        "hosts": ["web-c3a49a-0.example.net", "web-c3a49a-1.example.net", "web-c3a49a-2.example.net"],
+        "dummy_file": "/tmp/dummy.hosts"
+    },
     {
         "failed": false,
         "changed": true,


### PR DESCRIPTION
Added additional provider nummy clone of dummy provider to test inventory inconsistencies
Note: 
@p3ck @14rcole : Updated version on #780 
Any suggestions appreciated . 
fixes: #777 

Example Pinfile:
```
nummy-topo:
  topology:
    topology_name: "nummy_cluster" # topology name
    resource_groups:
      - resource_group_name: "nummy"
        resource_group_type: "nummy"
        resource_definitions:
          - name: "{{ distro | default('') }}web"
            role: "nummy_node"
            count: 3
          - name: "{{ distro | default('') }}test"
            role: "nummy_node"
            count: 1
  layout:
    inventory_layout:
      vars:
        hostname: __IP__
      hosts:
        example-node:
          count: 3
          host_groups:
            - example
        test-node:
          count: 1
          host_groups:
            - test
```