### PR TITLE
Freeze GitPython version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ jinja2>=2.10
 configparser>=3.5.0
 openshift>=0.8.6,<0.8.8
 pyasn1>=0.1.9
-gitpython>=2.1.11
+gitpython==2.1.11
 pytest<=4.4.0


### PR DESCRIPTION
GitPython 2.1.12 is only compatible with Python 3.  This freezes the version at 2.1.11 until Python 2 support is dropped