### PR TITLE
fix libvirt waiting for IP on net with disabled dhcp

### DIFF
--- a/docs/source/examples/workspaces/libvirt/PinFile
+++ b/docs/source/examples/workspaces/libvirt/PinFile
@@ -23,6 +23,8 @@ libvirt-new:
             {% else %}
             networks:
               - name: default
+              - name: default
+                dhcp: false
             {% endif %}
             additional_storage: {{ storage | default('10G') }}
             {% if user is defined %}
@@ -53,6 +55,7 @@ libvirt-new:
           count: 1
           host_groups:
             - example
+
 libvirt-network:
   topology:
     topology_name: "libvirt_network"

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -338,6 +338,18 @@
   when: not async
   register: node_data
 
+- set_fact:
+    networks: []
+
+- set_fact:
+    networks: "{{ networks + [net] }}"
+  loop: "{{ res_def['networks'] }}"
+  loop_control:
+    loop_var: net
+  when:
+    - res_def['networks'] is defined
+    - net.dhcp is not defined or net.dhcp == true
+
 - xml:
     xmlstring: "{{ node_data.results[net.1].get_xml }}"
     xpath: "//interface[@type='network' and ./source[@network='{{net.0.name}}']]/mac"
@@ -346,17 +358,14 @@
   ignore_errors: yes
   loop_control:
     loop_var: net
-  loop: "{{ res_def['networks']|product(res_count)|list }}"
-  when:
-    - res_def['networks'] is defined
-    - net.dhcp is not defined or net.dhcp == true
+  loop: "{{ networks|product(res_count)|list }}"
 
 - set_fact:
     macs: []
 
 - set_fact:
     macs: "{{ macs + [mac_addresses.results[node.1].matches[node.0].mac.address] }}"
-  loop: "{{ range(0,res_def['networks']|length,1)|list|product(res_count)|list }}"
+  loop: "{{ range(0,networks|length,1)|list|product(res_count)|list }}"
   loop_control:
     loop_var: node
 


### PR DESCRIPTION
Fixes #1023  - When a  libvirt system has multiple networks and has a subset with disabled dhcp, it will falsely to get a mac of skipped network, ending up in missing item (non existing dictionary path). The simple solution is to filter the valid networks for mac gathering before looking for mac addresses.