### PR TITLE
Introduce wait time before starting vm to avoid write locks

### DIFF
--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -292,6 +292,13 @@
   - fail:
       msg: 'Error running command qemu-img. Please make sure the dependencies are installed correctly. Try running `linchpin setup libvirt` to reinstall dependencies'
 
+
+- name: sleep for 60 seconds and continue with play
+  wait_for:
+    timeout: 60
+  delegate_to: localhost
+
+
 - name: "Start VM"
   virt:
     name: "{{ definition[0] }}{{ definition[3] }}{{ definition[2] }}"
@@ -305,6 +312,7 @@
   loop_control:
     loop_var: definition
   ignore_errors: no
+
 
 - name: wait for the vm to shut down (cloud-init)
   virt:
@@ -335,6 +343,12 @@
     loop_var: definition
   ignore_errors: yes
   when: node_exists['failed'] is defined and virt_type == "cloud-init" and cloud_config != {}
+
+
+- name: sleep for 60 seconds and continue with play
+  wait_for:
+    timeout: 60
+  delegate_to: localhost
 
 
 - name: "Start VM again (post cloud-init)"


### PR DESCRIPTION
When provisioning multiple machines
it creates  write lock on machines resulting in unstarted machines. 
Adding a wait time of a minute before restarting machines avoids this bug.
This PR fixes following error:
```
TASK [libvirt : Start VM] ****************************************************************************
task path: /home/srallaba/workspace/lp_ws_backup/lp_ws/master_wp/linchpin/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml:296
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: srallaba
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1567692828.02-68127106602630 `" && echo ansible-tmp-1567692828.02-68127106602630="` echo /root/.ansible/tmp/ansible-tmp-1567692828.02-68127106602630 `" ) && sleep 0'
Using module file /home/srallaba/.virtualenvs/master_wp/lib/python2.7/site-packages/ansible/modules/cloud/misc/virt.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-7346jkuTDn/tmpltV9Qf TO /root/.ansible/tmp/ansible-tmp-1567692828.02-68127106602630/AnsiballZ_virt.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1567692828.02-68127106602630/ /root/.ansible/tmp/ansible-tmp-1567692828.02-68127106602630/AnsiballZ_virt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/srallaba/.virtualenvs/master_wp/bin/python2 /root/.ansible/tmp/ansible-tmp-1567692828.02-68127106602630/AnsiballZ_virt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1567692828.02-68127106602630/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_virt_payload_Q8poY6/__main__.py", line 593, in main
    rc, result = core(module)
  File "/tmp/ansible_virt_payload_Q8poY6/__main__.py", line 497, in core
    res['msg'] = v.start(guest)
  File "/tmp/ansible_virt_payload_Q8poY6/__main__.py", line 405, in start
    return self.conn.create(vmid)
  File "/tmp/ansible_virt_payload_Q8poY6/__main__.py", line 238, in create
    return self.find_vm(vmid).create()
  File "/home/srallaba/.virtualenvs/master_wp/lib/python2.7/site-packages/libvirt.py", line 1068, in create
    if ret == -1: raise libvirtError ('virDomainCreate() failed', dom=self)
libvirtError: internal error: process exited while connecting to monitor: 2019-09-05T14:13:48.329295Z qemu-system-x86_64: -drive file=/var/lib/libvirt/images/linchpin//centosnom_0.qcow2,format=qcow2,if=none,id=drive-virtio-disk0,cache=none: Failed to get "write" lock
Is another process using the image?

failed: [localhost] (item=[u'centosnom', u'qemu:///system', 0, u'_']) => {
    "ansible_loop_var": "definition", 
    "changed": false, 
    "definition": [
        "centosnom", 
        "qemu:///system", 
        0, 
        "_"
    ], 
    "invocation": {
        "module_args": {
            "autostart": null, 
            "command": null, 
            "name": "centosnom_0", 
            "state": "running", 
            "uri": "qemu:///system", 
            "xml": null
        }
    }, 
    "msg": "internal error: process exited while connecting to monitor: 2019-09-05T14:13:48.329295Z qemu-system-x86_64: -drive file=/var/lib/libvirt/images/linchpin//centosnom_0.qcow2,format=qcow2,if=none,id=drive-virtio-disk0,cache=none: Failed to get \"write\" lock\nIs another process using the image?"
}

```
