### PR TITLE
Allow attaching multiple disks to multiple libvirt VMs

### DIFF
--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -303,10 +303,11 @@
 - name: Attempt and graceful roll back demo
   block:
   - name: "Create disk if it does not exist"
-    command: "qemu-img create -f qcow2 {{ libvirt_image_path }}/{{ libvirt_resource_name }}-{{ definition[1]['name'] }}.img {{ definition[1]['size'] }}{{ definition[1]['units'] }}"
+    command: "qemu-img create -f qcow2 {{ libvirt_image_path }}/{{ libvirt_resource_name }}_{{ definition[2] }}_{{ definition[1]['name'] }}.qcow2 {{ definition[1]['size'] }}{{ definition[1]['units'] }}"
     with_nested:
     - ["{{ res_def['name'] }}"]
-    - ["{{ res_def['storage'] }}"]
+    - "{{ res_def['storage'] }}"
+    - "{{ res_count }}"
     loop_control:
       loop_var: definition
     when:

--- a/linchpin/provision/roles/libvirt/templates/libvirt_node.xml.j2
+++ b/linchpin/provision/roles/libvirt/templates/libvirt_node.xml.j2
@@ -44,7 +44,7 @@
         <disk type='file' device='disk'>
           <driver name='qemu' type='qcow2'/>
           {% if storage_def['source'] is not defined %}
-            <source file='/var/lib/libvirt/images/linchpin/{{ libvirt_resource_name }}-{{ storage_def['name'] }}.img' />
+            <source file='/var/lib/libvirt/images/linchpin/{{ libvirt_resource_name }}_{{ definition[2] }}_{{ storage_def['name'] }}.qcow2' />
           {% elif storage_def['source']['file'] is defined %}
             {% if storage_def['source']['file'].startswith('/') %}
               <source file='{{ storage_def['source']['file'] }}'/>
@@ -63,7 +63,7 @@
             {% endif %}
           {% endif %}
           {% if storage_def['disk_type'] is not defined or storage_def['disk_type'] == 'virtio_blk' %}
-            target dev='{{ storage_def['device'] | default('vda') }}' bus='virtio' />
+            <target dev='{{ storage_def['device'] | default('vda') }}' bus='virtio' />
           {% else %}
             <target dev='{{ storage_def['device'] | default('vda') }}' bus='scsi' />
             <address type='drive' controller='0' />


### PR DESCRIPTION
This change implements the following changes that allow creating multiple
libvirt VMs with multiple disks attached to each:

 - create disks via qemu-img for each VM
 - create disks via qemu-img for each item in the storage attribute
 - change the disk file name to reflect the qcow2 format
 - correct typo in the target tag in libvirt_node.xml.j2

Fixes #974