### PR TITLE
Fix bug preventing releases from being created

### DIFF
--- a/config/Dockerfiles/JenkinsfileRelease
+++ b/config/Dockerfiles/JenkinsfileRelease
@@ -217,7 +217,7 @@ EOF
                     }
                     stage('create GitHub release') {
                         dir(repoName) {
-                            string: version = sh (
+                            string version = "v" + sh (
                                 script: "python setup.py --version",
                                 returnStdout: true
                             ).trim()


### PR DESCRIPTION
We were passing "1.7.4" to the script, while the release was tagged as "v1.7.4"