### PR TITLE
Upgrade to JMS Messaging 1.1.5

### DIFF
--- a/config/s2i/jenkins/master/configuration/jobs/ci-linchpin-messageBus-merge/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/ci-linchpin-messageBus-merge/config.xml
@@ -49,7 +49,7 @@
     </hudson.model.ParametersDefinitionProperty>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers>
-        <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.3">
+        <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.5">
            <spec/>
            <noSquash>true</noSquash>
            <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">

--- a/config/s2i/jenkins/master/configuration/jobs/ci-linchpin-messageBus-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/ci-linchpin-messageBus-trigger/config.xml
@@ -49,7 +49,7 @@
     </hudson.model.ParametersDefinitionProperty>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers>
-        <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.3">
+        <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.5">
            <spec/>
            <noSquash>true</noSquash>
            <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">

--- a/config/s2i/jenkins/master/plugins.txt
+++ b/config/s2i/jenkins/master/plugins.txt
@@ -54,7 +54,7 @@ ircbot:2.30
 jackson2-api:2.8.11.1
 javadoc:1.4
 jira:2.5
-jms-messaging:1.1.3
+jms-messaging:1.1.5
 job-dsl:1.68
 jquery-detached:1.2.1
 jsch:0.1.54.2


### PR DESCRIPTION
jms-messaging-1.1.5 fixes a bug where Jenkins restarts removed the fedmsg override topic from the triggers

Signed-off-by: Johnny Bieren <jbieren@redhat.com>