### PR TITLE
Fix os_server async provisioning

### DIFF
--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_os_server.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_os_server.yml
@@ -44,3 +44,11 @@
 - name: "Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server + [job_result_present] }}"
+
+- name: "Transform outputs to match the distiller format"
+  set_fact:
+    res_def_output: "{{ res_def_output | transform_os_server_output }}"
+
+- name: "Add type to resource"
+  set_fact:
+    topology_outputs_os_server: "{{ topology_outputs_os_server | add_res_type('os_server_res') }}"

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -162,12 +162,6 @@
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
 
-- name: "Transform outputs to match the distiller format"
-  set_fact:
-    res_def_output: "{{ res_def_output | transform_os_server_output }}"
-  when:
-    - async
-
 - name: "Async:: Append outputitem to topology_outputs"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server }} + [ {{ res_def_output }} ]"
@@ -178,3 +172,5 @@
 - name: "Add type to resource"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server | add_res_type('os_server_res') }}"
+  when:
+    - not async


### PR DESCRIPTION
os_server async provisioning retained the wrong data in the resources section of the rundb, and thus instances could not be destroyed.  Also, inventories could not be written correctly
fixes #932  