### PR TITLE
Nicely cancel Beaker jobs on error

### DIFF
--- a/config/Dockerfiles/JenkinsfileContainer
+++ b/config/Dockerfiles/JenkinsfileContainer
@@ -75,6 +75,7 @@ p_providers = ['__RELEASE__':
                'beaker':
                 ["^linchpin/provision/roles/beaker/.*",
                  "^linchpin/provision/beaker.yml",
+                 "^linchpin/provision/library/bkr.*py",
                  "^linchpin/InventoryFilters/BeakerInventory.py",
                  "^linchpin/InventoryFilters/GenericInventory.py",
                  "^linchpin/InventoryFilters/.*InventoryFormatter.py",


### PR DESCRIPTION
Currently the Beaker job with multiple reservation recipes,
in case at least one return Canceled/Aborted/Warn status then
Linchpin exits with error. But the Beaker job is not canceled,
as a result the remaining recipes may end up reserving resources
which likely won't be used.

Changed the bkr_info role to cancel the job if any recipe
return Canceled/Aborted/Warn status.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>