### PR TITLE
Disabling unit tests in linchpin via contra hdsl

### DIFF
--- a/config/Dockerfiles/tests.d/general/01_general
+++ b/config/Dockerfiles/tests.d/general/01_general
@@ -3,7 +3,7 @@
 # Verify basic provisioning for all supplied providers
 # distros.exclude: centos7 fedora28
 # providers.include: none
-providers.exclude: vmware
+# providers.exclude: vmware
 
 DISTRO=${1}
 PROVIDER=${2}

--- a/playbooks/tests/unit_tests.yml
+++ b/playbooks/tests/unit_tests.yml
@@ -3,21 +3,24 @@
   hosts: localhost
   gather_facts: False
   tasks:
-          - name: Install Test Reqs
-            pip:
-                    name: .[tests]
-                    virtualenv: /tmp/linchpin
-            args:
-                    chdir: ../../
-          - name: pyTest
-            shell: |
-                    source /tmp/linchpin/bin/activate
-                    python setup.py test
-            args:
-                    chdir: ../../
-          - name: Flake8 tests
-            shell: |
-                    source /tmp/linchpin/bin/activate
-                    flake8 --exclude=\.eggs,tests,docs --ignore=E124,E303,W504 --max-line-length 80 .
-            args:
-                    chdir: ../../
+          - name: debug
+            debug:
+              msg: "Disabling linchpin tests until container is fixed. Refer Travis ci for unit tests and flake8 tests"
+              #          - name: Install Test Reqs
+              #            pip:
+              #                    name: .[tests]
+              #                    virtualenv: /tmp/linchpin
+              #            args:
+              #                    chdir: ../../
+              #            - name: pyTest
+              #              shell: |
+              #                    source /tmp/linchpin/bin/activate
+              #                    python setup.py test
+              #            args:
+              #                    chdir: ../../
+              #          - name: Flake8 tests
+              #            shell: |
+              #                    source /tmp/linchpin/bin/activate
+              #                    flake8 --exclude=\.eggs,tests,docs --ignore=E124,E303,W504 --max-line-length 80 .
+              #            args:
+              #                    chdir: ../../


### PR DESCRIPTION
Will be reverting it back once the container is fixed. until then, please
refer to Travis ci logs for tests