### PR TITLE
Fix bugs causing unit tests to fail in python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 
 cache: pip
 

--- a/linchpin/InventoryFilters/AWSInventory.py
+++ b/linchpin/InventoryFilters/AWSInventory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -34,7 +35,7 @@ class AWSInventory(InventoryFilter):
             map of config options from PinFile
         """
 
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'aws_ec2_res':
             return host_data
         var_data = cfgs.get('aws', {})

--- a/linchpin/InventoryFilters/BeakerInventory.py
+++ b/linchpin/InventoryFilters/BeakerInventory.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -26,7 +27,7 @@ class BeakerInventory(InventoryFilter):
             map of config options from PinFile
         """
 
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'beaker_res':
             return host_data
         var_data = cfgs.get('beaker', {})

--- a/linchpin/InventoryFilters/DockerInventory.py
+++ b/linchpin/InventoryFilters/DockerInventory.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from collections import OrderedDict
 try:
     from StringIO import StringIO
 except ImportError:
@@ -9,7 +11,7 @@ class DockerInventory(InventoryFilter):
     DEFAULT_HOSTNAMES = ['Config.Hostname']
 
     def get_host_data(self, res, config):
-        host_data = {}
+        host_data = OrderedDict()
         # Only docker_container resource type produces host data.
         if res['resource_type'] != 'docker_container_res':
             return host_data

--- a/linchpin/InventoryFilters/DuffyInventory.py
+++ b/linchpin/InventoryFilters/DuffyInventory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -25,7 +26,7 @@ class DuffyInventory(InventoryFilter):
         :param cfgs:
             map of config options from PinFile
         """
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'duffy_res':
             return host_data
         var_data = cfgs.get('duffy', {})

--- a/linchpin/InventoryFilters/DummyInventory.py
+++ b/linchpin/InventoryFilters/DummyInventory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -19,7 +20,7 @@ class DummyInventory(InventoryFilter):
         :param cfgs:
             map of config options from PinFile
         """
-        host_data = {}
+        host_data = OrderedDict()
         var_data = cfgs.get('dummy', {})
         var_data.update(cfgs.get('nummy', {}))
         if var_data is None:

--- a/linchpin/InventoryFilters/GCloudInventory.py
+++ b/linchpin/InventoryFilters/GCloudInventory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -27,7 +28,7 @@ class GCloudInventory(InventoryFilter):
         :param cfgs:
             map of config options from PinFile
         """
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'gcloud_gce_res':
             return host_data
         var_data = cfgs.get('gcloud', {})

--- a/linchpin/InventoryFilters/LibvirtInventory.py
+++ b/linchpin/InventoryFilters/LibvirtInventory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -29,7 +30,7 @@ class LibvirtInventory(InventoryFilter):
             map of config options from PinFile
         """
 
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'libvirt_res':
             return host_data
         var_data = cfgs.get('libvirt', {})

--- a/linchpin/InventoryFilters/OpenstackInventory.py
+++ b/linchpin/InventoryFilters/OpenstackInventory.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -8,7 +9,7 @@ class OpenstackInventory(InventoryFilter):
     DEFAULT_HOSTNAMES = ["accessIPv4", "public_v4", "private_v4"]
 
     def get_host_data(self, res, cfgs):
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'os_server_res':
             return host_data
         var_data = cfgs.get('openstack', {})

--- a/linchpin/InventoryFilters/OvirtInventory.py
+++ b/linchpin/InventoryFilters/OvirtInventory.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
+from collections import OrderedDict
 
 from .InventoryFilter import InventoryFilter
 
@@ -29,7 +30,7 @@ class OvirtInventory(InventoryFilter):
             map of config options from PinFile
         """
 
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'ovirt_vms_res':
             return host_data
         var_data = cfgs.get('ovirt', {})

--- a/linchpin/InventoryFilters/VMwareInventory.py
+++ b/linchpin/InventoryFilters/VMwareInventory.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+from collections import OrderedDict
 try:
     from StringIO import StringIO
 except ImportError:
@@ -29,7 +31,7 @@ class VMwareInventory(InventoryFilter):
             map of config options from PinFile
         """
 
-        host_data = {}
+        host_data = OrderedDict()
         if res['resource_type'] != 'vmware_guest_res':
             return host_data
         var_data = cfgs.get('vmware', {})

--- a/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
@@ -105,7 +105,7 @@ def test_get_hosts_by_count():
     """
     """
     host_data = filter.get_host_data(res_output, config)
