### PR TITLE
Fix Openstack Network managment

### DIFF
--- a/docs/source/examples/workspaces/openstack-net/PinFile
+++ b/docs/source/examples/workspaces/openstack-net/PinFile
@@ -1,0 +1,23 @@
+---
+os_net:
+  topology:
+    topology_name: os-net
+    resource_groups:
+      - resource_group_name: os-net
+        resource_group_type: openstack
+        resource_definitions:
+          - name: lp-net
+            role: os_network
+          - name: lp-sub
+            role: os_subnet
+            network_name: lp-net
+            cidr: 172.16.180.0/24
+            dns_nameservers:
+              - 8.8.8.8
+          - name: lp-route
+            role: os_router
+            network: provider_net_cci_5
+            interfaces:
+              - net: lp-net
+                subnet: lp-sub
+                portip: 172.16.180.1

--- a/docs/source/examples/workspaces/openstack-net/README.md
+++ b/docs/source/examples/workspaces/openstack-net/README.md
@@ -1,0 +1,31 @@
+# Openstack simple single instance deployment
+
+Deployment of a single instance in Openstack with minimal set of settings.
+The example is [configurable] using the following arguments:
+
+ - `os_simple_name` - instance name, default is 'database'
+ - `os_simple_flavor` - [Openstack flavor], default is 'm1.small'
+ - `os_simple_image` - [Openstak image], default is CentOS image
+ - `os_simple_keypair` - [Key-pair in Openstack] to put into instance
+ - `os_simple_fip_pool` - [Openstack floating IP pool] to get public IP from
+ - `os_simple_networks` - Openstack network to get private IP from
+ - `os_simple_keypath` - Path to private key on local system
+
+To run with different configuration, you add `--template-data` option with path
+to file or inline, for example:
+
+    linchpin --template-data '{ "os_simple_name": "my_system" }' up
+
+From file:
+
+    linchpin --template-data '@settings.json' up
+
+Short version:
+
+    linchpin -d '@settings.json' up
+
+[configurable]: https://linchpin.readthedocs.io/en/latest/managing_resources.html
+[Openstack flavor]: https://docs.openstack.org/nova/rocky/user/flavors.html
+[Openstage image]: https://docs.openstack.org/ocata/admin-guide/compute-images-instances.html
+[Key-pair in Openstack]: https://docs.openstack.org/horizon/latest/user/configure-access-and-security-for-instances.html
+[Openstack floating IP pool]: https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html

