### PR TITLE
disable all the libvirt based tests

### DIFF
--- a/config/Dockerfiles/tests.d/libvirt/02_libvirt-storage
+++ b/config/Dockerfiles/tests.d/libvirt/02_libvirt-storage
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 # Verify basic provisioning for all supplied providers
-# distros.exclude: centos7 fedora30
+# distros.exclude: centos7 fedora30 fedora29
 # providers.include: libvirt
 
 ## NOTE: This is a temporary test to run libvirt tests until we fix

--- a/config/Dockerfiles/tests.d/libvirt/05_libvirt-builtins
+++ b/config/Dockerfiles/tests.d/libvirt/05_libvirt-builtins
@@ -1,9 +1,8 @@
 #!/bin/bash -xe
 
 # Verify basic provisioning with global hooks
-# distros.exclude: centos7
+# distros.exclude: centos7 fedora29 fedora30
 # providers.include: libvirt
-# providers.exclude: none
 
 set -o pipefail
 


### PR DESCRIPTION
Temporarily disable all the libvirt tests since we are blocked on resolving SELinux issues