### PR TITLE
Intro ssh_key_file property on Beaker's topology

### DIFF
--- a/docs/source/beaker.rst
+++ b/docs/source/beaker.rst
@@ -39,6 +39,9 @@ role definition, the following options are available.
 +-------------------+------------+----------+-------------------+-----------------+
 | attempt_wait_time | false      | integer  | attempt_wait_time |                 |
 +-------------------+------------+----------+-------------------+-----------------+
+| ssh_keys_path     | false      | string   | ssh_keys_path     | Credentials     |
+|                   |            |          |                   | directory       |
++-------------------+------------+----------+-------------------+-----------------+
 | recipesets        | false      | string   | recipesets        | see table below |
 +-------------------+------------+----------+-------------------+-----------------+
 
@@ -105,6 +108,8 @@ describes the available recipesets options.
 | ks_append           | false      | list     | list of strings                         |
 +---------------------+------------+----------+-----------------------------------------+
 | ssh_key             | false      | list     | list of strings                         |
++---------------------+------------+----------+-----------------------------------------+
+| ssh_key_file        | false      | list     | list of file names                      |
 +---------------------+------------+----------+-----------------------------------------+
 | kickstart           | false      | string   | absolute path to a kickstart template   |
 +---------------------+------------+----------+-----------------------------------------+

--- a/linchpin/provision/roles/beaker/files/schema.json
+++ b/linchpin/provision/roles/beaker/files/schema.json
@@ -14,6 +14,7 @@
                 "cancel_message": { "type": "string", "required": false },
                 "max_attempts": { "type": "integer", "required": false },
                 "attempt_wait_time": { "type": "integer", "required": false },
+		"ssh_keys_path": {"type": "string", "required": false },
                 "recipesets": {
                     "type": "list",
                     "schema": {
@@ -118,6 +119,11 @@
                                     "required": false,
                                     "schema": { "type": "string", "required": true }
                                 },
+				"ssh_key_file": {
+				    "type": "list",
+				    "required": false,
+				    "schema": {"type": "string", "required": true}
+				},
                                 "ks_append": {
                                     "type": "list",
                                     "required": false,

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set default ssh keys path
+  set_fact:
+    default_ssh_keys_path: "{{ creds_path | default(default_credentials_path) }}"
+
 - name: Provision beaker systems
   block:
   - name: "provision beaker systems"
@@ -12,6 +16,7 @@
       cancel_message: "{{ res.cancel_message | default(omit) }}"
       max_attempts: "{{ res.max_attempts | default(omit) }}"
       attempt_wait_time: "{{ attempt_wait_time | default(omit) }}"
+      ssh_keys_path: "{{ res.ssh_keys_path | default(default_ssh_keys_path) }}"
     with_items: "{{ res_defs['resource_definitions'] }}"
     # loop over res_defs even though there should be only one for beaker
     loop_control:


### PR DESCRIPTION
Linchpin provides the ssh_key property which allows to set (statically)
ssh key's content. However one may want to use a dynamically generated
key file, and that's what is solved on this change.

It was introduced the ssh_key_file property for recipesets, that you can set
a list of file names from where read the ssh public key. For example:
... snip ...
recipesets:
  - family: RedHatEnterpriseLinux8
    name: rhel80-x86_64
    arch: x86_64
    variant: BaseOS
    count: 1
    ssh_key_file:
      - ssh_key.pub
    hostrequires:
.. snip ..

The key files should be stored on the Linchpin's credentials directory, or
on alternative location and the ssh_keys_path property for resource_definitions
should be set accordingly.