### PR TITLE
Support stable tags based on the branch

### DIFF
--- a/config/Dockerfiles/Jenkinsfile
+++ b/config/Dockerfiles/Jenkinsfile
@@ -2,16 +2,17 @@ import com.cloudbees.plugins.credentials.Credentials
 
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
+env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'
 env.ghprbPullAuthorLogin = env.ghprbPullAuthorLogin ?: ''
 env.ghprbPullId = env.ghprbPullId ?: ''
 
-env.TARGET_BRANCH = env.TARGET_BRANCH ?: 'develop'
+env.TARGET_BRANCH = env.ghprbTargetBranch ?: 'develop'
 
 // Needed for podTemplate()
-env.SLAVE_TAG = env.SLAVE_TAG ?: 'stable'
-env.FEDORA28_TAG = env.FEDORA28_TAG ?: 'stable'
-env.FEDORA29_TAG = env.FEDORA29_TAG ?: 'stable'
-env.CENTOS7_TAG = env.CENTOS7_TAG ?: 'stable'
+env.SLAVE_TAG = env.SLAVE_TAG ?: 'stable-' + env.ghprbTargetBranch
+env.FEDORA28_TAG = env.FEDORA28_TAG ?: 'stable-' + env.ghprbTargetBranch
+env.FEDORA29_TAG = env.FEDORA29_TAG ?: 'stable-' + env.ghprbTargetBranch
+env.CENTOS7_TAG = env.CENTOS7_TAG ?: 'stable-' + env.ghprbTargetBranch
 
 DOCKER_REPO_URL = env.DOCKER_REPO_URL ?: '172.30.254.79:5000'
 // if LINCHPIN_PROVIDERS is defined in jenkins global
