### PR TITLE
Allow creating bridge libvirt networks

### DIFF
--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -113,7 +113,7 @@
                         "allowed": ["libvirt_network"] },
                     "name": { "type": "string", "required": true },
                     "uri": { "type": "string", "required": false },
-                    "ip": { "type": "string", "required": true },
+                    "ip": { "type": "string", "required": false },
                     "prefix": { "type": "string", "required": false },
                     "dhcp_start": { "type": "string", "required": false },
                     "dhcp_end": { "type": "string", "required": false },

--- a/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
+++ b/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
@@ -37,10 +37,13 @@
 {% endif %}
 </dns>
   {% endif %}
+{% if res_def['forward_mode'] is defined %}
 <forward mode="{{ res_def['forward_mode'] | default('nat') }}"{% if res_def['forward_dev'] is defined %} dev="{{ res_def['forward_dev'] }}"{% endif %}/>
+{% endif %}
 {% if res_def['domain'] is defined %}
   <domain name="{{ res_def['domain'] }}" localOnly="yes"/>
 {% endif %}
+{% if res_def['ip'] is defined %}
   <ip address="{{ res_def['ip'] }}" {% if res_def['netmask'] is defined %} netmask="{{ res_def['netmask'] }}" {% endif %}>
 {% if res_def['dhcp_start'] is defined %}
     <dhcp>
@@ -48,4 +51,5 @@
     </dhcp>
 {% endif %}
   </ip>
+{% endif %}
 </network>


### PR DESCRIPTION
- do not require the ip attribute to be set
- do not required forward mode attribute to be set

Fixes #969