### PR TITLE
Allow removing OpenStack routers with connected networks during destroy

### DIFF
--- a/linchpin/provision/roles/openstack/tasks/provision_os_router.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_router.yml
@@ -1,5 +1,27 @@
 ---
-- name: "provision/deprovision os_router"
+- name: "deprovision os_router"
+  os_router:
+    admin_state_up: "{{ res_def['admin_state_up'] | default(omit) }}"
+    api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
+    auth: "{{ auth_var | omit_filter(omit) }}"
+    enable_snat: "{{ res_def['enable_snat'] | default(omit) }}"
+    external_fixed_ips: "{{ res_def['external_fixed_ips'] | default(omit) }}"
+    interface: "{{ res_def['interface'] | default(omit) }}"
+    interfaces: []
+    name: "{{ os_resource_name }}"
+    network: "{{ res_def['network'] | default(omit) }}"
+    key: "{{ res_def['key'] | default(omit) }}"
+    project: "{{ res_def['project'] | default(omit) }}"
+    region_name: "{{ res_def['region_name'] | default(omit) }}"
+    state: "{{ state }}"
+    timeout: "{{ res_def['timeout'] | default(600) }}"
+    verify: no
+    wait: yes
+  register: res_def_output_auth
+  no_log: "{{ not debug_mode }}"
+  when: state=='absent'
+
+- name: "provision os_router"
   os_router:
     admin_state_up: "{{ res_def['admin_state_up'] | default(omit) }}"
     api_timeout: "{{ res_def['api_timeout'] | default(omit) }}"
@@ -19,6 +41,7 @@
     wait: yes
   register: res_def_output_auth
   no_log: "{{ not debug_mode }}"
+  when: state=='present'
 
 - name: "Append outputitem to topology_outputs"
   set_fact:


### PR DESCRIPTION
Currently removing an os_network that is connected to a router fails
with "Unable to complete operation on network. There are one or more
ports still in use on the network." This change sets the router interfaces
to an empty list during destroy hence allowing the router and
subsequent os_network delete to complete.


Failure:
```yaml
PLAY [schema check and Pre-Provisioning Activities on topology_file] ***********

TASK [common : assign async value] *********************************************
ok: [localhost] => {"ansible_facts": {"async": false}, "changed": false}

TASK [common : declare async_types array] **************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [common : output vars] ****************************************************
ok: [localhost] => {"ansible_facts": {"topology_outputs": {}}, "changed": false}

PLAY [Provisioning openstack resources] ****************************************

TASK [openstack : declaring output vars] ***************************************
ok: [localhost] => {"ansible_facts": {"topology_outputs_os_heat": [], "topology_outputs_os_keypair": [], "topology_outputs_os_network": [], "topology_outputs_os_object": [], "topology_outputs_os_server": [], "topology_outputs_os_sg": [], "topology_outputs_os_volume": []}, "changed": false}

TASK [openstack : Initiating Provision/Teardown of openstack resource group] ***
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml for localhost => (item={'resource_group_name': u'simple', 'resource_definitions': [{'unique': False, 'role': u'os_network', 'name': u'management'}, {'network_name': u'management', 'cidr': u'192.168.124.0/24', 'unique': False, 'role': u'os_subnet', 'name': u'management-subnet'}, {'unique': False, 'role': u'os_network', 'name': u'baremetal'}, {'no_gateway_ip': True, 'name': u'baremetal-subnet', 'enable_dhcp': False, 'role': u'os_subnet', 'cidr': u'192.168.111.0/24', 'unique': False, 'network_name': u'baremetal'}, {'unique': False, 'role': u'os_network', 'name': u'provisioning'}, {'no_gateway_ip': True, 'name': u'provisioning-subnet', 'enable_dhcp': False, 'role': u'os_subnet', 'cidr': u'172.22.0.0/24', 'unique': False, 'network_name': u'provisioning'}, {'interfaces': [u'management-subnet'], 'unique': False, 'role': u'os_router', 'name': u'management-router', 'network': u'38.145.32.0/22'}, {'rules': [{'rule_type': u'inbound', 'to_port': 22, 'from_port': 22, 'cidr_ip': u'0.0.0.0/0', 'proto': u'tcp'}, {'rule_type': u'inbound', 'to_port': -1, 'from_port': -1, 'cidr_ip': u'0.0.0.0/0', 'proto': u'icmp'}], 'role': u'os_sg', 'name': u'metalkube_security_group', 'description': u'Openstack Security Group with ssh and icmp access'}], 'resource_group_type': u'openstack', 'credentials': {'profile': u'rdocloud', 'filename': u'/root/.config/openstack/clouds.yaml'}})

TASK [openstack : Unset the authvar from previous run] *************************
ok: [localhost] => {"ansible_facts": {"auth_var": ""}, "changed": false}

TASK [openstack : set default_cred_profile when res_grp[credentials] is undefined] ***
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [openstack : set default_cred_profile when res_grp[credentials] is undefined] ***
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [openstack : set cred_profile when res_grp[credentials] is defined] *******
ok: [localhost] => {"ansible_facts": {"cred_profile": "rdocloud"}, "changed": false}

TASK [openstack : set default_cred_filename when res_grp[credentials] is defined] ***
ok: [localhost] => {"ansible_facts": {"cred_filename": "/root/.config/openstack/clouds.yaml"}, "changed": false}

TASK [openstack : Get creds from auth driver] **********************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: OSError: [Errno 2] No such file or directory: '/root/.config/linchpin'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1552701819.56-211789261384731/AnsiballZ_auth_driver.py\", line 113, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1552701819.56-211789261384731/AnsiballZ_auth_driver.py\", line 105, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1552701819.56-211789261384731/AnsiballZ_auth_driver.py\", line 48, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_auth_driver_payload_8ba4TW/__main__.py\", line 145, in <module>\n  File \"/tmp/ansible_auth_driver_payload_8ba4TW/__main__.py\", line 139, in main\n  File \"/tmp/ansible_auth_driver_payload_8ba4TW/__main__.py\", line 108, in get_cred\nOSError: [Errno 2] No such file or directory: '/root/.config/linchpin'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [openstack : set auth_var] ************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [openstack : provisioning resource definitions of current group] **********
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_res_defs.yml for localhost

TASK [openstack : Set os_res_type value] ***************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [openstack : Add resource type to async_types] ****************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [openstack : Get the resource name] ***************************************
ok: [localhost] => {"ansible_facts": {"os_resource_name": "management", "unique_name": false}, "changed": false}

TASK [openstack : Create name using uhash value] *******************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [openstack : provision/teardown resources }}] *****************************
included: /tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/roles/openstack/tasks/provision_os_network.yml for localhost

TASK [openstack : provision/deprovision os_network] ****************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "ConflictException: 409: Client Error for url: https://phx2.cloud.rdoproject.org:13696/v2.0/networks/94783eee-6743-41ae-be9b-e6c9c814d2d1.json, Unable to complete operation on network 94783eee-6743-41ae-be9b-e6c9c814d2d1. There are one or more ports still in use on the network."}
	to retry, use: --limit @/tmp/linchpin/.venv/lib/python2.7/site-packages/linchpin/provision/openstack.retry
```

