### PR TITLE
Add support for aws_ec2_eip module

### DIFF
--- a/config/Dockerfiles/tests.d/aws/01_aws_ec2_eip
+++ b/config/Dockerfiles/tests.d/aws/01_aws_ec2_eip
@@ -1,0 +1,26 @@
+#!/bin/bash -xe
+
+# Verify the openstack router provisioning
+# distros.exclude: none
+# providers.include: aws
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+
+TARGET="aws-ec2-eip"
+TEMPLATE_DATA="{\"distro\": \"${DISTRO}-\"}"
+TMP_FILE=$(mktemp)
+
+function clean_up {
+    set +e
+    linchpin -w . -v destroy "${TARGET}"
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+pushd docs/source/examples/workspaces/${PROVIDER}
+
+linchpin -w . -v up "${TARGET}"
+
+# cleanup the network
+linchpin -w . -v destroy "${TARGET}"

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -59,7 +59,7 @@ address will be provided since private EC2 DNS hostnames (e.g.
 For instances with both a public and private IP address, the public address is
 always provided instead of the private address, so as to avoid duplicate runs
 of Ansible on the same host via the generated inventory file.
-
+ 
 aws_ec2_key
 -----------
 
@@ -71,8 +71,8 @@ AWS SSH keys can be added using this resource.
 .. note:: This resource will not be torn down during a :term:`destroy`
    action. This is because other resources may depend on the now existing
    resource.
-
-aws_s3
+ 
+aws_s3 
 ------
 
 AWS Simple Storage Service buckets can be provisioned using this resource.
@@ -90,11 +90,19 @@ aws_sg
 AWS Security Groups can be provisioned using this resource.
 
 * :docs1.5:`Topology Example <workspace/topologies/aws-sg-new.yml>`
-* `ec2_group module <http://docs.ansible.com/ansible/latest/ec2_group_module.html>`_
+* `ec2_group module <http://docs.ansible.com/ansible/latest/ec2_group_module.html>`
 
 .. note:: This resource will not be torn down during a :term:`destroy`
    action. This is because other resources may depend on the now existing
    resource.
+  
+aws_ec2_eip
+-----------
+
+AWS EC2 elastic ips can be provisioned using this resource.
+
+* :docs1.5:`Topology Example <workspace/topologies/aws-ec2-eip.yml>`
+* `ec2_eip module <http://docs.ansible.com/ansible/latest/ec2_eip_module.html>`
 
 Additional Dependencies
 -----------------------
@@ -118,7 +126,7 @@ Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~
 
 LinchPin honors the AWS environment variables
-
+ 
 Provisioning
 ~~~~~~~~~~~~
 

--- a/docs/source/examples/workspace/topologies/aws-ec2-eip.yml
+++ b/docs/source/examples/workspace/topologies/aws-ec2-eip.yml
@@ -1,0 +1,11 @@
+---
+topology_name: ec2-new
+resource_groups:
+  - resource_group_name: "aws"
+    resource_group_type: "aws"
+    resource_definitions:
+      - name: demoday
+        role: aws_ec2_eip
+    credentials:
+      filename: aws.key
+      profile: default

--- a/docs/source/examples/workspaces/aws/PinFile
+++ b/docs/source/examples/workspaces/aws/PinFile
@@ -72,3 +72,16 @@ aws-s3-new:
             role: "aws_s3"
             region: "{{ aws_region | default('us-east-1') }}"
 
+aws-ec2-eip:
+  topology:
+    topology_name: ec2-new
+    resource_groups:
+      - resource_group_name: "aws"
+        resource_group_type: "aws"
+        resource_definitions:
+          - name: demoday
+            role: aws_ec2_eip
+            region: us-east-1
+        credentials:
+          filename: aws.key
+          profile: default

--- a/docs/source/examples/workspaces/aws/topologies/aws-ec2-eip.yml
+++ b/docs/source/examples/workspaces/aws/topologies/aws-ec2-eip.yml
@@ -1,0 +1,11 @@
+---
+topology_name: ec2-new
+resource_groups:
+  - resource_group_name: "aws"
+    resource_group_type: "aws"
+    resource_definitions:
+      - name: demoday
+        role: aws_ec2_eip
+    credentials:
+      filename: aws.key
+      profile: default

--- a/linchpin/provision/roles/aws/files/schema.json
+++ b/linchpin/provision/roles/aws/files/schema.json
@@ -85,7 +85,27 @@
                     "region": { "type": "string", "required": true },
                     "template_path": { "type": "string", "required": true }
                 }
-            }]
+            },
+            {
+                "type": "dict",
+                "schema": {
+                    "role": {
+                        "type": "string",
+                        "required": true,
+                        "allowed": ["aws_ec2_eip"] },
+                    "allow_reassociation": { "type": "string", "required": false },
+                    "name": { "type": "string", "required": true },
+                    "device_id": { "type": "string", "required": false },
+                    "ec2_url": { "type": "string", "required": false },
+                    "in_vpc": { "type": "string", "required":false },
+                    "private_ip_address": { "type": "string", "required": false },
+                    "public_ip": { "type": "string", "required": false },
+                    "region": { "type": "string", "required": true },
+                    "release_on_disassociation": { "type": "string", "required": false },
+                    "reuse_existing_ip_allowed": { "type": "string", "required": false }
+                }
+            }
+	    ]
         }
     }
 }

