### PR TITLE
Remove unused functions from Inventory Filters

### DIFF
--- a/config/Dockerfiles/tests.d/aws/06_aws_ec2_elb_lb
+++ b/config/Dockerfiles/tests.d/aws/06_aws_ec2_elb_lb
@@ -7,6 +7,7 @@
 
 DISTRO=${1}
 PROVIDER=${2}
+TEMPLATE_DATA="{\"distro\": \"${DISTRO}-\"}"
 
 TARGET="aws-ec2-elb-lb"
 
@@ -22,5 +23,5 @@ echo "add default profile in config"
 mkdir -p ~/.aws/
 printf "[default]\nregion = us-east-1" > ~/.aws/config
 
-linchpin -w . -v up "${TARGET}"
+linchpin -w . --template-data "${TEMPLATE_DATA}" -v up "${TARGET}"
 

--- a/config/Dockerfiles/tests.d/openstack/06_os-heat
+++ b/config/Dockerfiles/tests.d/openstack/06_os-heat
@@ -1,13 +1,14 @@
 #!/bin/bash -xe
 
 # Verify openstack heat provisioning
-# distros.exclude: fedora28 fedora29
+# distros.exclude: fedora28 fedora29 fedora30
 # providers.include: openstack
 # providers.exclude: none
 
 DISTRO=${1}
 PROVIDER=${2}
 
+TEMPLATE_DATA="{\"distro\": \"${DISTRO}-\"}"
 PINFILE="PinFile"
 TARGET="os_heat_target"
 WORKSPACE_PATH="docs/source/examples/workspaces/openstack-heat/"
@@ -29,4 +30,4 @@ fi
 
 # testing openstack heat workspace
 echo "Testing os_heat workspace"
-linchpin -w "${WORKSPACE_PATH}" -p "${PINFILE}" -v up "${TARGET}"
+linchpin -w "${WORKSPACE_PATH}" --template-data "${TEMPLATE_DATA}" -p "${PINFILE}" -v up "${TARGET}"

--- a/docs/source/examples/workspaces/aws/PinFile
+++ b/docs/source/examples/workspaces/aws/PinFile
@@ -333,7 +333,7 @@ aws-ec2-elb-lb:
       - resource_group_name: "awsec2elblbdemo"
         resource_group_type: "aws"
         resource_definitions:
-          - name: demoec2elblb
+          - name: "{{ distro }}demoec2elblb"
             role: aws_ec2_elb_lb
             region: {{ region | default('us-east-1') }}
             {% if zones is defined %}

--- a/docs/source/examples/workspaces/openstack-heat/PinFile
+++ b/docs/source/examples/workspaces/openstack-heat/PinFile
@@ -7,7 +7,7 @@ os_heat_target:
         resource_group_type: "openstack"
         resource_definitions:
           - role: "os_heat"
-            name: "test"
+            name: "{{ distro}}ci-lp-test"
             template_path: "/workDir/workspace/ci-linchpin/linchpin/docs/source/examples/workspaces/openstack-heat/os_stack.yml"
             tag: "testtag"
         credentials:

--- a/docs/source/examples/workspaces/openstack/PinFile
+++ b/docs/source/examples/workspaces/openstack/PinFile
@@ -164,7 +164,7 @@ os-keypair:
       - resource_group_name: os-server-test-lp
         resource_group_type: openstack
         resource_definitions:
-          - name: linchpintestkey
+          - name: "{{ distro }}linchpintestkey"
             role: os_keypair
         {% if credentials is defined %}
         credentials:

--- a/linchpin/InventoryFilters/AWSInventory.py
+++ b/linchpin/InventoryFilters/AWSInventory.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -54,31 +50,3 @@ class AWSInventory(InventoryFilter):
             host_data[hostname] = {}
             self.set_config_values(host_data[hostname], instance, var_data)
         return host_data
-
-    def get_host_ips(self, host_data):
-        if host_data:
-            return list(host_data.keys())
-        else:
-            return []
-
-    def get_inventory(self, topo, layout, config):
-        host_data = []
-        inven_hosts = []
-        for res in topo:
-            hd = self.get_host_data(res, config)
-            if hd:
-                host_data.append(hd)
-            inven_hosts.extend(self.get_host_ips(hd))
-        # adding sections to respective host groups
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-        # set children for each host group
-        self.set_children(layout)
-        # set vars for each host group
-        self.set_vars(layout)
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-        return output.getvalue()