Pinfile:

```yaml
---
cfgs:
  openstack:
    __IP__: name
    __ADDRESS__: accessIPv4
    __BAREMETALNETMAC__: addresses.baremetal.0.OS-EXT-IPS-MAC:mac_addr
    __PROVISIONINGNETMAC__: addresses.provisioning.0.OS-EXT-IPS-MAC:mac_addr

os-network:
  topology:
    topology_name: os_network
    resource_groups:
      - resource_group_name: simple
        resource_group_type: openstack
        resource_definitions:
          - name: management-router
            role: os_router
            network: "{{ test_os_floating_ip_net }}"
            unique: false
          - name: management
            role: os_network
            unique: false
          - name: management-subnet
            role: os_subnet
            network_name: management
            unique: false
            cidr: 192.168.124.0/24
          - name: baremetal
            role: os_network
            unique: false
          - name: baremetal-subnet
            role: os_subnet
            network_name: baremetal
            unique: false
            cidr: 192.168.111.0/24
            no_gateway_ip: true
            enable_dhcp: false
          - name: provisioning
            role: os_network
            unique: false
          - name: provisioning-subnet
            role: os_subnet
            network_name: provisioning
            unique: false
            cidr: 172.22.0.0/24
            no_gateway_ip: true
            enable_dhcp: false
          - name: management-router
            role: os_router
            network: "{{ test_os_floating_ip_net }}"
            unique: false
            interfaces:
              - management-subnet
          - name: "metalkube_security_group"
            role: os_sg
            description: "Openstack Security Group with ssh and icmp access"
            rules:
              - rule_type: "inbound"
                from_port: 22
                to_port: 22
                proto: "tcp"
                cidr_ip: "0.0.0.0/0"
              - rule_type: "inbound"
                from_port: -1
                to_port: -1
                proto: "icmp"
                cidr_ip: "0.0.0.0/0"
        credentials:
           filename: "{{ test_os_client_config }}"
           profile: "{{ test_os_client_profile }}"

os-server-new:
  topology:
    topology_name: os-server-new
    resource_groups:
     - resource_group_name: os-server-new
       resource_group_type: openstack
       resource_definitions:
         - name: "routerbmc"
           role: os_server
           flavor: {{ test_os_routerbmc_flavor }}
           image: "{{ test_os_image }}"
           unique: false
           count: 1
           keypair: "{{ test_os_keypair }}"
           security_groups: metalkube_security_group
           networks:
             - management
             - baremetal
       credentials:
         filename: {{ test_os_client_config }}
         profile: {{ test_os_client_profile }}

     - resource_group_name: os-server-new
       resource_group_type: openstack
       resource_definitions:
         - name: "provisionhost"
           role: os_server
           flavor: {{ test_os_provisionhost_flavor }}
           image: "{{ test_os_image }}"
           count: 1
           keypair: "{{ test_os_keypair }}"
           security_groups: metalkube_security_group
           networks:
             - management
             - baremetal
             - provisioning

     - resource_group_name: os-server-new
       resource_group_type: openstack
       resource_definitions:
         - name: "master"
           role: os_server
           flavor: {{ test_os_master_flavor }}
           image: "{{ test_os_image_ipxe }}"
           unique: false
           count: 3
           keypair: "{{ test_os_keypair }}"
           auto_ip: false
           networks:
             - provisioning
             - baremetal

  layout:
    inventory_layout:
      vars:
        hostname: __IP__
        ansible_ssh_host: __ADDRESS__
        baremetal_net_mac: __BAREMETALNETMAC__
        provisioning_net_mac: __PROVISIONINGNETMAC__
        ansible_ssh_user: centos
        ansible_ssh_common_args: '"-o StrictHostKeyChecking=no"'
      hosts:
        routerbmc:
          count: 1
          host_groups:
            - routerbmc
        provisionhost:
          count: 1
          host_groups:
            - provisionhost
        master:
          count: 3
          host_groups:
            - master
            - openshift
  hooks:
    postup:
      - name: post
        type: ansible
        context: True
        actions:
          - playbook: post.yaml
            vars: extravars.yml

```