### PR TITLE
Add support to aws ec2 vpc subnet module

### DIFF
--- a/config/Dockerfiles/tests.d/aws/01_aws_ec2_eip
+++ b/config/Dockerfiles/tests.d/aws/01_aws_ec2_eip
@@ -21,6 +21,3 @@ trap clean_up EXIT SIGHUP SIGINT SIGTERM
 pushd docs/source/examples/workspaces/${PROVIDER}
 
 linchpin -w . -v up "${TARGET}"
-
-# cleanup the network
-linchpin -w . -v destroy "${TARGET}"

--- a/config/Dockerfiles/tests.d/aws/02_aws_ec2_vpc_net
+++ b/config/Dockerfiles/tests.d/aws/02_aws_ec2_vpc_net
@@ -20,5 +20,3 @@ pushd docs/source/examples/workspaces/${PROVIDER}
 
 linchpin -w . -v up "${TARGET}"
 
-# cleanup the network
-linchpin -w . -v destroy "${TARGET}"

--- a/config/Dockerfiles/tests.d/aws/02_aws_ec2_vpc_net
+++ b/config/Dockerfiles/tests.d/aws/02_aws_ec2_vpc_net
@@ -18,7 +18,7 @@ trap clean_up EXIT SIGHUP SIGINT SIGTERM
 
 pushd docs/source/examples/workspaces/${PROVIDER}
 
-linchpin -w . -vvvv up "${TARGET}"
+linchpin -w . -v up "${TARGET}"
 
 # cleanup the network
-linchpin -w . -vvvv destroy "${TARGET}"
+linchpin -w . -v destroy "${TARGET}"

