### PR TITLE
Fixes for OpenStack 'additional_volumes'

### DIFF
--- a/linchpin/FilterUtils/FilterUtils.py
+++ b/linchpin/FilterUtils/FilterUtils.py
@@ -112,26 +112,21 @@ def format_networks(networks):
     return nics
 
 
-def render_os_server_insts(res_def, os_resource_name):
+def render_os_server_insts(res_def, res_def_names):
 
     output = []
-    if "count" in res_def:
-        server_names = [os_resource_name + str(i)
-                        for i in range(1, res_def["count"] + 1)]
-        for sname in server_names:
-            server_dict = {}
-            server_dict['name'] = sname
-            if 'additional_volumes' in res_def:
-                server_dict['volumes'] = []
-                for vol in res_def.get("additional_volumes", []):
-                    a_vol = {}
-                    a_vol.update(vol)
-                    a_vol["name"] = vol["name"] + "-" + server_dict["name"]
-                    a_vol["server_name"] = server_dict["name"]
-                    server_dict["volumes"].append(a_vol)
-            output.append(server_dict)
-    else:
-        return res_def
+    for sname in res_def_names:
+        server_dict = {}
+        server_dict['name'] = sname
+        if 'additional_volumes' in res_def:
+            server_dict['volumes'] = []
+            for vol in res_def.get("additional_volumes", []):
+                a_vol = {}
+                a_vol.update(vol)
+                a_vol["name"] = vol["name"] + "-" + server_dict["name"]
+                a_vol["server_name"] = server_dict["name"]
+                server_dict["volumes"].append(a_vol)
+        output.append(server_dict)
     return output
 
 

--- a/linchpin/provision/roles/openstack/files/schema.json
+++ b/linchpin/provision/roles/openstack/files/schema.json
@@ -53,10 +53,22 @@
 			"type": "list",
 			"required": false,
 			"schema": {
-                            "name": { "type": "string", "required": true },
-                            "size": { "type": "integer", "required": false },
-                            "device_name": { "type": "string", "required": false }
+                        "type": "dict",
+                        "schema": {
+                            "name": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "size": {
+                                "type": "integer",
+                                "required": false
+                            },
+                            "device_name": {
+                                "type": "string",
+                                "required": false
+                            }
                         }
+                }
 
 		    }
 

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -3,9 +3,22 @@
     res_def_names: []
     res_def_add_vol: "{{ res_def['additional_volumes'] | default([]) }}"
 
+- name: generate res_def_names
+  set_fact:
+    res_def_names: "{{ res_def_names  + [os_resource_name + default_delimiter + inst_c] }}"
+  with_sequence: start=0 end={{ res_def['count']|int - 1 }}
+  when: res_def['count'] > 1
+  loop_control:
+    loop_var: inst_c
+
+- name: generate res_def_names
+  set_fact:
+    res_def_names: "{{ res_def_names  + [os_resource_name] }}"
+  when: res_def['count'] == 1
+
 - name: set_fact instance filters
   set_fact:
-    res_def_prov: "{{ res_def | render_os_server_insts(os_resource_name) }}"
+    res_def_prov: "{{ res_def | render_os_server_insts(res_def_names) }}"
 
 - name: set_fact when addtional volumes
   set_fact:
@@ -46,19 +59,6 @@
   when: state == "absent"
   loop_control:
     loop_var: del_vol
-
-- name: generate res_def_names
-  set_fact:
-    res_def_names: "{{ res_def_names  + [os_resource_name + default_delimiter + inst_c] }}"
-  with_sequence: start=0 end={{ res_def['count']|int - 1 }}
-  when: res_def['count'] > 1
-  loop_control:
-    loop_var: inst_c
-
-- name: generate res_def_names
-  set_fact:
-    res_def_names: "{{ res_def_names  + [os_resource_name] }}"
-  when: res_def['count'] == 1
 
 - name: "provision/teardown os_server resources with provided auth"
   os_server:

--- a/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
+++ b/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
@@ -82,9 +82,10 @@ def test_format_networks():
 
 
 def test_os_server_insts():
-    res_def = { "count": 2 }
-    expected = [{ "name": "testname1"}, {"name": "testname2" }]
-    assert_equals(expected, filter_utils.render_os_server_insts(res_def, "testname"))
+    res_def = { 'additional_volumes': [{'name': 'test_vol', 'size': 1, 'device_name': '/dev/vdb'}]}
+    expected = [{ "name": "test_vol-testname", 'size': 1, 'device_name': '/dev/vdb', 'server_name': 'testname'}]
+    assert_equals(expected[-1],
+                  filter_utils.render_os_server_insts(res_def, ["testname"])[-1]['volumes'][-1])
 
 
 def test_merge_two_dicts():


### PR DESCRIPTION
 * Issue 1137 - Update the 'additional_volumes' key in the
   openstack schema.json to be compatible with Cerberus 1.3.1

 * Issue 1139 - Moved up the two 'generate res_def_names' tasks in
   the provision_os_server.yml to occur before the additional_volumes
   processing. Also updated the 'render_os_server_insts' filter to
   remove the server_name creation logic and use the res_def_names instead

 * Updated the test 'test_os_server_insts'