--- a/linchpin/InventoryFilters/BeakerInventory.py
+++ b/linchpin/InventoryFilters/BeakerInventory.py
@@ -1,8 +1,4 @@
 from __future__ import absolute_import
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -45,33 +41,3 @@ class BeakerInventory(InventoryFilter):
             var_data['__IP__'] = hostname_var
         self.set_config_values(host_data[hostname], res, var_data)
         return host_data
-
-    def get_host_ips(self, host_data):
-        if host_data:
-            return list(host_data.keys())
-        else:
-            return []
-
-    def add_hosts_to_groups(self, config, inven_hosts, layout):
-        pass
-
-    def get_inventory(self, topo, layout, config):
-        host_data = []
-        inven_hosts = []
-        for res in topo:
-            hd = self.get_host_data(res, config)
-            if hd:
-                host_data.append(hd)
-            inven_hosts.extend(self.get_host_ips(hd))
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-        # set children for each host group
-        self.set_children(layout)
-        # set vars for each host group
-        self.set_vars(layout)
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-        return output.getvalue()

--- a/linchpin/InventoryFilters/DockerInventory.py
+++ b/linchpin/InventoryFilters/DockerInventory.py
@@ -2,7 +2,6 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-
 from .InventoryFilter import InventoryFilter
 
 

--- a/linchpin/InventoryFilters/DuffyInventory.py
+++ b/linchpin/InventoryFilters/DuffyInventory.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-try:
-    from StrinIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -41,28 +37,3 @@ class DuffyInventory(InventoryFilter):
                 host_data[host]['__IP__'] = host
             self.set_config_values(host_data[host], res, var_data)
         return host_data
-
-    def get_host_ips(self, host_data):
-        return list(host_data.keys())
-
-    def get_inventory(self, topo, layout, config):
-        host_data = []
-        inven_hosts = []
-        for res in topo:
-            hd = self.get_host_data(res, config)
-            if hd:
-                host_data.append(hd)
-            inven_hosts.extend(self.get_host_ips(hd))
-        # adding sections to respective host groups
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-        # set children for each host group
-        self.set_children(layout)
-        # set vars for each host group
-        self.set_vars(layout)
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-        return output.getvalue()

--- a/linchpin/InventoryFilters/DummyInventory.py
+++ b/linchpin/InventoryFilters/DummyInventory.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -34,25 +30,6 @@ class DummyInventory(InventoryFilter):
             self.set_config_values(host_data[host], host, res, var_data)
         return host_data
 
