### PR TITLE
Improve how Linchpin destroys Libvirt VMs

### DIFF
--- a/linchpin/FilterUtils/FilterUtils.py
+++ b/linchpin/FilterUtils/FilterUtils.py
@@ -271,3 +271,11 @@ def fetch_beaker_job_ids(topo_out):
             entry_dict["ids"].append("J:" + entry["id"])
             output.append(entry_dict)
     return output
+
+
+def fetch_vm_names(topo_out):
+    output = []
+    for entry in topo_out:
+        if "name" in list(entry):
+            output.append(entry["name"])
+    return output

--- a/linchpin/provision/filter_plugins/fetch_vm_names.py
+++ b/linchpin/provision/filter_plugins/fetch_vm_names.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import linchpin.FilterUtils.FilterUtils as filter_utils
+
+
+class FilterModule(object):
+    ''' A filter to fetch vm/instance names from topology outputs '''
+    def filters(self):
+        return {
+            'fetch_vm_names': filter_utils.fetch_vm_names
+        }

--- a/linchpin/provision/roles/libvirt/tasks/teardown_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/teardown_libvirt_node.yml
@@ -1,16 +1,35 @@
+- name: "Get topology output data from RunDB"
+  rundb:
+    conn_str: "{{ rundb_conn }}"
+    operation: get
+    table: "{{ target }}"
+    key: "outputs"
+    run_id: "{{ orig_run_id }}"
+  register: topo_output
+
+- name: Filter list for resources
+  set_fact:
+    topo_output_resources: "{{ topo_output.output | filter_list_by_attr('resources') }}"
+
+- name: "set topo_output_resources fact"
+  set_fact:
+    topo_output_resources: "{{ topo_output_resources[0]['resources'] }}"
+
 - set_fact:
-      res_count: '{{ (res_count | default([])) + [item | int] }}'
-  with_sequence: "start=0 end={{ res_def['count'] | default(1) |int - 1 }}"
+    libvirt_resource_names: "{{ topo_output_resources | fetch_vm_names }}"
+
+#- set_fact:
+#      res_count: '{{ (res_count | default([])) + [item | int] }}'
+#  with_sequence: "start=0 end={{ res_def['count'] | default(1) |int - 1 }}"
 
 - name: "halt node"
   virt:
-    name: "{{ libvirt_resource_name }}{{ instance[2] }}{{ instance[1] }}"
+    name: "{{ instance[1] }}"
     state: destroyed
-    uri: "{{ instance[1]['uri'] | default('qemu:///system') }}"
+    uri: "{{ instance[0]['uri'] | default('qemu:///system') }}"
   with_nested:
     - ["{{ res_def }}"]
-    - "{{ res_count }}"
-    - ["{{ res_def['name_separator'] | default('_')  }}"]
+    - "{{ libvirt_resource_names }}"
   loop_control:
     loop_var: instance
   register: res_def_output
@@ -19,12 +38,10 @@
   when: not _async
 
 - name: "get XML definition of vm"
-  command: "virsh -c {{ instance[1]  }} dumpxml {{ instance[0] }}{{ instance[3] }}{{ instance[2] }}"
+  command: "virsh -c {{ instance[1]  }} dumpxml {{ instance[0] }}"
   with_nested:
-    - ["{{  libvirt_resource_name }}"]
+    - "{{ libvirt_resource_names }}"
     - ["{{ res_def['uri'] | default('qemu:///system') }}"]
-    - "{{ res_count }}"
-    - ["{{ res_def['name_separator'] | default('_')  }}"]
   loop_control:
     loop_var: instance
   when: not _async
@@ -33,13 +50,12 @@
 
 - name: "undefine node"
   virt:
-    name: "{{ libvirt_resource_name }}{{ instance[2] }}{{ instance[1] }}"
+    name: "{{ instance[1] }}"
     command: undefine
     uri: "{{ instance[0]['uri'] | default('qemu:///system') }}"
   with_nested:
     - ["{{ res_def }}"]
-    - "{{ res_count }}"
-    - ["{{ res_def['name_separator'] | default('_')  }}"]
+    - "{{ libvirt_resource_names }}"
   loop_control:
     loop_var: instance
   register: res_def_output

--- a/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
+++ b/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
@@ -152,3 +152,8 @@ def test_fetch_beaker_job_ids():
     expected = [{'ids': ['J:3124']}, {'ids': ['J:3214']}]
     assert_equals(expected,
                   filter_utils.fetch_beaker_job_ids(test_input))
+
+def test_fetch_vm_names():
+    test_input = [{"name": "test_vm_0"}, {"name": 'test_vm_1'}]
+    expected = ['test_vm_0', "test_vm_1"]
+    assert_equals(expected, filter_utils.fetch_vm_names(test_input))


### PR DESCRIPTION
 * Rather than rebuilding the names of the instances based on
   count and name during the destroy. Took the Beaker approach - query the
   rudb for target output and added a filter plugin to filter
   the output for vm names. This list of names is a fact set in the
   teardown_libvirt_node.yml and used by the rest of the plays to run
   virsh and virt commands against. Addresses issue #1257