--- a/docs/source/examples/workspaces/openstack-net/linchpin.conf
+++ b/docs/source/examples/workspaces/openstack-net/linchpin.conf
@@ -1,0 +1,325 @@
+# This file is a well-documented, and commented out (mostly) file, which
+# covers the configuration options available in LinchPin
+#
+# Used to override default configuration settings for LinchPin
+# Defaults exist in linchpin/linchpin.constants file
+#
+# Uncommented options enable features found in v1.5.1 or newer and
+# can be turned off by commenting them out.
+#
+# structured in INI style
+# use %% to allow code interpolation
+# use % to use config interpolation
+#
+
+[DEFAULT]
+# name of the python package (Redundant, but easier than programmatically
+# obtaining the value. It's very unlikely to change.)
+pkg = linchpin
+
+# Useful for storing the RunDB or other components like global credentials
+# travis-ci doesn't like ~/.config/linchpin, use /tmp
+#default_config_path = ~/.config/linchpin
+
+# When creating an provider not already included in LinchPin, this path
+# extends where LinchPin will look to run the appropriate playbooks
+#external_providers_path = %(default_config_path)s/linchpin-x
+
+# When adding anything to the lp section, it should be general for
+# the entire application.
+[lp]
+
+# load custom ansible modules from here
+#module_folder = library
+
+# rundb tracks provisioning transactions
+# If you add a new one, rundb/drivers.py needs to be updated to match
+# rundb_conn is the location of the run database.
+# A common reason to move it is to use the rundb centrally across
+# the entire system, or in a central db on a shared filesystem.
+# System-wide RunDB: rundb_conn = ~/.config/linchpin/rundb-::mac::.json
+#rundb_conn = {{ workspace }}/.rundb/rundb-::mac::.json
+rundb_conn = ~/.config/linchpin/rundb-::mac::.json
+
+# name the type of Run database. Currently only TinyRunDB exists
+#rundb_type = TinyRunDB
+
+# How to connect to the RunDB, if it's on a separate server,
+# it may be tcp or ssh
+#rundb_conn_type = file
+
+# The schema is used because TinyDB is a NoSQL db. Another DB
+# may use this as a way to manage fields in a specific table.
+#rundb_schema = {"action": "",
+#                "inputs": [],
+#                "outputs": [],
+#                "start": "",
+#                "end": "",
+#                "rc": 0,
+#                "uhash": ""}
+
+# each entry in the RunDB contains a unique-ish hash (uhash). This
+# sets the hashing mechanism used to generate the uhash.
+#rundb_hash = sha256
+
+# The default dateformat used in LinchPin. Specifically used in the
+# RunDB for recording start and end dates, but also used elsewhere.
+#dateformat = %%m/%%d/%%Y %%I:%%M:%%S %%p
+
+# The name of the pinfile. Someone could adjust this and use TopFile
+# or somesuch. The ramifications of this would mean that the file in
+# the workspace that linchpin reads would change to this value.
+#default_pinfile = PinFile
+
+# By default, whenever linchpin performs an action
+# (linchpin up/linchpin destroy), the data is read from the PinFile.
+# Enabling 'use_rundb_for_actions' will allow destroy and certain up
+# actions (specifically when using --run-id or --tx-id) to pull data
+# from the RunDB instead.
+#use_rundb_for_actions = False
+use_rundb_for_actions = True
+
+# A user can request specific data distilled from the RunDB. This flag
+# enables the Context Distiller.
+# NOTE: This flag requires generate_resources = False.
+#distill_data = False
+distill_data = True
+
+# If desired, enabling distill_on_error will distill any successfully (and
+# possibly failed) provisioned resources. This is predicated on the data
+# being written to the RunDB (usually means _async tasks may never record
+# data upon failure).
+distill_on_error = False
+
+# User can make linchpin use the actual return codes for final return code
+# if enabled True, even if one target provision is successfull linchpin 
+# returns exit code zero else returns the sum of all the return codes
+# use_actual_rcs = False
+
+# LinchPin sets several extra_vars (evars) that are passed to the playbooks.
+# This section controls those items.
+[evars]
+
+# enables the ansible --check option
+# _check_mode = False
+debug_mode = True
+
+
+# enables the ansible async ability. For some providers, it allows multiple
+# provisioning tasks to happen at once, then will collect the data afterward.
+# The default is perform the provision actions in serial.
+#_async = False
+
+# How long to wait before failing (in seconds) for an async task.
+#async_timeout = 1000
+
+# the uhash value will still exist, but will not be added to
+# instances or the inventory_path
+#enable_uhash = False
+enable_uhash = True
+
+# in older versions of linchpin (<v1.0.4), a resources folder exists, which
+# dumped the data that is now stored in the RunDB. To disable the resources
+# output, set the value to False.
+#generate_resources = True
+generate_resources = False
+
+# default paths in playbooks
+#
+# lp_path = <src_dir>/linchpin
+# determined in the load_config method of # linchpin.cli.LinchpinCliContext
+
+# Each of the following items controls the path (usually along with the
+# default values below) to the corresponding item.
+
+# In the workspace (generally), this is the location of the layouts and
+# topologies looked up by the PinFile. If either of these change, the
+# value in linchpin/templates must also change.
+#layouts_folder = layouts
+#topologies_folder = topologies
+
+# The relative location for hooks
+#hooks_folder = hooks
+
+# The relative location for provider roles
+#roles_folder = roles
+
+# The relative location for storing inventories
+#inventories_folder = inventories
+
+# The relative location for resources output (deprecated)
+#resources_folder = resources
+
+# The relative location to find schemas (deprecated)
+#schemas_folder = schemas
+
+# The relative location to find playbooks
+#playbooks_folder = provision
+
+# The default path to schemas for validation (deprecated)
+#default_schemas_path = {{ lp_path }}/defaults/%(schemas_folder)s
+
+# The default path to topologies if they aren't in the workspace
+#default_topologies_path = {{ lp_path }}/defaults/%(topologies_folder)s
+
+# The default path to inventory layouts if they aren't in the workspace
+#default_layouts_path = {{ lp_path }}/defaults/%(layouts_folder)s
+
+# The default path for outputting ansible static inventories
+#default_inventories_path = {{ lp_path }}/defaults/%(inventories_folder)s
+
+# The default path to the ansible roles which control the providers
+#default_roles_path = {{ lp_path }}/%(playbooks_folder)s/%(roles_folder)s
+
+# In older versions (<1.2.x), the schema was held here. These schemas are
+# deprecated.
+#schema_v3 = %(default_schemas_path)s/schema_v3.json
+#schema_v4 = %(default_schemas_path)s/schema_v4.json
+
+# The location where default credentials data would exist. This path doesn't
+# automatically exist
+#default_credentials_path = %(default_config_path)s
+
+# The location where default resources will be dumped. This path doesn't
+# automatically exist
+#default_resources_path = {{ workspace }}/%(resources_folder)s
+
+# If desired, one could overwrite the location of the generated inventory path
+#inventory_path = {{ workspace }}/{{inventories_folder}}/happy.inventory
+
+# Libvirt images can be stored almost anywhere (not /tmp).
+# Unprivileged users need not setup sudo to manage a path to which they have rights.
+# The following are specific settings to manage libvirt images and instances
+
+# the location to store generated ssh keys and the like
+#default_ssh_key_path = ~/.ssh
+
+# Where to store the libvirt images for copying/booting instances
+#libvirt_image_path = /var/lib/libvirt/images/
+
+# What user to use to access libvirt.
+# Using root means sudo without password must be setup
+#libvirt_user = root
+
+# When using root or any privileged user, this must be set to yes.
+# sudo without password must also be setup
+#libvirt_become = yes
+
+# This section covers settings for the `linchpin init` command
+#[init]
+
+# source path of files generated by linchpin init
+#source = templates/
+
+# formal name of the generated PinFile. Can be changed as desired.
+#pinfile = PinFile
+
+# default remote to pull workspaces from
+#remote = git://github.com/CentOS-PaaS-SIG/linchpin
+
+# git ref to use
+#fetch_ref = master
+
+# location in the above remote to copy to workspace
+#root = workspaces/dummy
+
+# what part of the workspace to pull (likely only workspace)
+#fetch_type = workspace
+
+# whether to cache the remote (default: always pull updates)
+#nocache = True
+
+# This section covers settings for the `linchpin fetch` command
+#[fetch]
+
+# If desired, disable the caching functionality
+#cache_ws = True
+
+# How long before an update to the destination workspace from the cache
+#cache_days = 1
+
+# This section covers logging setup
+[logger]
+
+# Turns off and on the logger functionality
+#enable = True
+
+# Full path to the location of the linchpin log file
+file = ~/.config/linchpin/linchpin.log
+
+# Log format used. See https://docs.python.org/2/howto/logging-cookbook.html
+#format = %%(levelname)s %%(asctime)s %%(message)s
+
+# Date format used. See https://docs.python.org/2/howto/logging-cookbook.html
+#dateformat = %%m/%%d/%%Y %%I:%%M:%%S %%p
+
+# Level of logging provided
+#level = logging.DEBUG
+
+# Logging to the console via STDERR
+#[console]
+
+# logging to the console should also be possible
+# NOTE: Placeholder only, cannot disable.
+#enable = True
+
+# Log format used. See https://docs.python.org/2/howto/logging-cookbook.html
+#format = %%(message)s
+
+# Level of logging provided
+#level = logging.INFO
+
+# LinchPin hooks have several states depending on the action. Currently, there
+# are three hook states relating to tasks being completed.
+# * up - when performing the up (provision) action
+# * destroy - when performing the destroy (teardown) action
+# * inv - when performing the internal inventory generation action
+#   (currently unimplemented)
+#[hookstates]
+
+# when performing the up action, these hooks states are run
+#up = pre,post,inv
+
+# when performing the inv action, these hooks states are run
+#inv = post
+
+# when performing the destroy action, these hooks states are run
+#destroy = pre,post
+
+# This section covers file extensions for generating or looking
+# up specific files
+#[extensions]
+
+# When looking for provider playbooks, use this extension
+#playbooks = .yml
+
+# When generating inventory files, use this extension
+#inventory = .inventory
+
+# This section controls the ansible settings for display or other settings
+#[ansible]
+
+# If set to true, this enables verbose output automatically to the screen.
+# This is equivalent of passing `-v` to the linchpin command line shell.
+#console = False
+
+# When linchpin is run, certain states are called at certain points along the
+# execution timeline. These STATES are defined below.
+#[states]
+# in future each state will have comma separated substates
+
+# The name of the state which occurs before (pre) provisioning (up)
+#preup = preup
+
+# The name of the state which occurs before (pre) teardown (destroy)
+#predestroy = predestroy
+
+# The name of the state which occurs after (post) provisioning (up)
+#postup = postup
+
+# The name of the state which occurs after (pre) teardown (destroy)
+#postdestroy = postdestroy
+
+# The name of the state which occurs after (post) inventory is generated (inv)
+#postinv = inventory
+

