### PR TITLE
Cancel beaker job when there is a timeout while fetching the resources

### DIFF
--- a/linchpin/FilterUtils/FilterUtils.py
+++ b/linchpin/FilterUtils/FilterUtils.py
@@ -260,3 +260,13 @@ def transform_os_server_output(res_def_out):
         res_def["openstack"].append(ele.get("openstack", {}))
         res_def["servers"].append(ele.get("server", {}))
     return res_def
+
+
+def fetch_beaker_job_ids(topo_out):
+    output = []
+    for entry in topo_out:
+        entry_dict = {}
+        entry_dict["ids"] = []
+        entry_dict["ids"].append("J:" + entry["id"])
+        output.append(entry_dict)
+    return output

--- a/linchpin/provision/filter_plugins/fetch_beaker_job_ids.py
+++ b/linchpin/provision/filter_plugins/fetch_beaker_job_ids.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import linchpin.FilterUtils.FilterUtils as filter_utils
+
+
+class FilterModule(object):
+    ''' A filter to fetch jobids from topology outputs '''
+    def filters(self):
+        return {
+            'fetch_beaker_job_ids': filter_utils.fetch_beaker_job_ids
+        }

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -100,12 +100,19 @@
       run_id: "{{ rundb_id }}"
     when: not generate_resources
 
+- name: Provision beaker systems
+  block:
   - name: "fetch beaker details"
     bkr_info:
       ids: "{{ bkr_ids }}"
-      # pull provision params from the first (should be only) result
+  # pull provision params from the first (should be only) result
       provision_params: "{{ bkr.results[0].provision_params }}"
     register: _topo_out_bkr_server
+  rescue:
+  - bkr_server:
+      recipesets: "{{ topology_outputs_beaker_server | fetch_beaker_job_ids }}"
+      state: absent
+      cancel_message: "cancelled provisioning on timeout"
 
   - name: "set topology_outputs_beaker_server using recipe id"
     set_fact:

--- a/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
+++ b/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
@@ -144,4 +144,11 @@ def test_prepare_ssh_args():
 def test_transform_os_server_output():
     res_def_out = {"results": [{ "id": "testid" }]}
     expected = {'ids': ['testid'], 'openstack': [{}], 'servers': [{}]}
-    assert_equals(expected, filter_utils.transform_os_server_output(res_def_out))
+    assert_equals(expected,
+                  filter_utils.transform_os_server_output(res_def_out))
+
+def test_fetch_beaker_job_ids():
+    test_input = [{"id": "3124"}, {"id": "3214"}]
+    expected = [{'ids': ['J:3124']}, {'ids': ['J:3214']}]
+    assert_equals(expected,
+                  filter_utils.fetch_beaker_job_ids(test_input))


### PR DESCRIPTION
fixes #1153 

Summary:
- added fetch_beaker_ids filter
- added unit test to fetch_beaker_ids
- Updated playbooks to handle timed out beaker resources