### PR TITLE
Disable Openstack Cleanup

### DIFF
--- a/config/Dockerfiles/JenkinsfileContainer
+++ b/config/Dockerfiles/JenkinsfileContainer
@@ -199,9 +199,6 @@ pipeline {
                 node('master') {
                     script {
                       def providers = linchpinPipelineUtils.getProvidersToTest(p_providers)
-                      if ( "openstack" in providers) {
-                        pipelineUtils.executeInContainer("cleanup-openstack", "centos7", "./config/Dockerfiles/cleanup-openstack.sh")
-                      }
                       test_providers = providers.join(" ")
                     }
                 }


### PR DESCRIPTION
Disable openstack cleanup since it is holding up the release. We can re-enable it in a future PR