--- a/linchpin/provision/roles/openstack/files/schema.json
+++ b/linchpin/provision/roles/openstack/files/schema.json
@@ -195,15 +195,22 @@
                         "allowed": ["os_router"] },
                     "admin_state_up": { "type": "boolean", "required": false},
                     "api_timeout": { "type": "number", "required": false},
-		    "external_fixed_ips": {
+                    "external_fixed_ips": {
                         "type": "list",
                         "required": false,
                         "schema": { "type": "string", "required": true }
                     },
-		    "interfaces": {
+                    "interfaces": {
                         "type": "list",
                         "required": false,
-                        "schema": { "type": "string", "required": true }
+                        "schema": {
+                          "type": "dict",
+                          "schema": {
+                            "net": { "type": "string", "required": true },
+                            "subnet": { "type": "string", "required": true },
+                            "portip": { "type": "string", "required": true }
+                          }
+                        }
                     },
                     "network": { "type": "string", "required": false },
                     "enable_snat": { "type": "boolean", "required": false},

--- a/linchpin/provision/roles/openstack/tasks/main.yml
+++ b/linchpin/provision/roles/openstack/tasks/main.yml
@@ -13,9 +13,18 @@
     topology_outputs_os_keypair: []
     topology_outputs_os_sg: []
     topology_outputs_os_network: []
+    topology_outputs_os_router: []
+    topology_outputs_os_subnet: []
 
-- name: "Initiating Provision/Teardown of openstack resource group"
+- name: "Initiating Provision of openstack resource group"
   include: provision_resource_group.yml res_grp={{ item }}
   with_items:
     - "{{ resources }}"
   register: resource_grps_output
+  when: state == "present"
+
+- name: "Initiating Teardown of openstack resource group"
+  include: teardown_resource_group.yml res_grp={{ item }}
+  with_items:
+    - "{{ resources }}"
+  when: state == "absent"

--- a/linchpin/provision/roles/openstack/tasks/provision_os_network.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_network.yml
@@ -6,7 +6,7 @@
     external: "{{ res_def['external'] | default(omit) }}"
     interface: "{{ res_def['interface'] | default(omit) }}"
     key: "{{ res_def['key'] | default(omit) }}"
-    name: "{{ os_resource_name }}"
+    name: "{{ res_def['name'] }}"
     project: "{{ res_def['project'] | default(omit) }}"
     provider_network_type: "{{ res_def['provider_network_type'] | default(omit) }}"
     provider_physical_network: "{{ res_def['provider_physical_network'] | default(omit) }}"

--- a/linchpin/provision/roles/openstack/tasks/provision_os_router.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_router.yml
@@ -8,7 +8,7 @@
     external_fixed_ips: "{{ res_def['external_fixed_ips'] | default(omit) }}"
     interface: "{{ res_def['interface'] | default(omit) }}"
     interfaces: []
-    name: "{{ os_resource_name }}"
+    name: "{{ res_def['name'] }}"
     network: "{{ res_def['network'] | default(omit) }}"
     key: "{{ res_def['key'] | default(omit) }}"
     project: "{{ res_def['project'] | default(omit) }}"
@@ -30,7 +30,7 @@
     external_fixed_ips: "{{ res_def['external_fixed_ips'] | default(omit) }}"
     interface: "{{ res_def['interface'] | default(omit) }}"
     interfaces: "{{ res_def['interfaces'] | default(omit) }}"
-    name: "{{ os_resource_name }}"
+    name: "{{ res_def['name'] }}"
     network: "{{ res_def['network'] | default(omit) }}"
     key: "{{ res_def['key'] | default(omit) }}"
     project: "{{ res_def['project'] | default(omit) }}"

--- a/linchpin/provision/roles/openstack/tasks/provision_os_subnet.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_subnet.yml
@@ -18,7 +18,7 @@
     no_gateway_ip:  "{{ res_def['no_gateway_ip'] | default(omit) }}"
     use_default_subnetpool:  "{{ res_def['use_default_subnetpool'] | default(omit) }}"
     interface: "{{ res_def['interface'] | default(omit) }}"
-    name: "{{ os_resource_name }}"
+    name: "{{ res_def['name'] }}"
     key: "{{ res_def['key'] | default(omit) }}"
     project: "{{ res_def['project'] | default(omit) }}"
     region_name: "{{ res_def['region_name'] | default(omit) }}"

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_heat.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_heat.yml
@@ -1,0 +1,1 @@
+provision_os_heat.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_keypair.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_keypair.yml
@@ -1,0 +1,1 @@
+provision_os_keypair.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_network.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_network.yml
@@ -1,0 +1,1 @@
+provision_os_network.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_object.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_object.yml
@@ -1,0 +1,1 @@
+provision_os_object.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_router.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_router.yml
@@ -1,0 +1,1 @@
+provision_os_router.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_server.yml
@@ -1,0 +1,1 @@
+provision_os_server.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_sg.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_sg.yml
@@ -1,0 +1,1 @@
+provision_os_sg.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_subnet.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_subnet.yml
@@ -1,0 +1,1 @@
+provision_os_subnet.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_volume.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_volume.yml
@@ -1,0 +1,1 @@
+provision_os_volume.yml

--- a/linchpin/provision/roles/openstack/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_resource_group.yml
@@ -1,0 +1,153 @@
+---
+# Credentials
+- name: "Unset the authvar from previous run"
+  set_fact:
+    auth_var: ""
+
+- name: "set default_cred_profile when res_grp[credentials] is undefined"
+  set_fact:
+    cred_profile: 'default'
+  when: res_grp['credentials'] is not defined
+
+- name: "set default_cred_profile when res_grp[credentials] is undefined"
+  set_fact:
+    cred_filename: 'clouds.yaml'
+  when: res_grp['credentials'] is not defined
+
+- name: "set cred_profile when res_grp[credentials] is defined"
+  set_fact:
+    cred_profile: "{{ res_grp['credentials']['profile'] }}"
+  when: res_grp['credentials'] is defined
+
+- name: "set default_cred_filename when res_grp[credentials] is defined"
+  set_fact:
+    cred_filename: "{{ res_grp['credentials']['filename'] }}"
+  when: res_grp['credentials'] is defined
+
+- name: "Get creds from auth driver"
+  auth_driver:
+    filename: "{{ cred_filename }}"
+    cred_type: "openstack"
+    cred_path: "{{ creds_path | default(default_credentials_path) }}"
+    driver: "file"
+    vault_enc: "{{ vault_encryption }}"
+    vault_pass: "{{ vault_pass }}"
+  register: auth_var_out
+  ignore_errors: true
+  no_log: "{{ not debug_mode }}"
+  when: res_grp['credentials'] is defined
+
+- name: "set auth_var"
+  set_fact:
+    auth_var: "{{ auth_var_out['output']['clouds'][cred_profile]['auth'] }}"
+  ignore_errors: true
+  when: auth_var_out['output'] is defined
+  no_log: "{{ not debug_mode }}"
+
+# Deployment information
+- name: "Get topology output data from resources file"
+  output_parser:
+    output_file: "{{ default_resources_path + '/' + topo_data['topology_name'].replace(' ', '_').lower() + '.output' }}"
+  register: topo_output
+  when: generate_resources
+
+- name: "set topo_output_resources fact"
+  set_fact:
+    topo_output_resources: "{{ topo_output.output['content'] }}"
+  when: generate_resources
+
+- name: "Get topology output data from RunDB"
+  rundb:
+    conn_str: "{{ rundb_conn }}"
+    operation: get
+    table: "{{ target }}"
+    key: "outputs"
+    run_id: "{{ orig_run_id }}"
+  register: topo_output_rundb
+  when: not generate_resources
+
+- name: "set topo_output_resources fact rundb"
+  set_fact:
+    topo_output_resources: "{{ topo_output_rundb.output[0]['resources'] }}"
+  when: not generate_resources
+
+- name: teardown os_router resource def of current group
+  include: teardown_os_router.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_router"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_heat resource def of current group
+  include: teardown_os_heat.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_heat"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_keypair resource def of current group
+  include: teardown_os_keypair.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_keypair"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_network resource def of current group
+  include: teardown_os_network.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_network"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_object resource def of current group
+  include: teardown_os_object.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_object"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_server resource def of current group
+  include: teardown_os_server.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_server"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_sg resource def of current group
+  include: teardown_os_sg.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_sg"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_subnet resource def of current group
+  include: teardown_os_subnet.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_subnet"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item
+
+- name: teardown os_volume resource def of current group
+  include: teardown_os_volume.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}
+  when: res_item.0['role'] == "os_volume"
+  with_nested:
+    - "{{ res_grp['res_defs'] | default(res_grp['resource_definitions']) }}"
+    - ["{{ res_grp['resource_group_name'] }}"]
+  loop_control:
+    loop_var: res_item


### PR DESCRIPTION
- Openstack teardown of network resources wasn't in specific order which failed when there is dependency (net -> sub -> router).
- Network resources names were generated (uhash) which makes it impossible to link dependent resources (net -> sub -> router)f