### PR TITLE
Add support for async_retries option in linchpin

### DIFF
--- a/docs/source/examples/workspace/linchpin.conf
+++ b/docs/source/examples/workspace/linchpin.conf
@@ -215,6 +215,9 @@ generate_resources = False
 # Default vault password other than Environment var VAULT_PASSWORD
 #vault_pass = ''
 
+# Deafault number of retries on async timeout
+#async_retries = 60
+
 # This section covers settings for the `linchpin init` command
 #[init]
 

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -37,6 +37,7 @@ default_ssh_key_path = ~/.ssh
 debug_mode = False
 vault_encryption = False
 vault_pass = ''
+async_retries = 60
 
 
 # NOTE: if either of these change, the value in linchpin/templates must also change

--- a/linchpin/provision/roles/gather_resources/tasks/wait.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait.yml
@@ -7,6 +7,6 @@
     jid: "{{ job_obj['results'][0].ansible_job_id }}"
   register: job_result
   until: job_result.finished
-  retries: 45
+  retries: "{{ async_retries | default(60) }}"
   when: job_obj['results'][0].ansible_job_id is defined
   ignore_errors: yes

--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_aws_ec2.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_aws_ec2.yml
@@ -4,7 +4,7 @@
     jid: "{{ aws_ec2_group['ansible_job_id'] }}"
   register: job_result
   until: job_result.finished
-  retries: 30
+  retries: "{{ async_retries | default(60) }}"
   when: state == "present"
 
 - name: "Append outputitem to topology_outputs"

--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_gcloud_gce.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_gcloud_gce.yml
@@ -4,7 +4,7 @@
     jid: "{{ gcloud_gce_group['ansible_job_id'] }}"
   register: job_result
   until: job_result.finished
-  retries: 45
+  retries: "{{ async_retries | default(60) }}"
 
 - name: "Append outputitem"
   set_fact:

--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_os_heat.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_os_heat.yml
@@ -4,7 +4,7 @@
     jid: "{{ os_heat_group['ansible_job_id'] }}"
   register: job_result
   until: job_result.finished
-  retries: 30
+  retries: "{{ async_retries | default(60) }}"
 
 - name: "Append outputitem to topology_outputs"
   set_fact:

--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_os_obj.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_os_obj.yml
@@ -4,7 +4,7 @@
     jid: "{{ job_item['ansible_job_id'] }}"
   register: job_result
   until: job_result.finished
-  retries: 30
+  retries: "{{ async_retries | default(60) }}"
   with_items: "{{ os_obj_group['results']}}"
   loop_control:
     loop_var: job_item

--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_os_server.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_os_server.yml
@@ -9,7 +9,7 @@
   #  module_name: "os_server"
   register: job_result_present
   until: job_result_present.finished
-  retries: 30
+  retries: "{{ async_retries | default(60) }}"
   #debug:
   #  msg: "{{ item['ansible_job_id'] }}"
   loop: "{{ os_server_group['results'] }}"
@@ -20,26 +20,9 @@
     jid: "{{ item['ansible_job_id'] }}"
   register: job_result_absent
   until: job_result_absent.finished
-  retries: 30
+  retries: "{{ async_retries | default(60) }}"
   when: state == "absent"
   loop: "{{ os_server_group['results'] }}"
-
-#- name: "waiting on each job id when state is present"
-#  async_status_custom:
-#    jid: "{{ os_server_group['ansible_job_id'] }}"
-#    module_name: "os_server"
-#  register: job_result_present
-#  until: job_result_present.finished
-#  retries: 30
-#  when: state == "present"
-
-#- name: "waiting on each job id when state is absent"
-#  async_status_custom:
-#    jid: "{{ os_server_group['ansible_job_id'] }}"
-#  register: job_result_absent
-#  until: job_result_absent.finished
-#  retries: 30
-#  when: state == "absent"
 
 - name: "Append outputitem to topology_outputs"
   set_fact:

--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_os_volume.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_os_volume.yml
@@ -5,7 +5,7 @@
     module_name: "os_volume"
   register: job_result
   until: job_result.finished
-  retries: 30
+  retries: "{{ async_retries | default(60) }}"
   with_items: "{{ os_volume_group['results']}}"
 
 - name: "Append outputitem to topology_outputs"

--- a/linchpin/provision/roles/gather_resources/tasks/wait_on_vmware_guest.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/wait_on_vmware_guest.yml
@@ -4,7 +4,7 @@
     jid: "{{ vmware_guest_group['ansible_job_id'] }}"
   register: job_result
   until: job_result.finished
-  retries: 30
+  retries: "{{ async_retries | default(60) }}"
   when: state == "present"
 
 - name: "Append outputitem to topology_outputs"


### PR DESCRIPTION
fixes #1148

Summary:
- adds async_retries option to configure the number of retries
- updated example linchpin.conf
- updated playbooks