### PR TITLE
Improve hook communication

### DIFF
--- a/docs/source/examples/workspaces/dummy-python-hook/PinFile
+++ b/docs/source/examples/workspaces/dummy-python-hook/PinFile
@@ -3,10 +3,15 @@ dummy_target:
   topology: dummy-topology.yml
   layout: dummy-layout.yml
   hooks:
-    postup:
+    preup:
       - name: ex_hook
         type: python
         context: False
         actions:
           - list_files.py
+    postdestroy:
+      - name: ex_hook
+        type: python
+        context: False
+        actions:
           - find_pinfile.py

--- a/docs/source/examples/workspaces/dummy-python-hook/hooks/python/ex_hook/find_pinfile.py
+++ b/docs/source/examples/workspaces/dummy-python-hook/hooks/python/ex_hook/find_pinfile.py
@@ -3,18 +3,20 @@ import sys
 import json
 
 
-prev_hooks = sys.argv[-1]
+prev_hooks = sys.argv[-2]
+pipe_path = sys.argv[-1]
 print("input: {0}".format(prev_hooks))
 
 prev_hooks = json.loads(prev_hooks)
-
+respipe = open(pipe_path, 'w')
 
 # return successfully if the PinFile is in the list of files
 for hook in prev_hooks:
+    print(hook['data'])
     if type(hook['data']) is list and 'PinFile' in hook['data']:
-        print('found PinFile')
+        print('Found PinFile')
         sys.exit(0)
 
 error = {'error': 'could not find \'PinFile\'', 'files': files}
-print(error, file=sys.stderr)
+print(error, file=respipe)
 sys.exit(1)

--- a/docs/source/examples/workspaces/dummy-python-hook/hooks/python/ex_hook/list_files.py
+++ b/docs/source/examples/workspaces/dummy-python-hook/hooks/python/ex_hook/list_files.py
@@ -3,8 +3,13 @@ import os
 import json
 import sys
 
-workspace = os.listdir(".")
-
-print("output to stderr: {0}".format(json.dumps(workspace)))
-print(json.dumps(workspace), file=sys.stderr)
-
+output_path = sys.argv[-1]
+print(output_path)
+try:
+    workspace = os.listdir(".")
+    print("output to stderr: {0}".format(json.dumps(workspace)))
+    out = open(output_path, 'w')
+    out.write(json.dumps(workspace))
+    out.close()
+except OSError as e:
+    print(e)

--- a/docs/source/hooks.rst
+++ b/docs/source/hooks.rst
@@ -263,7 +263,7 @@ Hook Communication:
 
 Hooks can read data from other hooks run in the same target.  Hook data is not shared between a provisioning and corresponding teardown task, but is shared between pre- and post- provisioning as well as between action managers.
 
-With the exception of the Ansible action manager, hook data is passed as the last argument to the hook.  The data is formatted as a JSON array.  Each item in the array is an object with three fields: :term:`return_code`. :term:`data`, and :term:`state` (e.g. preup).  In order for a hook to share data, it should output it as json to stderr.  This will be saved to the :term:`data` field of the hook data object.  If the stderr output is not valid json, it will be ignored.
+**Experimental** With the exception of the Ansible action manager, hook data is passed via the command line.  Each hook will receive two arguments on the command line.  The first is a json array containing data from previous hook runs.  If the hooks are associated with a teardown, this will include hook data for both the hooks in the current run and the hooks in the corresponding provisioning step.  Each item in the array is an object with three fields: :term:`return_code`. :term:`data`, and :term:`state` (e.g. preup).  The second argument is a path to a temporary file.  In order for a hook to share data, it should write any data it wants to share as json to this file.  If the data in the file is not valid json, it will be ignored.
 
 The ansible action manager handles data somewhat differently.  The results array is passed as a variable called :term:`hook_results` to Ansible's extra vars.  Data from Ansible will be sent back to LinchPin using the :term:`PlaybookCallback` class.
 

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -622,7 +622,13 @@ class LinchpinAPI(object):
                                     ])
 
             # note : changing the state triggers the hooks
-            self.hooks.rundb = (rundb, rundb_id)
+            if action == 'destroy':
+                if not run_id:
+                    prev_id = run_id if run_id else rundb.get_run_id(target,
+                                                                     'up')
+                self.hooks.rundb = (rundb, rundb_id, prev_id)
+            else:
+                self.hooks.rundb = (rundb, rundb_id)
             self.pb_hooks = self.get_cfg('hookstates', action)
             self.ctx.log_debug('calling: {0}{1}'.format('pre', action))
 

--- a/linchpin/hooks/action_managers/nodejs_action_manager.py
+++ b/linchpin/hooks/action_managers/nodejs_action_manager.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
+import os
 import json
+import shutil
+import tempfile
 from .action_manager import ActionManager
 from Naked.toolshed.shell import muterun_js
 from cerberus import Validator
@@ -69,20 +72,19 @@ class NodejsActionManager(ActionManager):
             return status
 
 
