### PR TITLE
Add missing ghprbGhRepository variable for downstream

### DIFF
--- a/config/Dockerfiles/JenkinsfileGHPRMerge
+++ b/config/Dockerfiles/JenkinsfileGHPRMerge
@@ -87,6 +87,7 @@ pipeline {
                                 "ghprbActualCommit": env.ghprbActualCommit,
                                 "ghprbPullId": env.ghprbPullId,
                                 "ghprbPullAuthorLogin": env.ghprbPullAuthorLogin,
+                                "ghprbGhRepository": env.ghprbGhRepository,
                                 "ghprbTargetBranch": env.ghprbTargetBranch,
                                 "sha1": env.sha1
                             ]

--- a/config/Dockerfiles/JenkinsfileMessageBusMerge
+++ b/config/Dockerfiles/JenkinsfileMessageBusMerge
@@ -38,6 +38,7 @@ node('master') {
                 def ghprbPullAuthorLogin = msg_content['ghprbPullAuthorLogin']
                 def ghprbActualCommit = msg_content['ghprbActualCommit']
                 env.ghprbTargetBranch = msg_content['ghprbTargetBranch']
+                env.ghprbGhRepository = msg_content['ghprbGhRepository']
                 def sha1 = msg_content['sha1']
 
                 currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - PR: ${ghprbPullId} - Author: ${ghprbPullAuthorLogin}"


### PR DESCRIPTION
Downstream wasn't getting the ghprbGhRepository populated
because it wasn't included in the messagebus message.