### PR TITLE
Prevent dicts in template from being treated as strings

### DIFF
--- a/linchpin/utils/dataparser.py
+++ b/linchpin/utils/dataparser.py
@@ -77,7 +77,10 @@ class DataParser(object):
             A dictionary of variables to be rendered againt the template
         """
 
-        c = self.parse_json_yaml(context, ordered=ordered)
+        # setting ordered=False may be problematic, but it is required until
+        # ansible supports OrderedDict in templates, which can't happen until
+        # it stops supporting python 2.6
+        c = self.parse_json_yaml(context, ordered=False)
         t = Environment(loader=BaseLoader).from_string(str(template))
         return t.render(c)
 


### PR DESCRIPTION
We load templates as an OrderedDict, which Ansible cannot parse in its template rendering.  Until Ansible can, which should be shortly after it stops supporting python 2.6, we can revert this change