### PR TITLE
Add integration test to check for correct number of hosts in beaker

### DIFF
--- a/config/Dockerfiles/tests.d/beaker/03_beaker_inventory
+++ b/config/Dockerfiles/tests.d/beaker/03_beaker_inventory
@@ -1,0 +1,44 @@
+#!/bin/bash -xe
+
+# Verify distro selection in beaker
+# distros.exclude: none
+# providers.include: beaker
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+
+TARGET="beaker-multiple"
+TMP_FILE=$(mktemp)
+CONFIG_FILE="../linchpin.conf"
+
+function clean_up {
+    set +e
+    linchpin -w . -v -c ${CONFIG_FILE} destroy "${TARGET}"
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+pushd docs/source/examples/workspaces/${PROVIDER}
+linchpin -w . -v -c ${CONFIG_FILE} up --inventory-format json "${TARGET}" 2>&1 | tee -a ${TMP_FILE}
+
+RC0=${?}
+
+# check inventory to make sure that we have the right number of lines
+sed -i '$ d' ${TMP_FILE}
+uhash=$(tail -n 1 ${TMP_FILE} | awk '{ print $3 }' )
+echo ${uhash}
+
+INVENTORY_FILE="./inventories/${TARGET}-${uhash}.inventory"
+ls -l ./inventories
+ls -l ${INVENTORY_FILE}
+
+RC1=${?}
+
+# expect two hosts in 'all' section of json
+LINES=$(cat ${INVENTORY_FILE} | jq .all.hosts[] | wc -l)
+
+if [ ${RC0} -eq 0 ] && [ ${RC1} -eq 0 ] && [ ${LINES} -eq 2 ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/docs/source/examples/workspaces/beaker/PinFile
+++ b/docs/source/examples/workspaces/beaker/PinFile
@@ -53,3 +53,39 @@ beaker-family:
                 variant: Server
                 hostrequires:
                   - rawxml: '<key_value key="model" op="=" value="KVM"/>'
+
+beaker-multiple:
+  topology:
+    topology_name: "beaker-multiple"
+    resource_groups:
+      - resource_group_name: "beaker-multiple"
+        resource_group_type: beaker
+        resource_definitions:
+          - role: bkr_server
+            # option to set job whiteboard message
+            whiteboard: Provisioned with linchpin
+            # options to configure amount of time spent polling beaker:
+            # 60 attempts with 60 seconds wait time between them,
+            # provisioning timeout is roughly 3600 seconds
+            max_attempts: 240
+            attempt_wait_time: 60
+            # option to set cancellation message if linchpin cancels provisioning
+            cancel_message: Job cancelled on account of rain
+            recipesets:
+              - distro: RHEL-7.5
+                name: rheltest
+                arch: x86_64
+                variant: Server
+                count: 2
+                name: rhel75
+                hostrequires:
+                  - rawxml: '<key_value key="model" op="=" value="KVM"/>'
+  layout:
+    inventory_layout:
+      vars:
+        hostname: __IP__
+      hosts:
+        bkr-node:
+          count: 2
+          host_groups:
+            - bkr-multiple


### PR DESCRIPTION
Tests for this will fail until #926 is merged.  This is the integration test corresponding to #909.  I can modify it so that it passes without #926 if necessary but it'll be sloppy