### PR TITLE
Libvirt optional DHCP for node network

### DIFF
--- a/docs/source/examples/workspaces/libvirt-no-dhcp/PinFile
+++ b/docs/source/examples/workspaces/libvirt-no-dhcp/PinFile
@@ -1,0 +1,44 @@
+---
+cfgs:
+  libvirt:
+    __IP__: name
+    __ADDRESS__: ip
+
+
+libvirt-no-dhcp:
+  topology:
+    topology_name: libvirt-no-dhcp
+    resource_groups:
+      - resource_group_name: libvirt-no-dhcp
+        resource_group_type: libvirt
+        resource_definitions:
+          - name: no-dhcp-net
+            role: libvirt_network
+            uri: qemu:///system
+            bridge: no-dhcp
+            delete_on_destroy: yes
+          - role: libvirt_node
+            name: no-dhcp-node
+            uri: qemu:///system
+            count: 1
+            image_src: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+            memory: 4086
+            vcpus: 1
+            arch: x86_64
+            ssh_key: id_rsa
+            additional_storage: 5G
+            networks:
+              - name: default
+              - name: no-dhcp-net
+                dhcp: false
+  layout:
+    inventory_layout:
+      vars:
+        hostname: __IP__
+        ansible_ssh_host: __ADDRESS__
+        ansible_ssh_user: centos
+      hosts:
+        example:
+          count: 1
+          host_groups:
+            - examples

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -65,6 +65,7 @@
                             "schema": {
                                 "name": { "type": "string", "required": true },
                                 "ip": { "type": "string", "required": false },
+                                "dhcp": { "type": "boolean", "required": false },
                                 "mac": { "type": "string", "required": false }
                             }
                         }
@@ -172,8 +173,8 @@
                                     "type": "dict",
                                     "schema": {
                                         "ip": { "type": "string", "required": false },
-                                        "hostnames": { 
-					    "type": "list", 
+                                        "hostnames": {
+					    "type": "list",
 					    "required": true
 					}
                                     }

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -350,15 +350,13 @@
     xpath: "//interface[@type='network']/source[@network='{{net.name}}']/../mac"
     content: attribute
   register: mac_addresses
+  ignore_errors: yes
   loop_control:
     loop_var: net
   with_items: "{{ res_def['networks'] }}"
   when:
     - res_def['networks'] is defined
     - net.dhcp is not defined or net.dhcp == true
-
-- debug:
-    var: mac_addresses.results
 
 - set_fact:
     mac_addresses: "{{ mac_addresses.results[0].matches | default([]) }}"
@@ -445,4 +443,4 @@
     loop_var: data
   when:
     - extract_ip_address_result is not defined
-    - extract_ip_address_result is not defined
+    - extract_ip_address_result_remote is not defined

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -350,7 +350,7 @@
 
 - xml:
     xmlstring: "{{ node_data.results[net.1].get_xml }}"
-    xpath: "//interface[@type='network']/source[@network='{{net.0.name}}']/../mac"
+    xpath: "//interface[@type='network' and ./source[@network='{{net.0.name}}']]/mac | //interface[@type='bridge' and ./source[@bridge='virbr0']]/mac"
     content: attribute
   register: mac_addresses
   ignore_errors: yes

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -2,6 +2,9 @@
       res_count: '{{ (res_count | default([])) + [item | int] }}'
   with_sequence: "start=0 end={{ res_def['count'] | default(1) |int - 1 }}"
 
+- set_fact:
+    res_count: "{{ res_count | unique }}"
+
 - name: "does node already exist"
   virt:
     name: "{{ nodeinfo[0] }}_{{ nodeinfo[1] }}"
@@ -346,26 +349,32 @@
   register: node_data
 
 - xml:
-    xmlstring: "{{ node_data.results[0].get_xml }}"
-    xpath: "//interface[@type='network']/source[@network='{{net.name}}']/../mac"
+    xmlstring: "{{ node_data.results[net.1].get_xml }}"
+    xpath: "//interface[@type='network']/source[@network='{{net.0.name}}']/../mac"
     content: attribute
   register: mac_addresses
   ignore_errors: yes
   loop_control:
     loop_var: net
-  with_items: "{{ res_def['networks'] }}"
+  loop: "{{ res_def['networks']|product(res_count)|list }}"
   when:
     - res_def['networks'] is defined
     - net.dhcp is not defined or net.dhcp == true
 
 - set_fact:
-    mac_addresses: "{{ mac_addresses.results[0].matches | default([]) }}"
+    macs: []
+
+- set_fact:
+    macs: "{{ macs + [mac_addresses.results[node.1].matches[node.0].mac.address] }}"
+  loop: "{{ range(0,res_def['networks']|length,1)|list|product(res_count)|list }}"
+  loop_control:
+    loop_var: node
 
 - name: "mac_and_ip | wait up to 5 mins for dhcp ip address"
   shell: |
-    /usr/sbin/arp -an | grep -F {{ mac.mac.address }} | cut -f 2 -d "(" | cut -f 1 -d ")"
+    /usr/sbin/arp -an | grep -F {{ mac }} | cut -f 2 -d "(" | cut -f 1 -d ")"
   with_items:
-    - "{{ mac_addresses }}"
+    - "{{ macs }}"
   loop_control:
     loop_var: mac
   register: extract_ip_address_result
@@ -376,9 +385,9 @@
 
 - name: "mac_and_ip | wait up to 5 mins for dhcp ip address"
   shell: |
-    /usr/sbin/arp -an | grep -F {{ mac.mac.address }} | cut -f 2 -d "(" | cut -f 1 -d ")"
+    /usr/sbin/arp -an | grep -F {{ mac }} | cut -f 2 -d "(" | cut -f 1 -d ")"
   with_items:
-    - "{{ mac_address.results[0].matches }}"
+    - "{{ macs }}"
   loop_control:
     loop_var: mac
   register: extract_ip_address_result_remote
@@ -400,33 +409,23 @@
   ignore_errors: yes
   when: node_exists['failed'] is defined and virt_type == "cloud-init"
 
-- name: "Set Output name"
+- name: "Append ip_addresses and node_data to topology_outputs_libvirt_nodes"
   set_fact:
-      output_name: '{{ output_name|default([]) + [data[0]+"_"+data[1]|string] }}'
+    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [ { 'name': data[0]+'_'+data[1]|string, 'ip': extract_ip_address_result.results[data[1]].stdout, 'resource_type': 'libvirt_res' }] }}"
   with_nested:
     - "{{ libvirt_resource_name }}"
     - "{{ res_count }}"
   loop_control:
     loop_var: data
