### PR TITLE
add "future" package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ openshift>=0.8.6,<0.8.8
 pyasn1>=0.1.9
 gitpython==2.1.11
 pytest<=4.4.0
+future


### PR DESCRIPTION
As a bug fix to issue #1269 
including future package inside for supporting rhel images