### PR TITLE
RPM

### DIFF
--- a/linchpin.json
+++ b/linchpin.json
@@ -1,0 +1,38 @@
+{
+    "extensions": {
+        "enabled": [
+            "python_venv",
+            "blocks"
+        ]
+    },
+    "core": {
+        "group": "Application/System",
+        "license": "GPLv3+",
+        "name": "linchpin",
+        "summary": "Ansible based multicloud orchestrator",
+        "release": "2%{?dist}",
+        "url": "https://linchpin.readthedocs.io",
+        "requires": [
+          "python2-lxml",
+          "git",
+          "beaker-client",
+          "python2-libvirt"
+        ]
+    },
+    "python_venv": {
+        "name": "linchpin",
+        "path": "/opt",
+        "python": "python2.7",
+        "strip_binaries": false
+
+    },
+    "blocks": {
+        "desc": [
+            "linchpin is an Ansible-based tool to stand up and tear down",
+            "resources in various cloud environments"
+        ],
+        "post": [
+          "ln -s /opt/linchpin/bin/linchpin /usr/bin/linchpin"
+        ]
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ configparser>=3.5.0
 openshift>=0.8.6
 pyasn1>=0.1.9
 gitpython>=2.1.11
+urllib3<1.25

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -x # verbose output
+set -e # fail the whole script if some command fails
+mkdir -p results
+resultdir=$(readlink -f results)
+repo=https://github.com/CentOS-PaaS-SIG/linchpin
+
+pip install --user rpmvenv
+
+git clone --single-branch --branch master --depth 1 $repo
+cd linchpin
+python2 setup.py sdist -d "$resultdir"
+
+version="$(cat linchpin/version.py | awk -F "'" '{print $2}' | head -n1)"
+rpmvenv linchpin.json --core_version="${version}" --verbose --spec > "${resultdir}/linchpin.spec"
+sed -i '/^# Blocks/i BuildRequires: python2-pip' "${resultdir}/linchpin.spec"
+sed -i '/^# Blocks/i BuildRequires: python2-devel' "${resultdir}/linchpin.spec"
+sed -i "s#^cd %{SOURCE0}#cd %{_builddir}/linchpin-${version}/#g" "${resultdir}/linchpin.spec"
+sed -i "s#^Source0: .*#Source0: https://github.com//linchpin/archive/v${version}.tar.gz#g" "${resultdir}/linchpin.spec"
+sed -i '/^%prep/a %setup -q' "${resultdir}/linchpin.spec"
+sed -i '/^%prep/a pip2 install --user rpmvenv virtualenv==16.1.0' "${resultdir}/linchpin.spec"
+sed -i '/^%install/a export PATH=$PATH:~/.local/bin' "${resultdir}/linchpin.spec"
+sed -i '/^%post/i find %{buildroot} -name "*.pyc" -exec rm -rf {} \\\;' "${resultdir}/linchpin.spec"
+sed -i '/^%post/i find %{buildroot} -type f -print0 | xargs -0 sed -i "s|${RPM_BUILD_ROOT}||g"' "${resultdir}/linchpin.spec"
+sed -i '/^# Macros/i %undefine __brp_mangle_shebangs' "${resultdir}/linchpin.spec"
+sed -i '/^# Macros/i %global _build_id_links none' "${resultdir}/linchpin.spec"
+sed -i '/^%post/i unlink %{buildroot}/opt/linchpin/lib64 || true' "${resultdir}/linchpin.spec"
+sed -i '/^%post/i ln -s /opt/linchpin/lib %{buildroot}/opt/linchpin/lib64 || true' "${resultdir}/linchpin.spec"


### PR DESCRIPTION
Build Linchpin RPM using [rpmvenv](https://github.com/kevinconway/rpmvenv): `rpmvenv linchpin.json --core_version=1.7.4.1`
Installs linchpin to /opt/linchpin with most python libraries (troublesome libraries are system requirement such as python2-libvirt). The user call linchpin just as it was normally installed.
The RPM created symbolic link from /usr/bin/linchpin to /opt/linchpin/bin/linchpin . The user
doesn't have to activate the virtualenv to make Linchpin work. The RPM was tested in Fedora:30 container.

Fixes #240