### PR TITLE
Validate high-level components of topologies

### DIFF
--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -619,7 +619,6 @@ class LinchpinCli(LinchpinAPI):
             (default: topology)
 
         """
-
         folder = self.get_evar('topologies_folder', 'topologies')
         if ftype == 'layout':
             folder = self.get_evar('layouts_folder', 'layouts')
@@ -667,7 +666,7 @@ class LinchpinCli(LinchpinAPI):
 
             provision_data[target] = {}
 
-            if not isinstance(pf[target]['topology'], dict):
+            if isinstance(pf[target]['topology'], str):
                 topology_path = self.find_include(pf[target]["topology"])
                 topology_data = self.parser.process(topology_path,
                                                     data=self.pf_data)

--- a/linchpin/provision/roles/common/files/topo-schema.json
+++ b/linchpin/provision/roles/common/files/topo-schema.json
@@ -1,6 +1,6 @@
 {
     "topology": {
-        "type": "dict",
+        "type": ["dict", "string"],
         "schema": {
             "topology_name": {
                 "type": "string",
@@ -25,7 +25,7 @@
                             "required": true
                         },
                         "credentials": {
-                            "type": "string",
+                            "type": ["string", "dict"],
                             "required": false
                         }
                     }


### PR DESCRIPTION
Topology validation only considers resource groups, which are provider-specific.  This validates the general components of the topology as well