-    def add_ctx_params(self, file_path, context=True):
+    def add_ctx_params(self, hook_path, results, data_path, context=True):
 
         """
         Adds ctx params to the action_block run when context is true
-        :param file_path: path to the script
+        :param hook_path: path to the script
         :param context: whether the context params are to be included or not
         """
-
-        if not context:
-            return file_path
-        params = file_path
-        for key in self.target_data:
-            params += " {0}={1} ".format((key, self.target_data[key]))
-        return "{0} {1}".format(file_path, params)
+        params = hook_path
+        if context:
+            for key in self.target_data:
+                params += " {0}={1} ".format(key, self.target_data[key])
+        params += " -- '{0}' {1}".format(results, data_path)
+        return params
 
 
     def execute(self, results):
@@ -91,22 +93,32 @@ class NodejsActionManager(ActionManager):
         Executes the action_block in the PinFile
         """
 
+        tmpdir = tempfile.mkdtemp()
         for action in self.action_data["actions"]:
             result = {}
 
+            data_path = os.path.join(tmpdir, action)
             context = self.action_data.get("context", True)
             path = self.action_data["path"]
-            file_path = "{0}/{1}".format(path, action)
+            hook_path = "{0}/{1}".format(path, action)
             res_str = json.dumps(results, separators=(',', ':'))
-            command = self.add_ctx_params(file_path, context)
+            command = self.add_ctx_params(hook_path,
+                                          res_str,
+                                          data_path,
+                                          context)
             run_data = muterun_js(command, arguments=res_str)
 
             print(run_data.stdout)
 
-            data = run_data.stderr
             try:
+                data_file = open(data_path, 'r')
+                data = data_file.read()
                 if data:
                     result['data'] = json.loads(data)
+            except IOError:
+                # if an IOError is thrown, the file was not created because
+                # the hook passed no data back
+                continue
             except ValueError:
                 print("Warning: '{0}' is not a valid JSON object.  "
                       "Data from this hook will be discarded".format(data))
@@ -115,4 +127,7 @@ class NodejsActionManager(ActionManager):
             result['state'] = str(self.state)
             results.append(result)
 
+            data_file.close()
+
+        shutil.rmtree(tmpdir)
         return results

--- a/linchpin/hooks/action_managers/python_action_manager.py
+++ b/linchpin/hooks/action_managers/python_action_manager.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from .action_manager import ActionManager
+import os
 import sys
 import json
 import subprocess
+import tempfile
+import shutil
 from cerberus import Validator
 
 from linchpin.exceptions import HookError
@@ -69,41 +72,40 @@ class PythonActionManager(ActionManager):
             return status
 
 
-    def add_ctx_params(self, file_path, results, context=True):
+    def add_ctx_params(self, hook_path, results, data_path, context=True):
 
         """
         Adds ctx params to the action_block run when context is true
-        :param file_path: path to the script
+        :param hook_path: path to the script
         :param context: whether the context params are to be included or not
         """
 
-        if not context:
-            return "{0} {1} -- '{2}'".format(sys.executable,
-                                             file_path,
-                                             results)
-        params = ""
-        for key in self.target_data:
-            params += " {0}={1} ".format(key, self.target_data[key])
-        params += '{0}'.format(results)
-        return "{0} {1} {2}".format(sys.executable,
-                                    file_path,
-                                    params)
+        params = "{0} {1}".format(sys.executable, hook_path)
+        if context:
+            for key in self.target_data:
+                params += " {0}={1} ".format(key, self.target_data[key])
+        params += " -- '{0}' {1}".format(results, data_path)
+        return params
 
 
     def execute(self, results):
-
         """
         Executes the action_block in the PinFile
         """
 
+        tmpdir = tempfile.mkdtemp()
         for action in self.action_data["actions"]:
             result = {}
 
+            data_path = os.path.join(tmpdir, action)
             context = self.action_data.get("context", True)
             path = self.action_data["path"]
-            file_path = "{0}/{1}".format(path, action)
+            hook_path = "{0}/{1}".format(path, action)
             res_str = json.dumps(results, separators=(',', ':'))
-            command = self.add_ctx_params(file_path, res_str, context)
+            command = self.add_ctx_params(hook_path,
+                                          res_str,
+                                          data_path,
+                                          context)
             proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
             proc.wait()
@@ -111,15 +113,21 @@ class PythonActionManager(ActionManager):
             for line in proc.stdout:
                 print(line)
 
-            data = proc.stderr.read()
             try:
+                data_file = open(data_path, 'r')
+                data = data_file.read()
                 if data:
                     result['data'] = json.loads(data)
+            except IOError:
+                # if an IOError is thrown, the file does not exist
+                continue
             except ValueError:
                 print("Warning: '{0}' is not a valid JSON object.  "
                       "Data from this hook will be discarded".format(data))
             result['return_code'] = proc.returncode
             result['state'] = str(self.state)
-
             results.append(result)
+            data_file.close()
+
+        shutil.rmtree(tmpdir)
         return results


### PR DESCRIPTION
Improve the manner in which data is passed between hooks.  Since this feature is targeted for 2.0, this is experimental for now.  In particular, `-destroy` hooks cannot collect data from `-up` hooks.  This is something I'm still working on but I wanted to get this piece submitted