### PR TITLE
bugfix: Fix linchpin release compilation error

### DIFF
--- a/config/Dockerfiles/JenkinsfileRelease
+++ b/config/Dockerfiles/JenkinsfileRelease
@@ -217,8 +217,8 @@ EOF
                     }
                     stage('create GitHub release') {
                         dir(reponame) {
-                            string version = sh (
-                                script python setup.py --version,
+                            string: version = sh (
+                                script: "python setup.py --version",
                                 returnStdout: true
                             ).trim()
                             withCredentials([string(credentialsId: 'github_api_token', variable: 'TOKEN')]) {
@@ -227,6 +227,7 @@ EOF
                         }
                     }
                 }
+              
                 catch (e) {
 
                         // Set build result


### PR DESCRIPTION
This PR fixes the following error in linchpin release 
```
Started by upstream project "ci-linchpin-GHPRB-merge" build number 302

originally caused by:

 GitHub pull request #1060 of commit ae0653a00acbe033fd39957d8913f0e9c2a9a3bc, no merge conflicts.

Obtained config/Dockerfiles/JenkinsfileRelease from git https://github.com/CentOS-PaaS-SIG/linchpin

Running in Durability level: MAX_SURVIVABILITY

org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:

WorkflowScript: 220: expecting '}', found 'version' @ line 220, column 36.

                               string version = sh (

                                      ^



1 error



	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)

	at org.codehaus.groovy.control.ErrorCollector.addFatalError(ErrorCollector.java:150)

	at org.codehaus.groovy.control.ErrorCollector.addError(ErrorCollector.java:120)

	at org.codehaus.groovy.control.ErrorCollector.addError(ErrorCollector.java:132)

	at org.codehaus.groovy.control.SourceUnit.addError(SourceUnit.java:350)

	at org.codehaus.groovy.antlr.AntlrParserPlugin.transformCSTIntoAST(AntlrParserPlugin.java:144)

	at org.codehaus.groovy.antlr.AntlrParserPlugin.parseCST(AntlrParserPlugin.java:110)

	at org.codehaus.groovy.control.SourceUnit.parse(SourceUnit.java:234)

	at org.codehaus.groovy.control.CompilationUnit$1.call(CompilationUnit.java:168)

	at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:943)

	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:605)

	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:581)

	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:558)

	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)

	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)

	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)

	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)

	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:131)

	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:125)

	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:560)

	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:521)

	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:320)

	at hudson.model.ResourceController.execute(ResourceController.java:97)

	at hudson.model.Executor.run(Executor.java:429)

Finished: FAILURE
```