### PR TITLE
Add travis.yml to manually trigger unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+
+language: python
+
+python:
+  - "2.7"
+#  - "3.6"
+
+cache: pip
+
+install:
+  - pip install -U setuptools
+  - pip install -U pip
+  - pip install .
+  - pip install .[tests]
+
+script:
+  - flake8 --exclude=\.eggs,tests,docs --ignore=E124,E303 --max-line-length 80 .
+  - $(which python) setup.py test
+#  - $(which python) $(which nosetests) -s linchpin/tests/*


### PR DESCRIPTION
Though this pr does not intend to replace contra.yml. 
It helps in triggering unit tests manually from travis ui.