### PR TITLE
Updated schema, template to support netmask in libvirt network provisioning

### DIFF
--- a/config/Dockerfiles/tests.d/libvirt/03_libvirt-network
+++ b/config/Dockerfiles/tests.d/libvirt/03_libvirt-network
@@ -1,0 +1,35 @@
+#!/bin/bash -xe
+
+# Verify basic provisioning for all supplied providers
+# distros.exclude: fedora28 centos7 fedora28
+# providers.include: libvirt
+# providers.exclude: none
+
+## NOTE: This is a temporary test to run libvirt tests until we fix
+## the networking race condition. Tests will only run on centos7.
+
+set -o pipefail
+
+DISTRO=${1}
+PROVIDER=${2}
+
+TEST_NAME="${DISTRO}/${PROVIDER}/03_libvirt-network"
+DESCRIPTION="Test ${PROVIDER} provider with network provisioning"
+
+echo "Test Name: ${TEST_NAME}"
+echo "${DESCRIPTION}"
+
+TARGET="libvirt-network"
+
+pushd docs/source/examples/workspaces/${PROVIDER}
+
+function clean_up {
+    set +e
+    linchpin -w . -v destroy ${TARGET}
+    # remove output file used to gen uhash if it exists
+    rm storage.txt || true
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+linchpin -w . -v up ${TARGET}
+

--- a/docs/source/examples/workspaces/libvirt/PinFile
+++ b/docs/source/examples/workspaces/libvirt/PinFile
@@ -48,6 +48,7 @@ libvirt-network:
             uri: qemu:///system
             ip: 192.168.74.100
             dhcp_start: 192.168.74.101
+            forward_mode: nat
             dhcp_end: 192.168.74.112
             domain: linchpin.net
 

--- a/docs/source/examples/workspaces/libvirt/PinFile
+++ b/docs/source/examples/workspaces/libvirt/PinFile
@@ -51,6 +51,7 @@ libvirt-network:
             forward_mode: nat
             dhcp_end: 192.168.74.112
             domain: linchpin.net
+            netmask: 255.255.255.0
 
 libvirt-storage:
   topology:

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -119,7 +119,8 @@
                     "dhcp_end": { "type": "string", "required": false },
                     "bridge": { "type": "string", "required": false },
                     "domain": { "type": "string", "required": false },
-                    "forward_mode": { "type": "string", "required": false }
+                    "forward_mode": { "type": "string", "required": false },
+                    "netmask": { "type": "string", "required": false }
                 }
             },
             {

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -120,7 +120,8 @@
                     "bridge": { "type": "string", "required": false },
                     "domain": { "type": "string", "required": false },
                     "forward_mode": { "type": "string", "required": false },
-                    "netmask": { "type": "string", "required": false }
+                    "netmask": { "type": "string", "required": false },
+                    "forward_dev": { "type": "string", "required": false }
                 }
             },
             {

--- a/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
+++ b/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
@@ -3,7 +3,7 @@
   {% if res_def['bridge'] is defined %}
   <bridge name="{{ res_def['bridge'] }}" stp='on' delay='0'/>
   {% endif %}
-  <forward mode="{{ res_def['forward_mode'] | default('nat') }}"{% if res_def['forward_dev'] is defined %} dev="{{ res_def['forward_dev'] }}"{% endif %}/>
+<forward mode="{{ res_def['forward_mode'] | default('nat') }}"{% if res_def['forward_dev'] is defined %} dev="{{ res_def['forward_dev'] }}"{% endif %}/>
 {% if res_def['domain'] is defined %}
   <domain name="{{ res_def['domain'] }}" localOnly="yes"/>
 {% endif %}

--- a/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
+++ b/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
@@ -1,15 +1,13 @@
 <network ipv6='yes'>
-  <name>{{ res_def['res_name'] | default(res_def['name'])  }}</name>
+  <name>{{ res_def['res_name'] | default(res_def['name']) }}</name>
   {% if res_def['bridge'] is defined %}
   <bridge name="{{ res_def['bridge'] }}" stp='on' delay='0'/>
-  {% endif %}/>
-  <forward mode="{{ res_def['forward_mode'] | default('nat') }}"
-{% if res_def['forward_dev'] is defined %}
-     dev="{{ res_def['forward_dev'] }}"{% endif %}/>
+  {% endif %}
+  <forward mode="{{ res_def['forward_mode'] | default('nat') }}"{% if res_def['forward_dev'] is defined %} dev="{{ res_def['forward_dev'] }}"{% endif %}/>
 {% if res_def['domain'] is defined %}
   <domain name="{{ res_def['domain'] }}" localOnly="yes"/>
 {% endif %}
-  <ip address="{{ res_def['ip'] }}">
+  <ip address="{{ res_def['ip'] }}" {% if res_def['netmask'] is defined %} netmask="{{ res_def['netmask'] }}" {% endif %}>
 {% if res_def['dhcp_start'] is defined %}
     <dhcp>
       <range start="{{ res_def['dhcp_start'] }}" end="{{ res_def['dhcp_end'] }}"/>


### PR DESCRIPTION
$subject
fixes #939 

Test template output:
```xml
<network ipv6='yes'>
  <name>linchpin-centos74</name>
  />
  <forward mode="nat"/>
  <domain name="linchpin.net" localOnly="yes"/>
  <ip address="192.168.74.100"  netmask="255.255.255.0" >
    <dhcp>
      <range start="192.168.74.101" end="192.168.74.112"/>
    </dhcp>
  </ip>
</network>
```