### PR TITLE
Remove import of update_aws_cfn_outputs.yml

### DIFF
--- a/linchpin/provision/roles/gather_resources/tasks/update_async_outputs.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/update_async_outputs.yml
@@ -19,10 +19,6 @@
   include: update_aws_ec2_outputs.yml
   when: async and 'aws_ec2' in async_types
 
-- name: "aws_cfn: wait and update outputs using jobids"
-  include: update_aws_cfn_outputs.yml
-  when: async and 'aws_cfn' in async_types
-
 - name: "gcloud_gce: wait and update outputs using jobids"
   include: update_gcloud_gce_outputs.yml
   when: async and 'gcloud_gce' in async_types


### PR DESCRIPTION
Remove the above dependency from the playbooks, as the file no longer exists.  Also gets rid of a long warning that prints every time linchpin is run