### PR TITLE
Adjust OpenStack instance naming

### DIFF
--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -49,8 +49,8 @@
 
 - name: generate res_def_names
   set_fact:
-    res_def_names: "{{ res_def_names  + [os_resource_name + inst_c] }}"
-  with_sequence: start=1 end={{ res_def['count'] }}
+    res_def_names: "{{ res_def_names  + [os_resource_name + '-' + inst_c] }}"
+  with_sequence: start=0 end={{ res_def['count']|int - 1 }}
   when: res_def['count'] > 1
   loop_control:
     loop_var: inst_c


### PR DESCRIPTION
This change adjusts the OpenStack instances naming so that:
 - index starts at 0 instead of 1
 - there is a '-' separator between the resource name and index

This makes the naming consistent with the libvirt provider.