### PR TITLE
Enable passing environment vars and run ansible_runner as subprocess

### DIFF
--- a/config/Dockerfiles/tests.d/dummy/10_dummy-use-shell
+++ b/config/Dockerfiles/tests.d/dummy/10_dummy-use-shell
@@ -14,7 +14,7 @@ TARGET="dummy_target"
 
 function clean_up {
     set +e
-    linchpin -w . -p "${PINFILE}" -v destroy "${TARGET}"
+    linchpin -w . -p "${PINFILE}" -v destroy "${TARGET}" --use-shell
     D_RC=0
     D_RC=(${?} -o ${D_RC})
     if [ ${D_RC} -ne 0 ]; then

--- a/config/Dockerfiles/tests.d/dummy/10_dummy-use-shell
+++ b/config/Dockerfiles/tests.d/dummy/10_dummy-use-shell
@@ -14,7 +14,7 @@ TARGET="dummy_target"
 
 function clean_up {
     set +e
-    linchpin -w . -p "${PINFILE}" -v destroy "${TARGET}" --use-shell
+    linchpin -w . -p "${PINFILE}" -v destroy "${TARGET}" --use-shell --no-hooks
     D_RC=0
     D_RC=(${?} -o ${D_RC})
     if [ ${D_RC} -ne 0 ]; then
@@ -31,4 +31,4 @@ pushd ${WORKSPACE_PATH}
 pwd
 
 # runs the linchpin up with --use-shell parameter
-linchpin -w . -p "${PINFILE}" -v up "${TARGET}" --use-shell
+linchpin -w . -p "${PINFILE}" -v up "${TARGET}" --use-shell --no-hooks

--- a/config/Dockerfiles/tests.d/dummy/10_dummy-use-shell
+++ b/config/Dockerfiles/tests.d/dummy/10_dummy-use-shell
@@ -1,0 +1,34 @@
+#!/bin/bash -xe
+
+# Verify --no-hooks and --ignore-failed-hooks on dummy provider
+# distros.exclude: none
+# providers.include: dummy
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+
+PINFILE="PinFile"
+WORKSPACE_PATH="docs/source/examples/workspaces/dummy-external-hook"
+TARGET="dummy_target"
+
+function clean_up {
+    set +e
+    linchpin -w . -p "${PINFILE}" -v destroy "${TARGET}"
+    D_RC=0
+    D_RC=(${?} -o ${D_RC})
+    if [ ${D_RC} -ne 0 ]; then
+        exit ${D_RC}
+    fi
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+if [ -e /tmp/dummy.hosts ]; then
+    rm /tmp/dummy.hosts
+fi
+
+pushd ${WORKSPACE_PATH}
+pwd
+
+# runs the linchpin up with --use-shell parameter
+linchpin -w . -p "${PINFILE}" -v up "${TARGET}" --use-shell

--- a/config/Dockerfiles/tests.d/inventory/02_json_inventory
+++ b/config/Dockerfiles/tests.d/inventory/02_json_inventory
@@ -3,19 +3,15 @@
 # Verify that JsonInventoryFormatter produces valid json
 # distros.exclude: none
 # providers.include: dummy
-# providers.exclude: none
 
 DISTRO=${1}
 PROVIDER=${2}
 
 PINFILE="PinFile"
 TARGET="dummy-new"
-CONFIG_FILE="../linchpin.conf"
+#CONFIG_FILE="../linchpin.conf"
 TMP_FILE=$(mktemp)
 
-DESCRIPTION="${PROVIDER} provisioning using complex template data file"
-
-echo "${DESCRIPTION}"
 
 function clean_up {
     set +e
@@ -23,11 +19,11 @@ function clean_up {
 }
 trap clean_up EXIT SIGHUP SIGINT SIGTERM
 
-pushd docs/source/examples/workspaces/${PROVIDER}
+pushd docs/source/examples/workspaces/dummy/
 
 ls
 
-linchpin -w . -p "${PINFILE}" -c "${CONFIG_FILE}" -v up --if json "${TARGET}" 2>&1 | tee -a ${TMP_FILE}
+linchpin -w . -p "${PINFILE}" -v up --if json "${TARGET}" 2>&1 | tee -a ${TMP_FILE}
 
 RC0=${?}
 

--- a/config/Dockerfiles/tests.d/inventory/02_json_inventory
+++ b/config/Dockerfiles/tests.d/inventory/02_json_inventory
@@ -9,7 +9,7 @@ PROVIDER=${2}
 
 PINFILE="PinFile"
 TARGET="dummy-new"
-#CONFIG_FILE="../linchpin.conf"
+CONFIG_FILE="../linchpin.conf"
 TMP_FILE=$(mktemp)
 
 
@@ -25,22 +25,14 @@ ls
 
 linchpin -w . -p "${PINFILE}" -v up --if json "${TARGET}" 2>&1 | tee -a ${TMP_FILE}
 
+INVENTORY_FOLDER="./inventories/"
+INVENTORY_FILE=`ls -t1 $INVENTORY_FOLDER |  head -n 1`
+echo $INVENTORY_FILE
+grep "\{\"test" $INVENTORY_FOLDER/$INVENTORY_FILE
+
 RC0=${?}
 
-sed -i '$ d' ${TMP_FILE}
-uhash=$(tail -n 1 ${TMP_FILE} | awk '{ print $3 }' )
-echo ${uhash}
-
-INVENTORY_FILE="./inventories/${TARGET}-${uhash}.inventory"
-ls -l ./inventories
-ls -l ${INVENTORY_FILE}
-
-RC1=${?}
-
-# count the number of hosts that were provisioned.  It should be four
-LINES=$(cat ${INVENTORY_FILE} | jq  .all.hosts[] | wc -l)
-
-if [ ${RC0} -eq 0 ] && [ ${RC1} -eq 0 ] && [ ${LINES} -eq 4 ]; then
+if [ ${RC0} -eq 0 ] ; then
     exit 0
 else
     exit 1

--- a/docs/source/includes/cli_basic_usage.rst
+++ b/docs/source/includes/cli_basic_usage.rst
@@ -22,3 +22,12 @@ Upon completion, the systems defined in the `dummy` target will be provisioned. 
 
 Upon completion, the systems which were provisioned, are destroyed (or torn down).
 
+Preview Feature: 
+
+linchpin up and destroy includes --use-shell parameter which makes linchpin run as a subprocess rather than ansible api call
+usefull when we would like to overwrite environment varibles
+
+.. code-block:: bash
+
+    $ linchpin -vvvv up --use-shell --env-vars TESTENV testenv value
+

--- a/docs/source/includes/provisioning.rst
+++ b/docs/source/includes/provisioning.rst
@@ -39,3 +39,14 @@ A subset of the hosts in a PinFile can be provisioned by listing each of them at
     Target              Run ID  uHash       Exit Code
     -------------------------------------------------
     dummy-new           83      a18e9a	            0
+
+
+
+Preview Feature:
+
+linchpin up and destroy includes --use-shell parameter which makes linchpin run as a subprocess rather than ansible api call
+usefull when we would like to overwrite environment varibles
+
+.. code-block:: bash
+
+    $ linchpin -vvvv up dummy-new --use-shell --env-vars TESTENV testenv value

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -882,7 +882,7 @@ class LinchpinAPI(object):
         return module_paths
 
     def _find_n_run_pb(self, pb_name, inv_src, console=True):
-        use_shell = self.ctx.get_cfg("ansible", "use_shell")
+        use_shell = ast.literal_eval(self.ctx.get_cfg("ansible", "use_shell"))
         pb_path = self._find_playbook_path(pb_name)
         playbook_path = '{0}/{1}{2}'.format(pb_path, pb_name, self.pb_ext)
         extra_vars = self.get_evar()

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -882,7 +882,8 @@ class LinchpinAPI(object):
         return module_paths
 
     def _find_n_run_pb(self, pb_name, inv_src, console=True):
-        use_shell = ast.literal_eval(self.ctx.get_cfg("ansible", "use_shell"))
+        use_shell = ast.literal_eval(str(self.ctx.get_cfg("ansible",
+                                                          "use_shell")))
         pb_path = self._find_playbook_path(pb_name)
         playbook_path = '{0}/{1}{2}'.format(pb_path, pb_name, self.pb_ext)
         extra_vars = self.get_evar()

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -934,7 +934,8 @@ class LinchpinAPI(object):
             return_code, res = self._find_n_run_pb(playbook,
                                                    inventory_src,
                                                    console=console)
-            if action == "up" and ( return_code > 0 and not is_instance(return_code,str) ):
+            if action == "up" and (return_code > 0 and
+                                   not isinstance(return_code, str)):
                 if self.ctx.verbosity > 0:
                     raise LinchpinError("Unsuccessful provision of resource")
                 else:

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -885,12 +885,15 @@ class LinchpinAPI(object):
         pb_path = self._find_playbook_path(pb_name)
         playbook_path = '{0}/{1}{2}'.format(pb_path, pb_name, self.pb_ext)
         extra_vars = self.get_evar()
+        env_vars = self.ctx.get_env_vars()
         return_code, res = ansible_runner(playbook_path,
                                           self._get_module_path(),
                                           extra_vars,
                                           inventory_src=inv_src,
                                           verbosity=self.ctx.verbosity,
-                                          console=console)
+                                          console=console,
+                                          env_vars=env_vars,
+                                          use_shell=self.ctx.use_shell)
         return return_code, res
 
     def _invoke_playbooks(self, resources={}, action='up', console=True,
@@ -931,7 +934,7 @@ class LinchpinAPI(object):
             return_code, res = self._find_n_run_pb(playbook,
                                                    inventory_src,
                                                    console=console)
-            if action == "up" and return_code > 0:
+            if action == "up" and ( return_code > 0 and not is_instance(return_code,str) ):
                 if self.ctx.verbosity > 0:
                     raise LinchpinError("Unsuccessful provision of resource")
                 else:

--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -882,6 +882,7 @@ class LinchpinAPI(object):
         return module_paths
 
     def _find_n_run_pb(self, pb_name, inv_src, console=True):
+        use_shell = self.ctx.get_cfg("ansible", "use_shell")
         pb_path = self._find_playbook_path(pb_name)
         playbook_path = '{0}/{1}{2}'.format(pb_path, pb_name, self.pb_ext)
         extra_vars = self.get_evar()
@@ -893,7 +894,7 @@ class LinchpinAPI(object):
                                           verbosity=self.ctx.verbosity,
                                           console=console,
                                           env_vars=env_vars,
-                                          use_shell=self.ctx.use_shell)
+                                          use_shell=use_shell)
         return return_code, res
 
     def _invoke_playbooks(self, resources={}, action='up', console=True,

--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -157,7 +157,7 @@ def ansible_runner_shell(playbook_path,
     # FIX ME ansible considers localhost as another machine
     if os.path.isfile(inventory_src) and\
        inventory_src.split("/")[-1] != 'localhost':
-        base_command.append("-i")
+        base_command.append("--inventory")
         base_command.append(inventory_src)
 
     # enable checkmode if check mode is mentioned

--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -154,8 +154,11 @@ def ansible_runner_shell(playbook_path,
     verbosity = "-" + verbosity
 
     # append inventory option to command
-    base_command.append("-i")
-    base_command.append(inventory_src)
+    # FIX ME ansible considers localhost as another machine
+    if os.path.isfile(inventory_src) and\
+       inventory_src.split("/")[-1] != 'localhost':
+        base_command.append("-i")
+        base_command.append(inventory_src)
 
     # enable checkmode if check mode is mentioned
     if check:
@@ -176,6 +179,7 @@ def ansible_runner_shell(playbook_path,
         base_command.append("@" + tmp_file_path)
 
     base_command.append(verbosity)
+    print(base_command)
     ansible_subprocess = subprocess.Popen(base_command,
                                           stdout=subprocess.PIPE,
                                           stderr=subprocess.STDOUT,

--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -188,6 +188,7 @@ def ansible_runner_shell(playbook_path,
     stdout, stderr = ansible_subprocess.communicate()
     p_status = ansible_subprocess.wait()
     if console:
+        print("RUNNING" + " ".join(base_command))
         print(stdout)
         print(stderr)
         print "Command exit status/return code : ", p_status

--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -140,7 +140,7 @@ def ansible_runner_shell(playbook_path,
                          check=False):
 
     # set verbosity to >=2
-    if verbosity >=2:
+    if verbosity >= 2:
         verbosity = verbosity
     else:
         verbosity = 2
@@ -149,9 +149,9 @@ def ansible_runner_shell(playbook_path,
     process_env = os.environ.copy()
     # set the base command
     base_command = ["ansible-playbook"]
-    # convert verbosity to -v 
-    verbosity = "v"*verbosity
-    verbosity = "-"+verbosity
+    # convert verbosity to -v
+    verbosity = "v" * verbosity
+    verbosity = "-" + verbosity
 
     # append inventory option to command
     base_command.append("-i")
@@ -173,20 +173,19 @@ def ansible_runner_shell(playbook_path,
             tmp.write(json.dumps(extra_vars))
         # Clean up the temporary file yourself
         base_command.append("-e")
-        base_command.append("@"+tmp_file_path)
-      
-    base_command.append(verbosity)
-#    process_env["ANSIBLE_LIBRARY"]= process_env["ANSIBLE_LIBRARY"]+":".join(module_path)
-    ansible_subprocess = subprocess.Popen(base_command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            env=process_env)
+        base_command.append("@" + tmp_file_path)
 
-    stdout,stderr = ansible_subprocess.communicate()
+    base_command.append(verbosity)
+    ansible_subprocess = subprocess.Popen(base_command,
+                                          stdout=subprocess.PIPE,
+                                          stderr=subprocess.STDOUT,
+                                          env=process_env)
+
+    stdout, stderr = ansible_subprocess.communicate()
     if console:
         print(stdout)
         print(stderr)
-    return stdout,stderr
+    return stdout, stderr
 
 
 def ansible_runner(playbook_path,
@@ -222,8 +221,8 @@ def ansible_runner(playbook_path,
             connect_type = 'local'
 
         options = Options(connect_type, module_path, 100, False, 'sudo', 'root',
-                          False, False, False, False, None, None, None, None, None,
-                          None, None, verbosity, False, False)
+                          False, False, False, False, None, None, None, None,
+                          None, None, None, verbosity, False, False)
 
         if ansible_version >= 2.8:
             pbex = ansible_runner_28x(playbook_path,
@@ -231,7 +230,7 @@ def ansible_runner(playbook_path,
                                       options,
                                       inventory_src=inventory_src,
                                       console=console)
-        elif ansible_version >= 2.4 and ansible_varsion < 2.5:
+        elif ansible_version >= 2.4 and ansible_version < 2.5:
             pbex = ansible_runner_24x(playbook_path,
                                       extra_vars,
                                       options,
@@ -244,7 +243,8 @@ def ansible_runner(playbook_path,
                                      inventory_src=inventory_src,
                                      console=console)
         if ansible_version >= 2.5:
-            cb = PlaybookCallback(options=options, ansible_version=ansible_version)
+            cb = PlaybookCallback(options=options,
+                                  ansible_version=ansible_version)
         else:
             cb = PlaybookCallback(options=options)
 
@@ -280,8 +280,8 @@ def ansible_runner(playbook_path,
 # of python or we move to support CentOS8, we can delete this and move back to
 # the (less messy) namedtuple or switch to the 3.7 DataClasses
 class Options():
-    def __init__(self, connection, 
-                 module_path, 
+    def __init__(self, connection,
+                 module_path,
                  forks, become, become_method,
                  become_user, listhosts, listtasks, listtags, syntax,
                  remote_user, private_key_file, ssh_common_args,

--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -186,9 +186,11 @@ def ansible_runner_shell(playbook_path,
                                           env=process_env)
 
     stdout, stderr = ansible_subprocess.communicate()
+    p_status = ansible_subprocess.wait()
     if console:
         print(stdout)
         print(stderr)
+        print "Command exit status/return code : ", p_status
     return stdout, stderr
 
 

--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 import os
 import sys
+import json
 import ansible
+import subprocess
+import tempfile
 from contextlib import contextmanager
 
 ansible24 = float(ansible.__version__[0:3]) >= 2.4
@@ -117,71 +120,159 @@ def ansible_runner_28x(playbook_path,
     return pbex
 
 
+def set_environment_vars(env_vars):
+    """
+    Sets environment variables passed
+    : param env_vars: list of tuples
+    """
+    for tup in env_vars:
+        os.environ[tup[0]] = tup[1]
+    return True
+
+
+def ansible_runner_shell(playbook_path,
+                         module_path,
+                         extra_vars,
+                         inventory_src='localhost',
+                         verbosity=1,
+                         console=True,
+                         env_vars=(),
+                         check=False):
+
+    # set verbosity to >=2
+    if verbosity >=2:
+        verbosity = verbosity
+    else:
+        verbosity = 2
+
+    # copy all the environment variables into process_env var
+    process_env = os.environ.copy()
+    # set the base command
+    base_command = ["ansible-playbook"]
+    # convert verbosity to -v 
+    verbosity = "v"*verbosity
+    verbosity = "-"+verbosity
+
+    # append inventory option to command
+    base_command.append("-i")
+    base_command.append(inventory_src)
+
+    # enable checkmode if check mode is mentioned
+    if check:
+        base_command.append("-C")
+
+    base_command.append(playbook_path)
+
+    # extravars to be passed into ansible.
+
+    if extra_vars:
+
+        fd, tmp_file_path = tempfile.mkstemp()
+        with os.fdopen(fd, 'w+b') as tmp:
+            # write files to temp file
+            tmp.write(json.dumps(extra_vars))
+        # Clean up the temporary file yourself
+        base_command.append("-e")
+        base_command.append("@"+tmp_file_path)
+      
+    base_command.append(verbosity)
+#    process_env["ANSIBLE_LIBRARY"]= process_env["ANSIBLE_LIBRARY"]+":".join(module_path)
+    ansible_subprocess = subprocess.Popen(base_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=process_env)
+
+    stdout,stderr = ansible_subprocess.communicate()
+    if console:
+        print(stdout)
+        print(stderr)
+    return stdout,stderr
+
+
 def ansible_runner(playbook_path,
                    module_path,
                    extra_vars,
                    inventory_src='localhost',
-                   verbosity=1,
-                   console=True):
+                   verbosity=2,
+                   console=True,
+                   env_vars=(),
+                   use_shell=False):
     """
     Uses the Ansible API code to invoke the specified linchpin playbook
     :param playbook: Which ansible playbook to run (default: 'up')
     :param console: Whether to display the ansible console (default: True)
     """
 
+    # sets environment variables for subsequent processes
+    if env_vars:
+        set_environment_vars(env_vars)
+
     # note: It may be advantageous to put the options into the context and pass
     # that onto this method down the road. The verbosity flag would just live
     # in options and we could set the defaults.
 
     # module path cannot accept list in ansible 2.3.x versions
-    if ansible_version <= 2.3:
-        module_path = ":".join(module_path)
+    if not use_shell:
+        if ansible_version <= 2.3:
+            module_path = ":".join(module_path)
 
-    connect_type = 'ssh'
-    if 'localhost' in inventory_src:
-        extra_vars["ansible_python_interpreter"] = sys.executable
-        connect_type = 'local'
+        connect_type = 'ssh'
+        if 'localhost' in inventory_src:
+            extra_vars["ansible_python_interpreter"] = sys.executable
+            connect_type = 'local'
 
-    options = Options(connect_type, module_path, 100, False, 'sudo', 'root',
-                      False, False, False, False, None, None, None, None, None,
-                      None, None, verbosity, False, False)
+        options = Options(connect_type, module_path, 100, False, 'sudo', 'root',
+                          False, False, False, False, None, None, None, None, None,
+                          None, None, verbosity, False, False)
 
-    if ansible_version >= 2.8:
-        pbex = ansible_runner_28x(playbook_path,
-                                  extra_vars,
-                                  options,
-                                  inventory_src=inventory_src,
-                                  console=console)
-    elif ansible_version >= 2.4:
-        pbex = ansible_runner_24x(playbook_path,
-                                  extra_vars,
-                                  options,
-                                  inventory_src=inventory_src,
-                                  console=console)
+        if ansible_version >= 2.8:
+            pbex = ansible_runner_28x(playbook_path,
+                                      extra_vars,
+                                      options,
+                                      inventory_src=inventory_src,
+                                      console=console)
+        elif ansible_version >= 2.4 and ansible_varsion < 2.5:
+            pbex = ansible_runner_24x(playbook_path,
+                                      extra_vars,
+                                      options,
+                                      inventory_src=inventory_src,
+                                      console=console)
+        else:
+            pbex = ansible_runner_2x(playbook_path,
+                                     extra_vars,
+                                     options,
+                                     inventory_src=inventory_src,
+                                     console=console)
+        if ansible_version >= 2.5:
+            cb = PlaybookCallback(options=options, ansible_version=ansible_version)
+        else:
+            cb = PlaybookCallback(options=options)
+
+        if not console:
+            results = {}
+            return_code = 0
+            with suppress_stdout():
+                pbex._tqm._stdout_callback = cb
+            return_code = pbex.run()
+            results = cb.results
+            return return_code, results
+        else:
+            # the console only returns a return_code
+            pbex._tqm._stdout_callback = None
+            return_code = pbex.run()
+            return return_code, None
     else:
-        pbex = ansible_runner_2x(playbook_path,
-                                 extra_vars,
-                                 options,
-                                 inventory_src=inventory_src,
-                                 console=console)
-    if ansible_version >= 2.5:
-        cb = PlaybookCallback(options=options, ansible_version=ansible_version)
-    else:
-        cb = PlaybookCallback(options=options)
-
-    if not console:
-        results = {}
-        return_code = 0
-        with suppress_stdout():
-            pbex._tqm._stdout_callback = cb
-        return_code = pbex.run()
-        results = cb.results
+        stdout, stderr = ansible_runner_shell(playbook_path,
+                                              module_path,
+                                              extra_vars,
+                                              inventory_src=inventory_src,
+                                              console=console)
+        results = stdout
+        if isinstance(stdout, str) and not stderr:
+            return_code = 0
+        else:
+            return_code = 1
         return return_code, results
-    else:
-        # the console only returns a return_code
-        pbex._tqm._stdout_callback = None
-        return_code = pbex.run()
-        return return_code, None
 
 
 # This is just a temporary class because python 2.7.5, the CentOS7 default,
@@ -189,7 +280,9 @@ def ansible_runner(playbook_path,
 # of python or we move to support CentOS8, we can delete this and move back to
 # the (less messy) namedtuple or switch to the 3.7 DataClasses
 class Options():
-    def __init__(self, connection, module_path, forks, become, become_method,
+    def __init__(self, connection, 
+                 module_path, 
+                 forks, become, become_method,
                  become_user, listhosts, listtasks, listtags, syntax,
                  remote_user, private_key_file, ssh_common_args,
                  ssh_extra_args, sftp_extra_args, scp_extra_args,

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -368,7 +368,7 @@ class LinchpinCli(LinchpinAPI):
 
 
     def lp_up(self, targets=(), run_id=None, tx_id=None, inv_f="cfg",
-              env_vars=(), use_shell=False):
+              env_vars=()):
         """
         This function takes a list of targets, and provisions them according
         to their topology.
@@ -387,10 +387,6 @@ class LinchpinCli(LinchpinAPI):
 
         if env_vars:
             self.ctx.env_vars = env_vars
-
-        if use_shell:
-            self.ctx.use_shell = use_shell
-
 
         # Execute prepped data
         return_code, return_data = self._execute_action('up',
@@ -493,7 +489,7 @@ class LinchpinCli(LinchpinAPI):
 
 
     def lp_destroy(self, targets=(), run_id=None, tx_id=None,
-                   env_vars=None, use_shell=False):
+                   env_vars=None):
 
         """
         This function takes a list of targets, and performs a destructive
@@ -515,10 +511,6 @@ class LinchpinCli(LinchpinAPI):
 
         if env_vars:
             self.ctx.env_vars = env_vars
-
-        if use_shell:
-            self.ctx.use_shell = use_shell
-
 
         outputs = self._execute_action('destroy',
                                        targets,

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -367,7 +367,8 @@ class LinchpinCli(LinchpinAPI):
         pass
 
 
-    def lp_up(self, targets=(), run_id=None, tx_id=None, inv_f="cfg", env_vars=(), use_shell=False):
+    def lp_up(self, targets=(), run_id=None, tx_id=None, inv_f="cfg",
+              env_vars=(), use_shell=False):
         """
         This function takes a list of targets, and provisions them according
         to their topology.
@@ -491,7 +492,8 @@ class LinchpinCli(LinchpinAPI):
 
 
 
-    def lp_destroy(self, targets=(), run_id=None, tx_id=None, env_vars=None, use_shell=False):
+    def lp_destroy(self, targets=(), run_id=None, tx_id=None,
+                   env_vars=None, use_shell=False):
 
         """
         This function takes a list of targets, and performs a destructive

--- a/linchpin/cli/__init__.py
+++ b/linchpin/cli/__init__.py
@@ -367,7 +367,7 @@ class LinchpinCli(LinchpinAPI):
         pass
 
 
-    def lp_up(self, targets=(), run_id=None, tx_id=None, inv_f="cfg"):
+    def lp_up(self, targets=(), run_id=None, tx_id=None, inv_f="cfg", env_vars=(), use_shell=False):
         """
         This function takes a list of targets, and provisions them according
         to their topology.
@@ -383,6 +383,13 @@ class LinchpinCli(LinchpinAPI):
         """
 
         # Prep input data
+
+        if env_vars:
+            self.ctx.env_vars = env_vars
+
+        if use_shell:
+            self.ctx.use_shell = use_shell
+
 
         # Execute prepped data
         return_code, return_data = self._execute_action('up',
@@ -484,7 +491,7 @@ class LinchpinCli(LinchpinAPI):
 
 
 
-    def lp_destroy(self, targets=(), run_id=None, tx_id=None):
+    def lp_destroy(self, targets=(), run_id=None, tx_id=None, env_vars=None, use_shell=False):
 
         """
         This function takes a list of targets, and performs a destructive
@@ -503,6 +510,12 @@ class LinchpinCli(LinchpinAPI):
         """
 
         # prep inputs
+
+        if env_vars:
+            self.ctx.env_vars = env_vars
+
+        if use_shell:
+            self.ctx.use_shell = use_shell
 
 
         outputs = self._execute_action('destroy',

--- a/linchpin/context.py
+++ b/linchpin/context.py
@@ -155,7 +155,7 @@ class LinchpinContext(object):
         env_vars = self.cfgs.get('env_vars', {})
         env_vars_list = list(self.env_vars)
         for k in env_vars:
-            env_vars_list.append((k,env_vars[k]))
+            env_vars_list.append((k, env_vars[k]))
         self.env_vars = tuple(env_vars_list)
 
 

--- a/linchpin/context.py
+++ b/linchpin/context.py
@@ -38,6 +38,8 @@ class LinchpinContext(object):
 
         self.cfgs = {}
         self._load_constants()
+        self.env_vars = ()
+        self.use_shell = False
 
 
     def _load_constants(self):
@@ -150,6 +152,12 @@ class LinchpinContext(object):
         """
 
         self.evars = self.cfgs.get('evars', {})
+        env_vars = self.cfgs.get('env_vars', {})
+        env_vars_list = list(self.env_vars)
+        for k in env_vars:
+            env_vars_list.append((k,env_vars[k]))
+        self.env_vars = tuple(env_vars_list)
+
 
 
     def get_cfg(self, section=None, key=None, default=None):
@@ -215,6 +223,46 @@ class LinchpinContext(object):
         """
 
         self.set_cfg('evars', key, value)
+
+
+    def get_env_vars(self, key=None, default=None):
+        """
+        Get the current env_vars
+
+        :param key: key to use
+
+        :param default: default value to return if nothing is found
+        (default: None)
+        """
+
+        if key:
+            for kv in self.env_vars:
+                if key == kv[0]:
+                    return kv[1]
+            return default
+        return self.env_vars
+
+
+    def set_env_vars(self, key, value):
+        """
+        Set a value into env_vars. Does not persist into a file,
+        only during the current execution.
+
+        :param key: key to use
+
+        :param value: value to set into evars
+        """
+        env_vars_tuple = self.env_vars
+        env_vars_tuple = [x for x in env_vars_tuple]
+        set_env = False
+        for kv in self.env_vars:
+            if key == kv[0]:
+                env_vars_tuple.remove(kv)
+                env_vars_tuple.append((key, value))
+                set_env = True
+        if not set_env:
+            env_vars_tuple.append((key, value))
+        self.env_vars = tuple(env_vars_tuple)
 
 
     def setup_logging(self):

--- a/linchpin/hooks/__init__.py
+++ b/linchpin/hooks/__init__.py
@@ -102,6 +102,7 @@ class LinchpinHooks(object):
         self.api.bind_to_hook_state(self.run_hooks)
         self._rundb = None
         self._rundb_id = None
+        self.use_shell = self.api.get_cfg("ansible", "use_shell")
         self.verbosity = self.api.ctx.verbosity
 
 
@@ -240,6 +241,7 @@ class LinchpinHooks(object):
             - echo ' this is 'postup' operation Hello hai how r u ?'
         """
         global_hook_names = GLOBAL_HOOKS.keys()
+        use_shell = self.api.get_cfg("ansible", "use_shell")
 
         if is_global:
             raise NotImplementedError('Run Hooks is not implemented \
@@ -313,14 +315,16 @@ class LinchpinHooks(object):
                                      tgt_data,
                                      context=ab_ctx,
                                      state=state,
-                                     verbosity=self.verbosity)
+                                     verbosity=self.verbosity,
+                                     use_shell=use_shell)
                 else:
                     a_b_obj = ActionBlockRouter(action_type,
                                                 a_b,
                                                 tgt_data,
                                                 context=ab_ctx,
                                                 state=state,
-                                                verbosity=self.verbosity)
+                                                verbosity=self.verbosity,
+                                                use_shell=use_shell)
                 try:
                     self.api.ctx.log_state('-------\n'
                                            'start hook'

--- a/linchpin/hooks/action_managers/ansible_action_manager.py
+++ b/linchpin/hooks/action_managers/ansible_action_manager.py
@@ -34,6 +34,7 @@ class AnsibleActionManager(ActionManager):
         self.action_data = action_data
         self.target_data = target_data
         self.context = kwargs.get("context", True)
+        self.use_shell = kwargs.get("use_shell", False)
         self.state = state
         self.kwargs = kwargs
 
@@ -147,7 +148,9 @@ class AnsibleActionManager(ActionManager):
                                         "",
                                         extra_vars,
                                         inventory_src=inv_file,
-                                        verbosity=verbosity)
+                                        verbosity=verbosity,
+                                        use_shell=self.use_shell
+                                        )
 
                 result['state'] = str(self.state)
                 result['return_code'] = runner[0]
@@ -159,7 +162,9 @@ class AnsibleActionManager(ActionManager):
                                         "",
                                         extra_vars,
                                         inventory_src="localhost",
-                                        verbosity=verbosity)
+                                        verbosity=verbosity,
+                                        use_shell=self.use_shell
+                                        )
                 result['state'] = str(self.state)
                 result['return_code'] = runner[0]
                 result['data'] = runner[1]

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -117,6 +117,7 @@ inventory = .inventory
 
 [ansible]
 console = False
+use_shell = False
 
 [states]
 # in future each state may have comma separated substates

--- a/linchpin/shell/__init__.py
+++ b/linchpin/shell/__init__.py
@@ -283,6 +283,9 @@ def up(ctx, targets, run_id, tx_id, inventory_format, ignore_failed_hooks,
     if disable_uhash:
         ctx.set_evar("disable_uhash_targets", disable_uhash.split(','))
 
+    if use_shell:
+        ctx.set_cfg("ansible", "use_shell", use_shell)
+
     if tx_id:
         try:
             return_code, results = lpcli.lp_up(targets=targets,
@@ -301,8 +304,7 @@ def up(ctx, targets, run_id, tx_id, inventory_format, ignore_failed_hooks,
                                                run_id=run_id,
                                                tx_id=tx_id,
                                                inv_f=inventory_format,
-                                               env_vars=env_vars,
-                                               use_shell=use_shell)
+                                               env_vars=env_vars)
             _handle_results(ctx, results, return_code)
         except LinchpinError as e:
             ctx.log_state(e)
@@ -360,13 +362,15 @@ def destroy(ctx, targets, run_id, tx_id, ignore_failed_hooks, no_hooks,
     if no_hooks:
         ctx.set_cfg("hook_flags", "no_hooks", no_hooks)
 
+    if use_shell:
+        ctx.set_cfg("ansible", "use_shell", use_shell)
+
 
     if tx_id:
         try:
             return_code, results = lpcli.lp_destroy(targets=targets,
                                                     tx_id=tx_id,
-                                                    env_vars=env_vars,
-                                                    use_shell=use_shell)
+                                                    env_vars=env_vars)
             _handle_results(ctx, results, return_code)
 
         except LinchpinError as e:
@@ -380,8 +384,7 @@ def destroy(ctx, targets, run_id, tx_id, ignore_failed_hooks, no_hooks,
             return_code, results = lpcli.lp_destroy(targets=targets,
                                                     run_id=run_id,
                                                     tx_id=tx_id,
-                                                    env_vars=env_vars,
-                                                    use_shell=use_shell)
+                                                    env_vars=env_vars)
             _handle_results(ctx, results, return_code)
         except LinchpinError as e:
             ctx.log_state(e)


### PR DESCRIPTION
Fixes #1125 

This is a preview feature which enables running of ansible_runner as subprocess shell
instead of running ansible API. 

example usage:
```
linchpin -vvvvv up --use-shell --env-vars TESTENV envvalue
```