### PR TITLE
WIP: test unit test fix

### DIFF
--- a/config/s2i/jenkins/master-downstream/plugins.txt
+++ b/config/s2i/jenkins/master-downstream/plugins.txt
@@ -90,7 +90,7 @@ pipeline-model-extensions:1.2.7
 pipeline-rest-api:2.9
 pipeline-stage-step:2.3
 pipeline-stage-tags-metadata:1.2.7
-pipeline-stage-view:2.9
+pipeline-stage-view:2.10
 pipeline-utility-steps:2.0.1
 plain-credentials:1.4
 pubsub-light:1.12

--- a/playbooks/tests/unit_tests.yml
+++ b/playbooks/tests/unit_tests.yml
@@ -1,6 +1,7 @@
 ---
 - name: Unit tests for Linchpin
   hosts: localhost
+  any_errors_fatal: true
   gather_facts: False
   tasks:
           - name: Install Test Reqs


### PR DESCRIPTION
This patch fails any failures in playbook and also updates jenkins plugin-stage-view to 2.10 which currently is used by cvp and ci-pipeline