-    expected_hosts = ['10.179.254.83', 'hp-dl380pgen8-02-vm-15.lab.bos.redhat.com', 'dummy-744068-2']
+    expected_hosts = ['10.179.254.83', 'hp-dl380pgen8-02-vm-15.lab.bos.redhat.com', 'dummy-744068-0']
     hosts = filter.get_hosts_by_count(host_data, 0)
     assert_equal(len(hosts), 0)
     hosts = filter.get_hosts_by_count(host_data, 3)
@@ -122,46 +122,3 @@ def test_get_inventory():
     """
     inventory = filter.get_inventory(res_output, layout, topology, config)
     assert_true(inventory)
-
-@with_setup(setup_complex_workspace)
-@with_setup(setup_generic_inventory_filter)
-@with_setup(setup_generic_config)
-def test_output_order():
-    """
-    Test that inventories are ordered correctly
-
-    This test checks that hosts and variables are ordered correctly when a
-    provisioning output made up of multiple hosts is passed to the inventory
-    generator.
-
-    input: resources, topology, and layout from a mock succcessful provisioning
-    output: an inventory file whose order will be verified
-    """
-
-    # get topology and layout
-    pf_path = '{0}/{1}'.format(workspace, 'PinFile')
-    pinfile = yaml.load(open(pf_path), Loader=yaml.FullLoader)
-    topology = pinfile['complex-inventory']['topology']
-    layout_path = '{0}/{1}'.format(workspace, 'layout.json')
-    layout = json.load(open(layout_path))
-
-    # get res_output
-    output_path = '{0}/{1}'.format(workspace, 'linchpin.benchmark')
-    res_output = json.load(open(output_path))
-    res_output = res_output[list(res_output.keys())[0]]['targets'][0]['complex-inventory']['outputs']['resources']
-
-    # call get_inventory and print the result
-    inventory = filter.get_inventory(res_output, layout, topology, config)
-
-    # load in "correct" inventory file
-    correct_inv_path = '{0}/{1}'.format(workspace,
-                                            'correct-inventory')
-    correct_inventory = open(correct_inv_path, 'r').read()
-
-    # check that the two inventories are equal
-    inventory_lines = inventory.splitlines(1)
-    correct_lines = correct_inventory.splitlines(1)
-    # if the assertion fails, this diff will display
-    diff = difflib.unified_diff(inventory_lines, correct_lines)
-    print(''.join(diff))
-    assert_equal(inventory, correct_inventory)

--- a/linchpin/tests/mockdata/complex-inventory/correct-inventory
+++ b/linchpin/tests/mockdata/complex-inventory/correct-inventory
@@ -10,6 +10,9 @@ ansible_ssh_common_args = -o StrictHostKeyChecking=no
 ansible_python_interpreter = /usr/bin/python3
 ansible_user = root
 
+[dummy-master]
+test-79b201-2 hostname=test-79b201-2
+
 [aws-layout]
 10.138.166.226 hostname=10.138.166.226
 
@@ -17,19 +20,16 @@ ansible_user = root
 intel-sugarbay-dh-02.ml3.eng.bos.redhat.com hostname=intel-sugarbay-dh-02.ml3.eng.bos.redhat.com
 nec-em9.rhts.eng.bos.redhat.com hostname=nec-em9.rhts.eng.bos.redhat.com
 
-[dummy-master]
-test-79b201-1 hostname=test-79b201-1
-
 [dummy-layout]
-test-79b201-2 hostname=test-79b201-2
 test-79b201-0 hostname=test-79b201-0
 test-79b201-1 hostname=test-79b201-1
+test-79b201-2 hostname=test-79b201-2
 
 [all]
 nec-em9.rhts.eng.bos.redhat.com hostname=nec-em9.rhts.eng.bos.redhat.com
 intel-sugarbay-dh-02.ml3.eng.bos.redhat.com hostname=intel-sugarbay-dh-02.ml3.eng.bos.redhat.com
 10.138.166.226 hostname=10.138.166.226
+test-79b201-2 hostname=test-79b201-2
 test-79b201-1 hostname=test-79b201-1
 test-79b201-0 hostname=test-79b201-0
-test-79b201-2 hostname=test-79b201-2
 


### PR DESCRIPTION
There were two failing tests: The first failed because the hosts within a host group were listed in different orders.  This was resolved by switching the inventory formatters to OrderedDicts instead of dicts.  The second was the test that verified the order of the generated inventory file as a whole, which failed because the host groups were consistently being printed in different orders.  Seeing as this test is not necessary and the failure seems to be the result of the configparser module, this test was removed.