-    def get_host_ips(self, host_data):
-        return list(host_data.keys())
-
-    def get_inventory(self, topo, layout, config):
-        host_data = self.get_host_data(topo, config)
-        inven_hosts = self.get_host_ips(host_data)
-        # adding sections to respective host groups
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-        # set children for each host group
-        self.set_children(layout)
-        # set vars for each host group
-        self.set_vars(layout)
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-        return output.getvalue()
 
     def set_config_values(self, host_data, host, instance, cfgs={}):
         """

--- a/linchpin/InventoryFilters/GCloudInventory.py
+++ b/linchpin/InventoryFilters/GCloudInventory.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -48,29 +44,3 @@ class GCloudInventory(InventoryFilter):
                 host_data[hostname] = {}
             self.set_config_values(host_data[hostname], instance, var_data)
         return host_data
-
-    def get_host_ips(self, host_data):
-        return list(host_data.keys())
-
-    def get_inventory(self, topo, layout, config):
-        # get inventory hosts
-        host_data = []
-        inven_hosts = []
-        for res in topo:
-            hd = self.get_host_data(res, config)
-            if hd:
-                host_data.append(hd)
-            inven_hosts.extend(self.get_host_ips(hd))
-        # adding sections to respective host groups
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-        # set children for each host group
-        self.set_children(layout)
-        # set vars for each host group
-        self.set_vars(layout)
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-        return output.getvalue()

--- a/linchpin/InventoryFilters/InventoryFilter.py
+++ b/linchpin/InventoryFilters/InventoryFilter.py
@@ -19,10 +19,6 @@ class InventoryFilter(six.with_metaclass(abc.ABCMeta, object)):
     def get_host_data(self, topo, config):
         pass
 
-    @abc.abstractmethod
-    def get_inventory(self, topo, layout):
-        pass
-
     def get_layout_hosts(self, inv):
         count = 0
         for host_group in inv['hosts']:

--- a/linchpin/InventoryFilters/LibvirtInventory.py
+++ b/linchpin/InventoryFilters/LibvirtInventory.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -50,36 +46,3 @@ class LibvirtInventory(InventoryFilter):
         host_data[hostname] = {}
         self.set_config_values(host_data[hostname], res, var_data)
         return host_data
-
-
-    def get_host_ips(self, host_data):
-        return list(host_data.keys())
-
-
-    def get_inventory(self, topo, layout, config):
-
-        host_data = []
-        inven_hosts = []
-        for res in topo:
-            hd = self.get_host_data(res, config)
-            if hd:
-                host_data.append(hd)
-            inven_hosts.extend(self.get_host_ips(hd))
-
-        # adding sections to respective host groups
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-
-        # set children for each host group
-        self.set_children(layout)
-
-        # set vars for each host group
-        self.set_vars(layout)
-
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-
-        return output.getvalue()

--- a/linchpin/InventoryFilters/OpenstackInventory.py
+++ b/linchpin/InventoryFilters/OpenstackInventory.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -62,29 +58,3 @@ class OpenstackInventory(InventoryFilter):
                 host_data[hostname] = {}
                 self.set_config_values(host_data[hostname], grp, var_data)
         return host_data
-
-
-    def get_host_ips(self, host_data):
-        return list(host_data.keys())
-
-    def get_inventory(self, topo, layout, config):
-        host_data = []
-        inven_hosts = []
-        for res in topo:
-            hd = self.get_host_data(res, config)
-            if hd:
-                host_data.append(hd)
-            inven_hosts = self.get_host_ips(hd)
-        # adding sections to respective host groups
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-        # set children for each host group
-        self.set_children(layout)
-        # set vars for each host group
-        self.set_vars(layout)
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-        return output.getvalue()

--- a/linchpin/InventoryFilters/OvirtInventory.py
+++ b/linchpin/InventoryFilters/OvirtInventory.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .InventoryFilter import InventoryFilter
 
@@ -52,9 +48,6 @@ class OvirtInventory(InventoryFilter):
                 self.set_config_values(host_data[hostname], dev, var_data)
         return host_data
 
-    def get_host_ips(self, host_data):
-        return list(host_data.keys())
-
 
     def config_value_helper(self, instance, keys):
         if "." in keys:
@@ -91,26 +84,3 @@ class OvirtInventory(InventoryFilter):
             if val:
                 return (var, val)
         return ''
-
-
-    def get_inventory(self, topo, layout, config):
-        host_data = []
-        inven_hosts = []
-        for res in topo:
-            hd = self.get_host_data(res, config)
-            if hd:
-                host_data.append(hd)
-            inven_hosts = self.get_host_ips(hd)
-        # adding sections to respective host groups
-        host_groups = self.get_layout_host_groups(layout)
-        self.add_sections(host_groups)
-        # set children for each host group
-        self.set_children(layout)
-        # set vars for each host group
-        self.set_vars(layout)
-        # add ip addresses to each host
-        self.add_ips_to_groups(inven_hosts, layout)
-        self.add_common_vars(host_groups, layout)
-        output = StringIO()
-        self.config.write(output)
-        return output.getvalue()

--- a/linchpin/tests/InventoryFilters/test_AWSInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_AWSInventory_pass.py
@@ -31,6 +31,7 @@ def setup_aws_inventory():
     topo = json.load(topo_file)['17']['targets'][0]['general-inventory']['outputs']['resources']
     topo_file.close()
 
+
 def setup_aws_config():
     global config
 
@@ -45,18 +46,6 @@ def setup_aws_config():
     config = yaml.load(cfg_file, Loader=yaml.FullLoader)['general-inventory']['cfgs']
     cfg_file.close()
 
-def setup_aws_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
 
 @with_setup(setup_aws_inventory)
 @with_setup(setup_aws_config)
@@ -67,24 +56,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-@with_setup(setup_aws_inventory)
-@with_setup(setup_aws_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[0], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ['10.179.254.83']
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-@with_setup(setup_aws_inventory)
-@with_setup(setup_aws_config)
-@with_setup(setup_aws_layout)
-def test_get_inventory():
-    """
-    """
-    #inventory = filter.get_inventory(empty_topo, layout, config)
-    #assert_false(inventory)
-    inventory = filter.get_inventory(topo, layout, config)
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_BeakerInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_BeakerInventory_pass.py
@@ -28,6 +28,7 @@ def setup_beaker_inventory_filter():
     topo = json.load(topo_file)['17']['targets'][0]['general-inventory']['outputs']['resources']
     topo_file.close()
 
+
 def setup_beaker_config():
     global config
 
@@ -42,19 +43,6 @@ def setup_beaker_config():
     config = yaml.load(cfg_file, Loader=yaml.FullLoader)['general-inventory']['cfgs']
     cfg_file.close()
 
-def setup_beaker_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
-
 
 @with_setup(setup_beaker_inventory_filter)
 @with_setup(setup_beaker_config)
@@ -65,31 +53,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-@with_setup(setup_beaker_inventory_filter)
-@with_setup(setup_beaker_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[1], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ['hp-dl380pgen8-02-vm-15.lab.bos.redhat.com']
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-
-@with_setup(setup_beaker_inventory_filter)
-def test_add_hosts_to_groups():
-    """
-    this method currently has no body in class BeakerInventory
-    """
-    pass
-
-
-@with_setup(setup_beaker_inventory_filter)
-@with_setup(setup_beaker_config)
-@with_setup(setup_beaker_layout)
-def test_get_inventory():
-    """
-    """
-    inventory = filter.get_inventory(topo, layout, config)
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_DuffyInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_DuffyInventory_pass.py
@@ -28,6 +28,7 @@ def setup_duffy_inventory_filter():
     topo = json.load(topo_file)['17']['targets'][0]['general-inventory']['outputs']['resources']
     topo_file.close()
 
+
 def setup_duffy_config():
     global config
 
@@ -42,18 +43,6 @@ def setup_duffy_config():
     config = yaml.load(cfg_file, Loader=yaml.FullLoader)['general-inventory']['cfgs']
     cfg_file.close()
 
-def setup_duffy_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
 
 @with_setup(setup_duffy_inventory_filter)
 @with_setup(setup_duffy_config)
@@ -64,23 +53,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-@with_setup(setup_duffy_inventory_filter)
-@with_setup(setup_duffy_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[5], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ['109.254.93.117', 'test.example.com']
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-@with_setup(setup_duffy_inventory_filter)
-@with_setup(setup_duffy_config)
-@with_setup(setup_duffy_layout)
-def test_get_inventory():
-    """
-    """
-    inventory = filter.get_inventory(topo, layout, config)
-    # should return some data
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_DummyInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_DummyInventory_pass.py
@@ -28,6 +28,7 @@ def setup_dummy_inventory_filter():
     topo = json.load(topo_file)['17']['targets'][0]['general-inventory']['outputs']['resources']
     topo_file.close()
 
+
 def setup_dummy_config():
     global config
 
@@ -42,18 +43,6 @@ def setup_dummy_config():
     config = yaml.load(cfg_file, Loader=yaml.FullLoader)['general-inventory']['cfgs']
     cfg_file.close()
 
-def setup_dummy_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
 
 @with_setup(setup_dummy_inventory_filter)
 @with_setup(setup_dummy_config)
@@ -64,22 +53,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-@with_setup(setup_dummy_inventory_filter)
-@with_setup(setup_dummy_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[2], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ['dummy-744068-0', 'dummy-744068-1', 'dummy-744068-2']
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-@with_setup(setup_dummy_inventory_filter)
-@with_setup(setup_dummy_config)
-@with_setup(setup_dummy_layout)
-def test_get_inventory():
-    """
-    """
-    inventory = filter.get_inventory(topo[2], layout, config)
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_GCloudInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_GCloudInventory_pass.py
@@ -28,6 +28,7 @@ def setup_gcloud_inventory_filter():
     topo = json.load(topo_file)['17']['targets'][0]['general-inventory']['outputs']['resources']
     topo_file.close()
 
+
 def setup_gcloud_config():
     global config
 
@@ -42,19 +43,6 @@ def setup_gcloud_config():
     config = yaml.load(cfg_file, Loader=yaml.FullLoader)['general-inventory']['cfgs']
     cfg_file.close()
 
-def setup_gcloud_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
-
 
 @with_setup(setup_gcloud_inventory_filter)
 @with_setup(setup_gcloud_config)
@@ -65,24 +53,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-
-@with_setup(setup_gcloud_inventory_filter)
-@with_setup(setup_gcloud_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[7], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ["194.231.24.112", "180.20.194.96"]
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-
-@with_setup(setup_gcloud_inventory_filter)
-@with_setup(setup_gcloud_config)
-@with_setup(setup_gcloud_layout)
-def test_get_inventory():
-    """
-    """
-    inventory = filter.get_inventory(topo, layout, config)
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_LibvirtInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_LibvirtInventory_pass.py
@@ -44,20 +44,6 @@ def setup_libvirt_config():
     cfg_file.close()
 
 
-def setup_libvirt_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
-
-
 @with_setup(setup_libvirt_inventory_filter)
 @with_setup(setup_libvirt_config)
 def test_get_host_data():
@@ -67,24 +53,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-
-@with_setup(setup_libvirt_inventory_filter)
-@with_setup(setup_libvirt_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[3], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ["192.168.122.219"]
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-
-@with_setup(setup_libvirt_inventory_filter)
-@with_setup(setup_libvirt_config)
-@with_setup(setup_libvirt_layout)
-def test_get_inventory():
-    """
-    """
-    inventory = filter.get_inventory(topo, layout, config)
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_OpenstackInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_OpenstackInventory_pass.py
@@ -44,20 +44,6 @@ def setup_openstack_config():
     cfg_file.close()
 
 
-def setup_openstack_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
-
-
 @with_setup(setup_openstack_inventory_filter)
 @with_setup(setup_openstack_config)
 def test_get_host_data():
@@ -67,24 +53,3 @@ def test_get_host_data():
     expected_vars = ['__IP__', '__ZONE__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-
-@with_setup(setup_openstack_inventory_filter)
-@with_setup(setup_openstack_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[4], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ['172.16.100.11']
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-
-@with_setup(setup_openstack_inventory_filter)
-@with_setup(setup_openstack_config)
-@with_setup(setup_openstack_layout)
-def test_get_inventory():
-    """
-    """
-    inventory = filter.get_inventory(topo, layout, config)
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_OvirtInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_OvirtInventory_pass.py
@@ -44,20 +44,6 @@ def setup_ovirt_config():
     cfg_file.close()
 
 
-def setup_ovirt_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
-
-
 @with_setup(setup_ovirt_inventory_filter)
 @with_setup(setup_ovirt_config)
 def test_get_host_data():
@@ -67,24 +53,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-
-@with_setup(setup_ovirt_inventory_filter)
-@with_setup(setup_ovirt_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[8], config)
-    ips = filter.get_host_ips(host_data)
-    expected_hosts = ["155.132.55.17", "11.50.197.1"]
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-
-@with_setup(setup_ovirt_inventory_filter)
-@with_setup(setup_ovirt_config)
-@with_setup(setup_ovirt_layout)
-def test_get_inventory():
-    """
-    """
-    inventory = filter.get_inventory(topo, layout, config)
-    assert_true(inventory)

--- a/linchpin/tests/InventoryFilters/test_VMwareInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_VMwareInventory_pass.py
@@ -30,6 +30,7 @@ def setup_vmware_inventory():
     topo = json.load(topo_file)['17']['targets'][0]['general-inventory']['outputs']['resources']
     topo_file.close()
 
+
 def setup_vmware_config():
     global config
 
@@ -44,18 +45,6 @@ def setup_vmware_config():
     config = yaml.load(cfg_file, Loader=yaml.FullLoader)['general-inventory']['cfgs']
     cfg_file.close()
 
-def setup_vmware_layout():
-    global layout
-
-    provider = 'general-inventory'
-    base_path = '{0}'.format(os.path.dirname(
-    os.path.realpath(__file__))).rstrip('/')
-    lib_path = os.path.realpath(os.path.join(base_path, os.pardir))
-    mock_path = '{0}/{1}/{2}'.format(lib_path, 'mockdata', provider)
-
-    template = 'linchpin.benchmark'
-    template_file = open(mock_path+'/'+template)
-    layout = json.load(template_file)['17']['targets'][0]['general-inventory']['inputs']['layout_data']['inventory_layout']
 
 @with_setup(setup_vmware_inventory)
 @with_setup(setup_vmware_config)
@@ -66,25 +55,3 @@ def test_get_host_data():
     expected_vars = ['__IP__']
     for host in host_data:
         assert_equal(set(host_data[host].keys()), set(expected_vars))
-
-@with_setup(setup_vmware_inventory)
-@with_setup(setup_vmware_config)
-def test_get_host_ips():
-    """
-    """
-    host_data = filter.get_host_data(topo[9], config)
-    ips = filter.get_host_ips(host_data)
-    print(ips)
-    expected_hosts = ['192.168.122.210']
-    assert_equal(set(host_data.keys()), set(expected_hosts))
-
-@with_setup(setup_vmware_inventory)
-@with_setup(setup_vmware_config)
-@with_setup(setup_vmware_layout)
-def test_get_inventory():
-    """
-    """
-    #inventory = filter.get_inventory(empty_topo, layout, config)
-    #assert_false(inventory)
-    inventory = filter.get_inventory(topo, layout, config)
-    assert_true(inventory)


### PR DESCRIPTION
Many of the provider-specific inventory filter functions are never used (and likely never will be) so there's no need to keep them around