### PR TITLE
Fix ansible 2.7.x version compatibility

### DIFF
--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -253,7 +253,7 @@ def ansible_runner(playbook_path,
                                       options,
                                       inventory_src=inventory_src,
                                       console=console)
-        elif ansible_version >= 2.4 and ansible_version < 2.5:
+        elif ansible_version >= 2.4 and ansible_version < 2.8:
             pbex = ansible_runner_24x(playbook_path,
                                       extra_vars,
                                       options,


### PR DESCRIPTION
Due to the recent changes in ansible 2.7.x. Linchpin broke on ansible 2.7.x versions
The following fix will mitigate the issues caused. 
fixes #1302 