### PR TITLE
Allow passing cpu mode to libvirt VM

### DIFF
--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -13,6 +13,7 @@
                     "name": { "type": "string", "required": true },
                     "name_separator": { "type": "string", "required": false },
                     "vcpus": { "type": "integer", "required": true },
+                    "cpu_mode": { "type": "string", "required": false },
                     "memory": { "type": "integer", "required": true },
                     "count": { "type": "integer", "required": false },
                     "uri": { "type": "string", "required": false },

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -59,6 +59,7 @@
     - ["{{ img_src_ext }}"]
     - ["{{ res_def['name_separator'] | default('_')  }}"]
     - ["{{ res_def['disk_cache'] | default('none')  }}"]
+    - ["{{ res_def['cpu_mode'] | default('host-model')  }}"]
   loop_control:
     loop_var: definition
   when:  node_exists['failed'] is defined
@@ -264,6 +265,7 @@
     - ["{{ img_src_ext }}"]
     - ["{{ res_def['name_separator'] | default('_')  }}"]
     - ["{{ res_def['disk_cache'] | default('none')  }}"]
+    - ["{{ res_def['cpu_mode'] | default('host-model')  }}"]
   loop_control:
     loop_var: definition
   when: node_exists['failed'] is defined

--- a/linchpin/provision/roles/libvirt/templates/libvirt_node.xml.j2
+++ b/linchpin/provision/roles/libvirt/templates/libvirt_node.xml.j2
@@ -11,7 +11,7 @@
     <apic/>
     <pae/>
   </features>
-  <cpu mode='host-model'>
+  <cpu mode='{{ definition[7] }}'>
     <model fallback='allow' />
   </cpu>
   <clock offset='utc'/>


### PR DESCRIPTION
Use host-model as default and make it configurable via cpu_mode parameter.