### PR TITLE
Apply reserve_duration time to /distribution/reservesys task

### DIFF
--- a/linchpin/provision/library/bkr_server.py
+++ b/linchpin/provision/library/bkr_server.py
@@ -116,6 +116,8 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
             else:
                 requested_tasks.append({'arches': [],
                                         'name': '/distribution/reservesys'})
+                if reserve_duration:
+                    task_params.append("RESERVETIME=%s" % reserve_duration)
 
             # Update defaults
             kwargs.update({"suppress_install_task": True})


### PR DESCRIPTION
Currently, when the system is reserved through the task /distribution/reservesys (which is the case by default) reserve_duration has no effect.