### PR TITLE
bugfix: get inventory data only when inv_filter is defined

### DIFF
--- a/linchpin/InventoryFilters/GenericInventory.py
+++ b/linchpin/InventoryFilters/GenericInventory.py
@@ -18,9 +18,11 @@ class GenericInventory(InventoryFilter):
         host_data = []
         for res_grp in res_output:
             inv_filter = res_grp['resource_type']
-            data = self.filter_classes[inv_filter]()\
-                .get_host_data(res_grp, config)
-            host_data.append(data)
+            # check only when the inventory_filter exists
+            if inv_filter in list(self.filter_classes.keys()):
+                data = self.filter_classes[inv_filter]()\
+                    .get_host_data(res_grp, config)
+                host_data.append(data)
         return host_data
 
     def get_hosts_by_count(self, host_data, count):


### PR DESCRIPTION
Inventory fails when os_keypair and os_server are provisioned together. 

```
---
os-server-addl-vols:
  topology:
    topology_name: os-server-inst
    resource_groups:
      - resource_group_name: os-server-test-lp
        resource_group_type: openstack
        resource_definitions:
          - name: linchpintestkey
            role: os_keypair
          - name: "linchpintestdatabase"
            role: os_server
            flavor: m1.small
            image: CentOS-7-x86_64-GenericCloud-1808
            count: 1
            keypair: linchpintestkey
            networks:
              - provider_net_cci_6
        credentials:
          filename: clouds.yaml
          profile: openstack
  layout:
    inventory_layout:
      vars:
        hostname: __IP__
      hosts:
        addl-vols-node:
          count: 1
          host_groups:
            - hello
```

Error while debugging with PDB
```
 17             """
 18             host_data = []
 19             for res_grp in res_output:
 20                 inv_filter = res_grp['resource_type']
 21  ->             data = self.filter_classes[inv_filter]()\
 22                     .get_host_data(res_grp, config)
 23                 host_data.append(data)
 24             return host_data
 25  
 26         def get_hosts_by_count(self, host_data, count):
(Pdb) self.filter_classes
{'libvirt_res': <class 'linchpin.InventoryFilters.LibvirtInventory.LibvirtInventory'>, 'dummy_res': <class 'linchpin.InventoryFilters.DummyInventory.DummyInventory'>, 'beaker_res': <class 'linchpin.InventoryFilters.BeakerInventory.BeakerInventory'>, 'duffy_res': <class 'linchpin.InventoryFilters.DuffyInventory.DuffyInventory'>, 'nummy_res': <class 'linchpin.InventoryFilters.DummyInventory.DummyInventory'>, 'os_server_res': <class 'linchpin.InventoryFilters.OpenstackInventory.OpenstackInventory'>, 'ovirt_vms_res': <class 'linchpin.InventoryFilters.OvirtInventory.OvirtInventory'>, 'aws_ec2_res': <class 'linchpin.InventoryFilters.AWSInventory.AWSInventory'>, 'gcloud_gce_res': <class 'linchpin.InventoryFilters.GCloudInventory.GCloudInventory'>}
(Pdb) c
Error: u'os_keypair_res'
```

fixes #1053