--- a/config/Dockerfiles/tests.d/aws/03_aws_ec2_vpc_subnet
+++ b/config/Dockerfiles/tests.d/aws/03_aws_ec2_vpc_subnet
@@ -1,0 +1,24 @@
+#!/bin/bash -xe
+
+# Verify the aws ec2 vpc subnet provisioning
+# distros.exclude: centos7 fedora27
+# providers.include: aws
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+
+TARGET="aws-ec2-vpc-subnet"
+
+function clean_up {
+    set +e
+    linchpin -w . -v destroy "${TARGET}"
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+pushd docs/source/examples/workspaces/${PROVIDER}
+
+linchpin -w . -vvvv up "${TARGET}"
+
+# cleanup the network
+linchpin -w . -vvvv destroy "${TARGET}"

--- a/config/Dockerfiles/tests.d/aws/03_aws_ec2_vpc_subnet
+++ b/config/Dockerfiles/tests.d/aws/03_aws_ec2_vpc_subnet
@@ -18,7 +18,7 @@ trap clean_up EXIT SIGHUP SIGINT SIGTERM
 
 pushd docs/source/examples/workspaces/${PROVIDER}
 
-linchpin -w . -vvvv up "${TARGET}"
+linchpin -w . validate
 
-# cleanup the network
-linchpin -w . -vvvv destroy "${TARGET}"
+linchpin -w . -v up "${TARGET}"
+

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -83,7 +83,7 @@ AWS Simple Storage Service buckets can be provisioned using this resource.
 .. note:: This resource will not be torn down during a :term:`destroy`
    action. This is because other resources may depend on the now existing
    resource.
-
+ 
 aws_sg
 ------
 
@@ -120,8 +120,15 @@ aws_ec2_vpc_net
 AWS VPC networks can be provisioned using this resource.
 
 * :docs1.5:`Topology Example <workspace/topologies/aws-ec2-vpc-net.yml>`
-* `ec2_vpc_net module <http://docs.ansible.com/ansible/latest/ec2_vpc_net.html
->`_
+* `ec2_vpc_net module <http://docs.ansible.com/ansible/latest/ec2_vpc_net.html>`_
+
+
+aws_ec2_vpc_subnet
+---------------
+
+AWS VPC subnets can be provisioned using this resource.
+* :docs1.5:`Topology Example <workspace/topologies/aws-ec2-vpc-subnet.yml>`
+* `ec2_vpc_subnet module <http://docs.ansible.com/ansible/latest/ec2_vpc_subnet.html>`_
 
 
 Additional Dependencies

--- a/docs/source/aws.rst
+++ b/docs/source/aws.rst
@@ -114,6 +114,16 @@ AWS VPC networks can be provisioned using this resource.
 >`_
 
 
+aws_ec2_vpc_net
+---------------
+
+AWS VPC networks can be provisioned using this resource.
+
+* :docs1.5:`Topology Example <workspace/topologies/aws-ec2-vpc-net.yml>`
+* `ec2_vpc_net module <http://docs.ansible.com/ansible/latest/ec2_vpc_net.html
+>`_
+
+
 Additional Dependencies
 -----------------------
 

--- a/docs/source/examples/workspace/topologies/aws-ec2-vpc-subnet.yml
+++ b/docs/source/examples/workspace/topologies/aws-ec2-vpc-subnet.yml
@@ -1,0 +1,26 @@
+---
+topology:
+  topology_name: ec2vpcsubnetdemo
+  resource_groups:
+    - resource_group_name: "awsvpcsubnet"
+      resource_group_type: "aws"
+      resource_definitions:
+        - name: demovpcnetsubnet
+          role: aws_ec2_vpc_net
+          region: us-east-1
+          cidr_block: 13.0.0.0/16
+          tags:
+            module: aws_ec2_vpc_net
+            this: alsoworks
+          tenancy: dedicated
+        - name: demodayvpcsubnet
+          role: aws_ec2_vpc_subnet
+          region: us-east-1
+          cidr_block: 13.0.1.0/24 
+          tags:
+            module: aws_ec2_vpc_net
+            this: alsoworks
+          tenancy: dedicated
+      credentials:
+        filename: aws.key
+        profile: default

--- a/docs/source/examples/workspaces/aws/PinFile
+++ b/docs/source/examples/workspaces/aws/PinFile
@@ -123,11 +123,11 @@ aws-ec2-vpc-subnet:
           - name: demodayvpcsubnet
             role: aws_ec2_vpc_subnet
             region: us-east-1
-            cidr_block: 13.0.1.0/24 
+            vpc_name: demovpcnetsubnet
+            cidr: 13.0.1.0/24
             tags:
-              module: aws_ec2_vpc_net
+              module: aws_ec2_vpc_subnet
               this: alsoworks
-            tenancy: dedicated
         credentials:
           filename: aws.key
           profile: default

--- a/docs/source/examples/workspaces/aws/PinFile
+++ b/docs/source/examples/workspaces/aws/PinFile
@@ -104,3 +104,30 @@ aws-ec2-vpc-net:
         credentials:
           filename: aws.key
           profile: default
+
+aws-ec2-vpc-subnet:
+  topology:
+    topology_name: ec2vpcsubnetdemo
+    resource_groups:
+      - resource_group_name: "awsvpcsubnet"
+        resource_group_type: "aws"
+        resource_definitions:
+          - name: demovpcnetsubnet
+            role: aws_ec2_vpc_net
+            region: us-east-1
+            cidr_block: 13.0.0.0/16
+            tags:
+              module: aws_ec2_vpc_net
+              this: alsoworks
+            tenancy: dedicated
+          - name: demodayvpcsubnet
+            role: aws_ec2_vpc_subnet
+            region: us-east-1
+            cidr_block: 13.0.1.0/24 
+            tags:
+              module: aws_ec2_vpc_net
+              this: alsoworks
+            tenancy: dedicated
+        credentials:
+          filename: aws.key
+          profile: default

--- a/linchpin/provision/filter_plugins/fetch_attr.py
+++ b/linchpin/provision/filter_plugins/fetch_attr.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-import json
-
 
 def fetch_attr(output_dict, attr, default):
     return output_dict.get(attr, default)
 
 
 class FilterModule(object):
-    ''' A filter to fetch from dict '''
+    ''' A filter to fetch ann attr from dict '''
     def filters(self):
         return {
             'fetch_attr': fetch_attr

--- a/linchpin/provision/filter_plugins/fetch_attr.py
+++ b/linchpin/provision/filter_plugins/fetch_attr.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import json
+
+
+def fetch_attr(output_dict, attr, default):
+    return output_dict.get(attr, default)
+
+
+class FilterModule(object):
+    ''' A filter to fetch from dict '''
+    def filters(self):
+        return {
+            'fetch_attr': fetch_attr
+        }

--- a/linchpin/provision/roles/aws/files/schema.json
+++ b/linchpin/provision/roles/aws/files/schema.json
@@ -125,7 +125,30 @@
 		    "tenancy": { "type": "string", "required": false },
 		    "validate_certs": { "type": "boolean", "required": false }
                 }
-            }]
+            },
+	    {
+                "type": "dict",
+                "schema": {
+                    "role": {
+                        "type": "string",
+                        "required": true,
+                        "allowed": ["aws_ec2_vpc_subnet"] },
+                    "name": { "type": "string", "required": true },
+                    "assign_instances_ipv6": { "type": "boolean", "required": false },
+                    "vpc_name": { "type": "string", "required": false },
+                    "vpc_id": { "type": "string", "required": false },
+                    "az": { "type": "string", "required": false },
+                    "cidr": { "type": "string", "required": false },
+                    "ec2_url": { "type": "string", "required": false },
+                    "ipv6_cidr": { "type": "string", "required": false },
+                    "map_public": { "type": "boolean", "required": false },
+                    "purge_tags": { "type": "boolean", "required": false },
+                    "region": { "type": "string", "required": true },
+                    "tags": { "type": "dict", "required": false },
+                    "validate_certs": { "type": "boolean", "required": false }
+                }
+            }
+	    ]
         }
     }
 }

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_net.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_net.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Provisioning AWS_EC2_VPC_NET"
+- name: "Provision/Teardown AWS_EC2_VPC_NET"
   ec2_vpc_net:
     aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
     aws_secret_key: "{{  auth_var['aws_secret_access_key'] | default(omit) }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
@@ -1,0 +1,41 @@
+---
+- name: "Fetch vpc details when vpc_name is defined"
+  ec2_vpc_net_facts:
+    aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
+    aws_secret_key: "{{  auth_var['aws_secret_access_key'] | default(omit) }}"
+    filters:
+      "tag:Name": "{{ res_def['vpc_name'] }}"
+  register: vpc_net_details
+  when: res_def['vpc_name'] is defined
+
+- name: "Fetch vpc details when vpc_name is defined"
+  set_fact:
+    vpc_id_fetched: "{{ vpc_net_details['vpcs'] | first | default({}) | fetch_attr('vpc_id', '')}}"
+  when: res_def['vpc_name'] is defined
+
+- name: "Provisioning AWS_EC2_VPC_NET"
+  ec2_vpc_subnet:
+    aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
+    aws_secret_key: "{{  auth_var['aws_secret_access_key'] | default(omit) }}"
+    # either vpc_id or vpc_name needs to be mentioned in topology
+    vpc_id: "{{ res_def['vpc_id'] | default(vpc_id_fetched) }}" 
+    az: "{{ res_def['az'] | default(omit) }}"
+    cidr: "{{ res_def['cidr'] | default(omit) }}"
+    ec2_url: "{{ res_def['ec2_url'] | default(omit) }}"
+    ipv6_cidr: "{{ res_def['ipv6_cidr'] | default(omit) }}"
+    map_public: "{{ res_def['map_public'] | default(omit) }}"
+    purge_tags: "{{ res_def['purge_tags'] | default(omit) }}"
+    region: "{{ res_def['region'] }}"
+    tags: "{{ res_def['tags'] | default(omit) }}"
+    validate_certs: "{{ res_def['validate_certs'] | default('no') }}"
+    state: "{{ state }}"
+  register: res_def_output
+
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net + [res_def_output] }}"
+  when: res_def_output['changed'] == true
+
+- name: "Add type to resource"
+  set_fact:
+    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net | add_res_type('aws_ec2_vpc_subnet') }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
@@ -14,6 +14,16 @@
     vpc_id_fetched: "{{ vpc_net_details['vpcs'] | first | default({}) | fetch_attr('vpc_id', '')}}"
   when: res_def['vpc_name'] is defined
 
+- name: "Add tags to subnet"
+  set_fact:
+    subnet_tags: "{{ res_def['tags'] | default({}) }}"
+
+- name: "Add name to subnet"
+  set_fact:
+    subnet_tags: "{{ subnet_tags | combine({item.key: item.value}) }}"
+  with_items:
+    - { key: 'Name', value: "{{ res_def['name'] }}" }
+
 - name: "Provision/teardown AWS_EC2_VPC_SUBNET"
   ec2_vpc_subnet:
     aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
@@ -27,7 +37,7 @@
     map_public: "{{ res_def['map_public'] | default(omit) }}"
     purge_tags: "{{ res_def['purge_tags'] | default(omit) }}"
     region: "{{ res_def['region'] }}"
-    tags: "{{ res_def['tags'] | default(omit) }}"
+    tags: "{{ subnet_tags | default(omit) }}"
     validate_certs: "{{ res_def['validate_certs'] | default('no') }}"
     state: "{{ state }}"
   register: res_def_output

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
@@ -3,6 +3,7 @@
   ec2_vpc_net_facts:
     aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
     aws_secret_key: "{{  auth_var['aws_secret_access_key'] | default(omit) }}"
+    region: "{{ res_def['region'] }}"
     filters:
       "tag:Name": "{{ res_def['vpc_name'] }}"
   register: vpc_net_details

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
@@ -13,7 +13,7 @@
     vpc_id_fetched: "{{ vpc_net_details['vpcs'] | first | default({}) | fetch_attr('vpc_id', '')}}"
   when: res_def['vpc_name'] is defined
 
-- name: "Provisioning AWS_EC2_VPC_NET"
+- name: "Provision/teardown AWS_EC2_VPC_SUBNET"
   ec2_vpc_subnet:
     aws_access_key: "{{ auth_var['aws_access_key_id'] | default(omit) }}"
     aws_secret_key: "{{  auth_var['aws_secret_access_key'] | default(omit) }}"
@@ -34,7 +34,6 @@
 - name: "Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_aws_net: "{{ topology_outputs_aws_net + [res_def_output] }}"
-  when: res_def_output['changed'] == true
 
 - name: "Add type to resource"
   set_fact:

--- a/linchpin/provision/roles/aws/tasks/teardown_aws_ec2_vpc_subnet.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_aws_ec2_vpc_subnet.yml
@@ -1,0 +1,1 @@
+provision_aws_ec2_vpc_subnet.yml

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -106,6 +106,16 @@
   loop_control:
     loop_var: res_item
 
+- name: "teardown aws_ec2_vpc_subnet resource def of current group"
+  include: teardown_aws_ec2_vpc_subnet.yml res_def={{ res_item.0 }} tp_out={{ res_item.1 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "aws_ec2_vpc_subnet"
+  with_nested:
+    - "{{ resource_definitions }}"
+    - "{{ topo_output_resources }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
 - name: "teardown aws_ec2_vpc_net resource def of current group"
   include: teardown_aws_ec2_vpc_net.yml res_def={{ res_item.0 }} tp_out={{ res_item.1 }} res_grp_name={{ res_item.1 }}
   when: res_item.0['role'] == "aws_ec2_vpc_net"


### PR DESCRIPTION
fixes: #911 

example:
```yaml
aws-ec2-vpc-subnet:
  topology:
    topology_name: ec2vpcsubnetdemo
    resource_groups:
      - resource_group_name: "awsvpcsubnet"
        resource_group_type: "aws"
        resource_definitions:
          - name: demovpcnetsubnet
            role: aws_ec2_vpc_net
            region: us-east-1
            cidr_block: 13.0.0.0/16
            tags:
              module: aws_ec2_vpc_net
              this: alsoworks
            tenancy: dedicated
          - name: demodayvpcsubnet
            role: aws_ec2_vpc_subnet
            region: us-east-1
            cidr_block: 13.0.1.0/24 
            tags:
              module: aws_ec2_vpc_net
              this: alsoworks
            tenancy: dedicated
        credentials:
          filename: aws.key
          profile: default
```

To be merged after #894 #907  to avoid merge conflicts
