### PR TITLE
cli: improve the setup subcommand documentation

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -12,6 +12,7 @@ This document covers the ``linchpin`` Command Line Interface (CLI) in detail. Ea
    linchpin_journal
    linchpin_fetch
    linchpin_validate
+   linchpin_setup
 
 
 

--- a/docs/source/includes/setup.rst
+++ b/docs/source/includes/setup.rst
@@ -1,0 +1,5 @@
+Some providers require additional dependencies installed on the system running linchpin. Use ``linchpin setup`` to setup the given provider(s) properly.
+
+If a list of providers is ommitted, then it will install dependencies for all providers that need so.
+
+In case you execute ``linchpin setup`` with a user not allowed to install packages, then pass the `--ask-sudo-pass` option to prompt for the sudo password.

--- a/docs/source/linchpin_setup.rst
+++ b/docs/source/linchpin_setup.rst
@@ -1,0 +1,7 @@
+.. _cli_setup:
+
+linchpin setup
+--------------
+
+.. include:: includes/setup.rst
+

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -636,10 +636,10 @@ It is suggested to update any of the following:
 @pass_context
 def setup(ctx, providers, ask_sudo_pass):
     """
-    Validate topologies for the given target(s) in the given PinFile.
-    The data from the targets is obtained from the PinFile (default).
-    targets:    Validate ONLY the listed target(s). If omitted, ALL targets in
-    the appropriate PinFile will be validate
+    Install the dependencies needed for the given provider(s).
+
+    providers:    Setup ONLY the providers listed. If omitted, it installs
+    the dependencies for ALL providers.
     """
     lpcli.ctx.set_evar("ask_sudo_pass", ask_sudo_pass)
     return_code, output = lpcli.lp_setup(providers)

--- a/linchpin/shell/click_default_group.py
+++ b/linchpin/shell/click_default_group.py
@@ -114,7 +114,7 @@ class DefaultGroup(click.Group):
         not be listed
         """
 
-        return ['init', 'up', 'destroy', 'fetch', 'journal']
+        return ['init', 'up', 'destroy', 'fetch', 'journal', 'setup']
 
     def get_command(self, ctx, cmd_name):
 


### PR DESCRIPTION
- Fixed the help text on `linchpin setup --help`
- Added 'setup' on list of commands of cli documentation, and
  make a page for it.
- Show 'setup' on the list of commands when `linchpin --help`