### PR TITLE
remove duplicate requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,4 @@ configparser>=3.5.0
 openshift>=0.8.6,<0.8.8
 pyasn1>=0.1.9
 gitpython>=2.1.11
-urllib3<1.25
 pytest<=4.4.0


### PR DESCRIPTION
Duplicate requirements found on requirements.txt causing error on linchpin release
```
00:26:16  DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
00:26:16  ERROR: Double requirement given: urllib3<1.25 (from -r /tmp/tmp.wpSCcliKzL/requirements.txt (line 23)) (already in urllib3<1.25,>=1.23 (from -r /tmp/tmp.wpSCcliKzL/requirements.txt (line 16)), name='urllib3')
00:26:16  + pip install linchpin==1.7.6 --index-url https://test.pypi.org/simple
00:26:16  DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
00:26:16  Looking in indexes: https://test.pypi.org/simple
00:26:16  Collecting linchpin==1.7.6
00:26:16    Downloading https://test-files.pythonhosted.org/packages/f0/f4/96957ab5499177d734a4ecc67516e08955dc535502bc770f63fde69a310d/linchpin-1.7.6-py2-none-any.whl (735kB)
00:26:16  Requirement already satisfied: ipaddress>=1.0.17 in /usr/lib/python2.7/site-packages (from linchpin==1.7.6) (1.0.18)
00:26:16  Collecting shade>=1.30.0 (from linchpin==1.7.6)
00:26:16    ERROR: Could not find a version that satisfies the requirement shade>=1.30.0 (from linchpin==1.7.6) (from versions: none)
00:26:16  ERROR: No matching distribution found for shade>=1.30.0 (from linchpin==1.7.6)
00:26:16  + linchpin --version
00:26:16  + grep 1.7.6
00:26:16  + '[' 1 -eq 0 ']'
00:26:16  + echo FAILURE
00:26:16  FAILURE
00:26:16  + exit 1
```