-
-- name: "Append ip_addresses and node_data to topology_outputs_libvirt_nodes"
-  set_fact:
-    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [ { 'name': data[0], 'ip': extract_ip_address_result.results[data[1]].stdout, 'resource_type': 'libvirt_res' }] }}"
-  with_nested:
-    - "{{ output_name }}"
-    - "{{ res_count }}"
-  loop_control:
-    loop_var: data
   when:
     - not async and uri_hostname == 'localhost'
-    - data[0][-1]|int == data[1]|int
     - extract_ip_address_result is defined and extract_ip_address_result.changed == true
 
 - name: "remote: Append ip_addresses and node_data to topology_outputs_libvirt_nodes"
   set_fact:
-    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [ { 'name': data[0], 'ip': extract_ip_address_result_remote.results[data[1]].stdout, 'resource_type': 'libvirt_res' }] }}"
+    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [ { 'name': data[0]+'_'+data[1]|string, 'ip': extract_ip_address_result_remote.results[data[1]].stdout, 'resource_type': 'libvirt_res' }] }}"
   with_nested:
-    - "{{ output_name }}"
+    - "{{ libvirt_resource_name }}"
     - "{{ res_count }}"
   loop_control:
     loop_var: data
@@ -436,9 +435,10 @@
 
 - name: "Append to topology_outputs_libvirt_nodes"
   set_fact:
-    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [ { 'name': data[0], 'resource_type': 'libvirt_res' }] }}"
+    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [ { 'name': data[0]+'_'+data[1]|string, 'resource_type': 'libvirt_res' }] }}"
   with_nested:
-    - "{{ output_name }}"
+    - "{{ libvirt_resource_name }}"
+    - "{{ res_count }}"
   loop_control:
     loop_var: data
   when:

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -331,24 +331,43 @@
     loop_var: definition
   ignore_errors: no
 
-- name: "mac_and_ip | extract mac address"
-  shell: >
-    virsh -c {{ node[1] }} dumpxml {{ node[0] }}_{{ node[2] }}
-    | grep 'mac address'
-    | cut -f 2 -d "'"
+- name: "dump node data"
+  virt:
+    name: "{{ data[0] }}_{{ data[2] }}"
+    command: get_xml
+    uri: "{{ data[1] }}"
   with_nested:
     - ["{{ libvirt_resource_name }}"]
     - ["{{ res_def['uri'] | default('qemu:///system') }}"]
     - "{{ res_count }}"
   loop_control:
-    loop_var: node
-  register: extract_mac_address_result
+    loop_var: data
+  when: not async
+  register: node_data
+
+- xml:
+    xmlstring: "{{ node_data.results[0].get_xml }}"
+    xpath: "//interface[@type='network']/source[@network='{{net.name}}']/../mac"
+    content: attribute
+  register: mac_addresses
+  loop_control:
+    loop_var: net
+  with_items: "{{ res_def['networks'] }}"
+  when:
+    - res_def['networks'] is defined
+    - net.dhcp is not defined or net.dhcp == true
+
+- debug:
+    var: mac_addresses.results
+
+- set_fact:
+    mac_addresses: "{{ mac_addresses.results[0].matches | default([]) }}"
 
 - name: "mac_and_ip | wait up to 5 mins for dhcp ip address"
   shell: |
-    /usr/sbin/arp -an | grep -F {{ extract_mac_address_result.results[mac].stdout_lines[0] }} | cut -f 2 -d "(" | cut -f 1 -d ")"
+    /usr/sbin/arp -an | grep -F {{ mac.mac.address }} | cut -f 2 -d "(" | cut -f 1 -d ")"
   with_items:
-    - "{{ res_count }}"
+    - "{{ mac_addresses }}"
   loop_control:
     loop_var: mac
   register: extract_ip_address_result
@@ -359,9 +378,9 @@
 
 - name: "mac_and_ip | wait up to 5 mins for dhcp ip address"
   shell: |
-    /usr/sbin/arp -an | grep -F {{ extract_mac_address_result.results[mac].stdout_lines[0] }} | cut -f 2 -d "(" | cut -f 1 -d ")"
+    /usr/sbin/arp -an | grep -F {{ mac.mac.address }} | cut -f 2 -d "(" | cut -f 1 -d ")"
   with_items:
-    - "{{ res_count }}"
+    - "{{ mac_address.results[0].matches }}"
   loop_control:
     loop_var: mac
   register: extract_ip_address_result_remote
@@ -383,20 +402,6 @@
   ignore_errors: yes
   when: node_exists['failed'] is defined and virt_type == "cloud-init"
 
-- name: "dump node data"
-  virt:
-    name: "{{ data[0] }}_{{ data[2] }}"
-    command: get_xml
-    uri: "{{ data[1] }}"
-  with_nested:
-    - ["{{ libvirt_resource_name }}"]
-    - ["{{ res_def['uri'] | default('qemu:///system') }}"]
-    - "{{ res_count }}"
-  loop_control:
-    loop_var: data
-  when: not async
-  register: node_data
-
 - name: "Set Output name"
   set_fact:
       output_name: '{{ output_name|default([]) + [data[0]+"_"+data[1]|string] }}'
@@ -417,6 +422,7 @@
   when:
     - not async and uri_hostname == 'localhost'
     - data[0][-1]|int == data[1]|int
+    - extract_ip_address_result is defined and extract_ip_address_result.changed == true
 
 - name: "remote: Append ip_addresses and node_data to topology_outputs_libvirt_nodes"
   set_fact:
@@ -426,4 +432,17 @@
     - "{{ res_count }}"
   loop_control:
     loop_var: data
-  when: not async and uri_hostname != 'localhost'
+  when:
+    - not async and uri_hostname != 'localhost'
+    - extract_ip_address_result_remote is defined and extract_ip_address_result.changed == true
+
+- name: "Append to topology_outputs_libvirt_nodes"
+  set_fact:
+    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [ { 'name': data[0], 'resource_type': 'libvirt_res' }] }}"
+  with_nested:
+    - "{{ output_name }}"
+  loop_control:
+    loop_var: data
+  when:
+    - extract_ip_address_result is not defined
+    - extract_ip_address_result is not defined

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -432,7 +432,7 @@
     loop_var: data
   when:
     - not async and uri_hostname != 'localhost'
-    - extract_ip_address_result_remote is defined and extract_ip_address_result.changed == true
+    - extract_ip_address_result_remote is defined and extract_ip_address_result_remote.changed == true
 
 - name: "Append to topology_outputs_libvirt_nodes"
   set_fact:


### PR DESCRIPTION
The new option allows user to decide if node's network should provide IP automatically and Linchpin will wait for that to happen. Otherwise linchpin will skip that network. If there is no network with DHCP enabled, the inventory will be empty.

Fixes #980 