### PR TITLE
Remove herlo from JenkinsFiles

### DIFF
--- a/config/Dockerfiles/JenkinsfileContainer
+++ b/config/Dockerfiles/JenkinsfileContainer
@@ -11,7 +11,7 @@ openshiftProject = "continuous-infra"
 DOCKER_REPO_URL = env.DOCKER_REPO_URL ?: '172.30.254.79:5000'
 
 // Defaults for SCM operations
-env.ghOrg = 'herlo'
+env.ghOrg = '14rcole'
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
 env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'

--- a/config/Dockerfiles/JenkinsfileContainer
+++ b/config/Dockerfiles/JenkinsfileContainer
@@ -11,7 +11,7 @@ openshiftProject = "continuous-infra"
 DOCKER_REPO_URL = env.DOCKER_REPO_URL ?: '172.30.254.79:5000'
 
 // Defaults for SCM operations
-env.ghOrg = '14rcole'
+env.ghOrg = 'CentOS-PaaS-SIG'
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/linchpin'
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
 env.ghprbTargetBranch = env.ghprbTargetBranch ?: 'develop'
@@ -121,7 +121,7 @@ test_providers = ""
 IRC_NICK = "contra-bot"
 IRC_CHANNEL = "#contra-ci-cd"
 
-library identifier: "ci-pipeline@automate_lp",
+library identifier: "ci-pipeline@master",
         retriever: modernSCM([$class: 'GitSCMSource',
                               remote: "https://github.com/${env.ghOrg}/ci-pipeline"])
 

--- a/config/Dockerfiles/JenkinsfileRelease
+++ b/config/Dockerfiles/JenkinsfileRelease
@@ -14,7 +14,6 @@ repoName = 'linchpin'
 DOCKER_REPO_URL = env.DOCKER_REPO_URL ?: '172.30.254.79:5000'
 
 env.ghprbGhRepository = env.ghprbGhRepository ?: 'CentOS-PaaS-SIG/' + repoName
-//env.ghprbGhRepository = env.ghprbGhRepository ?: 'herlo/' + repoName
 
 env.ghprbActualCommit = env.ghprbActualCommit ?: 'develop'
 //env.ghprbActualCommit = env.ghprbActualCommit ?: 'test_pypi_install'

--- a/config/s2i/jenkins/buildah/Dockerfile
+++ b/config/s2i/jenkins/buildah/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:28
 LABEL name="contrainfra/buildah" \
-      maintainer="herlo@redhat.com" \
+      maintainer="srallaba@redhat.com" \
       version="0.0.1" \
       description="Container to build and release docker images used by contra-infra tools"
 


### PR DESCRIPTION
There's a couple of other references to copr repos that will be a bit harder to remove that we can get to another time