### PR TITLE
Reorder shell hook command

### DIFF
--- a/linchpin/hooks/__init__.py
+++ b/linchpin/hooks/__init__.py
@@ -318,5 +318,5 @@ class LinchpinHooks(object):
                     dflt = self.api.get_cfg("hook_flags",
                                             "ignore_failed_hooks")
                     if not dflt:
-                        raise HookError("Error executing hook")
+                        raise HookError("Error executing hook: '{0}'".format(e))
                     self.api.ctx.log_info(str(e))

--- a/linchpin/hooks/action_managers/subprocess_action_manager.py
+++ b/linchpin/hooks/action_managers/subprocess_action_manager.py
@@ -89,9 +89,10 @@ class SubprocessActionManager(ActionManager):
         """
 
         command = action
+        data = ""
         for key in self.target_data:
-            command += " {0}={1} ".format(key, self.target_data[key])
-        return command
+            data += "{0}={1}; ".format(key, self.target_data[key])
+        return data + command
 
 
     def execute(self):


### PR DESCRIPTION
Shell hook context was postfixed to the command, which would cause context to be interpreted as arguments to the command. This prefixes the context so that the context can be used as variables in the command and is not interpreted as a set of arguments

There needs to be an integration test that runs shell hooks (we currently only have ansible hooks).  I'm working on it, but I need to submit another bug fix related to shell hooks first so I'll include it in that.