### PR TITLE
Enable forward_mode for libvirt network

### DIFF
--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -118,7 +118,8 @@
                     "dhcp_start": { "type": "string", "required": false },
                     "dhcp_end": { "type": "string", "required": false },
                     "bridge": { "type": "string", "required": false },
-                    "domain": { "type": "string", "required": false }
+                    "domain": { "type": "string", "required": false },
+                    "forward_mode": { "type": "string", "required": false }
                 }
             },
             {


### PR DESCRIPTION
Though we have support in jinja network template the forward_mode is not enabled in topology
fixes: #941 