@@ -69,16 +70,16 @@ properties(
                 string(defaultValue: '',
                        description: 'Git Hub Repository',
                        name: 'ghprbGhRepository'),
-                string(defaultValue: 'stable',
+                string(defaultValue: 'stable-' + env.ghprbTargetBranch,
                        description: 'Tag for slave image',
                        name: 'SLAVE_TAG'),
-                string(defaultValue: 'stable',
+                string(defaultValue: 'stable-' + env.ghprbTargetBranch,
                        description: 'Tag for fedora28 image',
                        name: 'FEDORA28_TAG'),
-                string(defaultValue: 'stable',
+                string(defaultValue: 'stable-' + env.ghprbTargetBranch,
                        description: 'Tag for fedora29 image',
                        name: 'FEDORA29_TAG'),
-                string(defaultValue: 'stable',
+                string(defaultValue: 'stable-' + env.ghprbTargetBranch,
                        description: 'Tag for centos7 image',
                        name: 'CENTOS7_TAG'),
                 string(description: 'Providers to be tested',

--- a/config/Dockerfiles/JenkinsfileContainer
+++ b/config/Dockerfiles/JenkinsfileContainer
@@ -14,9 +14,10 @@ DOCKER_REPO_URL = env.DOCKER_REPO_URL ?: '172.30.254.79:5000'
 env.ghOrg = 'herlo'
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
+env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'
 
 // If this PR does not include an image change, then use this tag
-STABLE_LABEL = "stable"
+STABLE_LABEL = "stable-" + env.ghprbTargetBranch
 tagMap = [:]
 
 // Initialize
@@ -145,6 +146,9 @@ properties([
       string(defaultValue: 'develop',
              description: '',
              name: 'ghprbActualCommit'),
+      string(defaultValue: 'develop',
+             description: '',
+             name: 'ghprbTargetBranch'),
       string(defaultValue: '',
              description: '',
              name: 'sha1'),

--- a/config/Dockerfiles/JenkinsfileGHPRMerge
+++ b/config/Dockerfiles/JenkinsfileGHPRMerge
@@ -16,6 +16,7 @@ env.MSG_PROVIDER = 'fedora-fedmsg'
 // Defaults for SCM operations
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
+env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'
 
 library identifier: "ci-pipeline@master",
         retriever: modernSCM([$class: 'GitSCMSource',
@@ -86,6 +87,7 @@ pipeline {
                                 "ghprbActualCommit": env.ghprbActualCommit,
                                 "ghprbPullId": env.ghprbPullId,
                                 "ghprbPullAuthorLogin": env.ghprbPullAuthorLogin,
+                                "ghprbTargetBranch": env.ghprbTargetBranch,
                                 "sha1": env.sha1
                             ]
                             mContentString = JsonOutput.toJson(mContent)

--- a/config/Dockerfiles/JenkinsfileGHPRTrigger
+++ b/config/Dockerfiles/JenkinsfileGHPRTrigger
@@ -16,6 +16,7 @@ env.MSG_PROVIDER = 'fedora-fedmsg'
 // Defaults for SCM operations
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
+env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'
 
 library identifier: "ci-pipeline@master",
         retriever: modernSCM([$class: 'GitSCMSource',
@@ -67,6 +68,7 @@ pipeline {
                             "ghprbPullId": env.ghprbPullId,
                             "ghprbPullAuthorLogin": env.ghprbPullAuthorLogin,
                             "ghprbGhRepository": env.ghprbGhRepository,
+                            "ghprbTargetBranch": env.ghprbTargetBranch,
                             "sha1": env.sha1
                         ]
                         mContentString = JsonOutput.toJson(mContent)

--- a/config/Dockerfiles/JenkinsfileMergePR
+++ b/config/Dockerfiles/JenkinsfileMergePR
@@ -1,11 +1,12 @@
 // Openshift project
 openshiftProject = "continuous-infra"
 DOCKER_REPO_URL = env.DOCKER_REPO_URL ?: '172.30.254.79:5000'
-STABLE_LABEL = "stable"
 
 // Defaults for SCM operations
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
+env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'
+STABLE_LABEL = "stable-" + env.ghprbTargetBranch
 
 // Add new images here
 imageList = ["fedora28", "fedora29", "centos7"]
@@ -24,6 +25,9 @@ properties([
       string(defaultValue: 'develop',
              description: '',
              name: 'ghprbActualCommit'),
+      string(defaultValue: 'develop',
+             description: '',
+             name: 'ghprbTargetBranch'),
       string(defaultValue: '',
              description: '',
              name: 'sha1'),
@@ -85,7 +89,7 @@ pipeline {
                     openshift.withCluster() {
                         openshift.withProject(openshiftProject) {
                             imageOperations.each {
-                                pipelineUtils.buildStableImage(openshiftProject, it)
+                                pipelineUtils.buildStableImage(openshiftProject, it, STABLE_LABEL)
                             }
                         }
                     }

--- a/config/Dockerfiles/JenkinsfileMessageBusMerge
+++ b/config/Dockerfiles/JenkinsfileMessageBusMerge
@@ -37,6 +37,7 @@ node('master') {
                 def ghprbPullId = msg_content['ghprbPullId']
                 def ghprbPullAuthorLogin = msg_content['ghprbPullAuthorLogin']
                 def ghprbActualCommit = msg_content['ghprbActualCommit']
+                env.ghprbTargetBranch = msg_content['ghprbTargetBranch']
                 def sha1 = msg_content['sha1']
 
                 currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - PR: ${ghprbPullId} - Author: ${ghprbPullAuthorLogin}"
@@ -54,6 +55,8 @@ node('master') {
                            value: "${env.ghprbGhRepository}"),
                     string(name: 'ghprbPullAuthorLogin',
                            value: "${ghprbPullAuthorLogin}"),
+                    string(name: 'ghprbTargetBranch',
+                           value: "${env.ghprbTargetBranch}"),
                     string(name: 'sha1',
                            value: "${sha1}")
                   ],

--- a/config/Dockerfiles/JenkinsfileMessageBusTrigger
+++ b/config/Dockerfiles/JenkinsfileMessageBusTrigger
@@ -4,6 +4,8 @@ executionID = UUID.randomUUID().toString()
 podName = 'linchpinMB-' + executionID
 OPENSHIFT_NAMESPACE = env.OPENSHIFT_NAMESPACE ?: 'continuous-infra'
 OPENSHIFT_SERVICE_ACCOUNT = env.OPENSHIFT_SERVICE_ACCOUNT ?: 'jenkins'
+env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'default'
+STABLE_LABEL = 'stable-' + env.ghprbTargetBranch
 
 // Check out PR's version of library
 library identifier: "linchpin-pipeline@develop",
@@ -49,7 +51,7 @@ podTemplate(name: podName,
             // This adds the custom slave container to the pod.
             // Must be first with name 'jnlp'
             containerTemplate(name: 'jnlp',
-                image: DOCKER_REPO_URL + '/' + OPENSHIFT_NAMESPACE + '/jenkins-continuous-infra-slave:stable',
+                image: DOCKER_REPO_URL + '/' + OPENSHIFT_NAMESPACE + '/jenkins-continuous-infra-slave' + STABLE_LABEL,
                 ttyEnabled: false,
                 args: '${computer.jnlpmac} ${computer.name}',
                 command: '',
@@ -75,6 +77,7 @@ podTemplate(name: podName,
                         ghprbPullId = msg_content['ghprbPullId']
                         def ghprbPullAuthorLogin = msg_content['ghprbPullAuthorLogin']
                         def ghprbActualCommit = msg_content['ghprbActualCommit']
+                        env.ghprbTargetBranch = msg_content['ghprbTargetBranch']
                         ghprbGhRepository = msg_content['ghprbGhRepository']
                         def sha1 = msg_content['sha1']
 
@@ -93,6 +96,8 @@ podTemplate(name: podName,
                                    value: "${ghprbGhRepository}"),
                             string(name: 'ghprbPullAuthorLogin',
                                    value: "${ghprbPullAuthorLogin}"),
+                            string(name: 'ghprbTargetBranch',
+                                   value: "${env.ghprbTargetBranch}"),
                             string(name: 'sha1',
                                    value: "${sha1}")
                           ],

--- a/config/Dockerfiles/JenkinsfileRelease
+++ b/config/Dockerfiles/JenkinsfileRelease
@@ -18,10 +18,11 @@ env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/' + repoName
 
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
 //env.ghprbActualCommit = env.ghprbActualCommit ?: 'test_pypi_install'
+env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'
 
 env.ghprbPullAuthorLogin = env.ghprbPullAuthorLogin ?: ''
 
-env.TARGET_BRANCH = env.TARGET_BRANCH ?: 'develop'
+env.TARGET_BRANCH = env.ghprbTargetBranch ?: 'develop'
 //env.TARGET_BRANCH = env.TARGET_BRANCH ?: 'develop-testing'
 env.MASTER_BRANCH = env.MASTER_BRANCH ?: 'master'
 //env.MASTER_BRANCH = env.MASTER_BRANCH ?: 'master-testing'
@@ -35,7 +36,8 @@ DOCKER_HUB_IMAGE ?: 'linchpin'
 
 OPENSHIFT_NAMESPACE = env.OPENSHIFT_NAMESPACE ?: 'continuous-infra'
 OPENSHIFT_SERVICE_ACCOUNT = env.OPENSHIFT_SERVICE_ACCOUNT ?: 'jenkins'
-env.FEDORA29_TAG = env.FEDORA29_TAG ?: 'stable'
+STABLE_LABEL = 'stable-' + env.ghprbTargetBranch
+env.FEDORA29_TAG = env.FEDORA29_TAG ?: STABLE_LABEL
 
 // Pod name to use
 jslave_podName = 'jslave-' + repoName + '_' + executionID
@@ -74,7 +76,7 @@ podTemplate(name: jslave_podName,
             // This adds the custom slave container to the pod.
             // Must be first with name 'jnlp'
             containerTemplate(name: 'jnlp',
-                image: DOCKER_REPO_URL + '/' + OPENSHIFT_NAMESPACE + '/jenkins-continuous-infra-slave:stable',
+                image: DOCKER_REPO_URL + '/' + OPENSHIFT_NAMESPACE + '/jenkins-continuous-infra-slave:' + STABLE_LABEL,
                 ttyEnabled: false,
                 alwaysPullImage: true,
                 args: '${computer.jnlpmac} ${computer.name}',

--- a/config/s2i/jenkins/master-downstream/configuration/jobs/cd-linchpin-release/config.xml
+++ b/config/s2i/jenkins/master-downstream/configuration/jobs/cd-linchpin-release/config.xml
@@ -83,7 +83,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>

--- a/config/s2i/jenkins/master-downstream/configuration/jobs/ci-linchpin-container/config.xml
+++ b/config/s2i/jenkins/master-downstream/configuration/jobs/ci-linchpin-container/config.xml
@@ -95,7 +95,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>

--- a/config/s2i/jenkins/master-downstream/configuration/jobs/ci-linchpin-merge/config.xml
+++ b/config/s2i/jenkins/master-downstream/configuration/jobs/ci-linchpin-merge/config.xml
@@ -96,7 +96,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>

--- a/config/s2i/jenkins/master-upstream/configuration/jobs/cd-linchpin-release/config.xml
+++ b/config/s2i/jenkins/master-upstream/configuration/jobs/cd-linchpin-release/config.xml
@@ -83,7 +83,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>

--- a/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-GHPRB-merge/config.xml
+++ b/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-GHPRB-merge/config.xml
@@ -108,7 +108,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>

--- a/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-GHPRB-trigger/config.xml
+++ b/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-GHPRB-trigger/config.xml
@@ -87,7 +87,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>

--- a/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-container/config.xml
+++ b/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-container/config.xml
@@ -95,7 +95,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>

--- a/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-merge/config.xml
+++ b/config/s2i/jenkins/master-upstream/configuration/jobs/ci-linchpin-merge/config.xml
@@ -96,7 +96,7 @@
         <hudson.plugins.git.extensions.impl.ChangelogToBranch>
           <options>
             <compareRemote>origin</compareRemote>
-            <compareTarget>develop</compareTarget>
+	    <compareTarget>${ghprbTargetBranch}</compareTarget>
           </options>
         </hudson.plugins.git.extensions.impl.ChangelogToBranch>
       </extensions>


### PR DESCRIPTION
This will allow multiple branches to be in development at the
same time.  Containers promoted to stable from one branch will
not affect another branch.

This PR is dependent on https://github.com/CentOS-PaaS-SIG/ci-pipeline/pull/793