--- a/linchpin/provision/roles/aws/tasks/main.yml
+++ b/linchpin/provision/roles/aws/tasks/main.yml
@@ -5,6 +5,7 @@
     topology_outputs_aws_s3: []
     topology_outputs_aws_ec2_key: []
     topology_outputs_aws_cfn: []
+    topology_outputs_aws_net: []
 
 - name: "Initiating Provisioning of aws resource group"
   include: provision_resource_group.yml res_grp={{ item }}

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_eip.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_eip.yml
@@ -16,11 +16,7 @@
     state: "{{ state }}"
     validate_certs: no
   register: res_def_output
-  #  no_log: "{{ not debug_mode }}"
-
-- name: debug
-  debug:
-    msg: "{{ res_def_output }}"
+  no_log: "{{ not debug_mode }}"
 
 - name: "Append outputitem to topology_outputs"
   set_fact:

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_eip.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_eip.yml
@@ -1,0 +1,32 @@
+---
+- name: "Provisioning AWS_EC2_EIP"
+  ec2_eip:
+    aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
+    aws_secret_key: "{{  auth_var['aws_secret_access_key'] | default(omit) }}"
+    allow_reassociation: "{{ res_def['allow_reassociation'] | default(omit) }}"
+    device_id: "{{ res_def['device_id'] | default(omit) }}"
+    ec2_url: "{{ res_def['ec2_url'] | default(omit) }}"
+    in_vpc: "{{ res_def['in_vpc'] | default(omit) }}"
+    private_ip_address: "{{ res_def['private_ip_address'] | default(omit) }}"
+    public_ip: "{{ res_def['public_ip'] | default(omit) }}"
+    region: "{{ res_def['region'] | default(omit) }}"
+    release_on_disassociation: "{{ res_def['release_on_disassociation'] | default(omit) }}"
+    reuse_existing_ip_allowed: "{{ res_def['reuse_existing_ip_allowed'] | default(omit) }}"
+    security_token: "{{ res_def['security_token'] | default(omit) }}"
+    state: "{{ state }}"
+    validate_certs: no
+  register: res_def_output
+  #  no_log: "{{ not debug_mode }}"
+
+- name: debug
+  debug:
+    msg: "{{ res_def_output }}"
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net + [res_def_output] }}"
+  when: res_def_output['changed'] == true
+
+- name: "Add type to resource"
+  set_fact:
+    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net | add_res_type( 'aws_ec2_eip') }}"

--- a/linchpin/provision/roles/aws/tasks/teardown_aws_ec2_eip.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_aws_ec2_eip.yml
@@ -1,0 +1,11 @@
+---
+- name: "teardown AWS_EC2_EIP"
+  ec2_eip:
+    aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
+    aws_secret_key: "{{  auth_var['aws_secret_access_key'] | default(omit) }}"
+    device_id: "{{ res_def['device_id'] | default(omit) }}"
+    public_ip: "{{ tp_out['public_ip'] | default(omit) }}"
+    region: "{{ res_def['region'] | default(omit) }}"
+    state: "{{ state }}"
+    validate_certs: no
+  register: res_def_output

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -60,12 +60,20 @@
     topo_output_resources: "{{ topo_output_rundb.output[0]['resources'] }}"
   when: not generate_resources
 
+- name: debug
+  debug:
+    msg: "{{ resource_definitions }}"
+
+- name: debug
+  debug:
+    msg: "{{ topo_output_resources }}"
+
 - name: "teardown of ec2 resource definitions of current group"
   include: teardown_aws_ec2.yml res_def={{ res_item.0 }} tp_out={{ res_item.1 }} res_grp_name={{ res_item.2 }}
   when: res_item.0['role'] == "aws_ec2"
   with_nested:
     - "{{ resource_definitions }}"
-    - "{{ topo_output_resources[0]['instances'] }}"
+    - "{{ topo_output_resources[0]['instances'] | default('') }}"
     - ["{{ res_grp['resource_group_name']  }}"]
   loop_control:
     loop_var: res_item
@@ -93,6 +101,16 @@
   when: res_item.0['role'] == "aws_cfn"
   with_nested:
     - "{{ resource_definitions }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: "teardown aws_ec2_eip resource def of current group"
+  include: teardown_aws_ec2_eip.yml res_def={{ res_item.0 }} tp_out={{ res_item.1 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "aws_ec2_eip"
+  with_nested:
+    - "{{ resource_definitions }}"
+    - "{{ topo_output_resources }}"
     - ["{{ res_grp['resource_group_name'] }}"]
   loop_control:
     loop_var: res_item

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -60,14 +60,6 @@
     topo_output_resources: "{{ topo_output_rundb.output[0]['resources'] }}"
   when: not generate_resources
 
-- name: debug
-  debug:
-    msg: "{{ resource_definitions }}"
-
-- name: debug
-  debug:
-    msg: "{{ topo_output_resources }}"
-
 - name: "teardown of ec2 resource definitions of current group"
   include: teardown_aws_ec2.yml res_def={{ res_item.0 }} tp_out={{ res_item.1 }} res_grp_name={{ res_item.2 }}
   when: res_item.0['role'] == "aws_ec2"


### PR DESCRIPTION
$subject
Fixes #825 
Example:
```
aws-ec2-eip:
  topology:
    topology_name: ec2-new
    resource_groups:
      - resource_group_name: "aws"
        resource_group_type: "aws"
        resource_definitions:
          - name: demoday
            role: aws_ec2_eip
            region: us-east-1
        credentials:
          filename: aws.key
          profile: default
```