### PR TITLE
Enable public image azure

### DIFF
--- a/config/Dockerfiles/tests.d/azure/04_azure_vm_public_image
+++ b/config/Dockerfiles/tests.d/azure/04_azure_vm_public_image
@@ -1,0 +1,20 @@
+#!/bin/bash -xe
+  
+# Verify the azure vm provisioning
+# distros.exclude: none
+# providers.include: azure
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+TARGET="azure_vm_public_image"
+pushd docs/source/examples/workspaces/${PROVIDER}
+function clean_up {
+    set +e
+    linchpin -w . -vvv --creds-path ./ --template-data '{ "distro": '${DISTRO}""'}' destroy "${TARGET}"
+    rm -rf resources/ inventories/
+}
+
+trap clean_up EXIT
+
+linchpin -w . -vvv --creds-path ./ --template-data '{ "distro": '${DISTRO}""'}' up "${TARGET}"

--- a/docs/source/azure.rst
+++ b/docs/source/azure.rst
@@ -24,12 +24,29 @@ definition, the following options are available.
 | role             | true       | string        | N/A               |                 |
 +------------------+------------+---------------+-------------------+-----------------+
 | vm_name          | true       | string        | name              |It can't include |
-|                  |            |               |                   | _ and other     |
+|                  |            |               |                   | '_' and other   |
 |                  |            |               |                   |special char     |
 +------------------+------------+---------------+-------------------+-----------------+
-| image            | true       | string        | image             |                 |
+| private_image    | false      | string        | image             |This para takes  |
+|                  |            |               |                   | private images  |
+|                  |            |               |                   |                 |
++------------------+------------+---------------+-------------------+-----------------+
+| resource_group   | true       | string        | resource_group    |                 |
++------------------+------------+---------------+-------------------+-----------------+
+| vm_size          | true       | string        | vm_size           |                 |
++------------------+------------+---------------+-------------------+-----------------+
+| public_image     | false      | dict          | image             |This para takes  |
+|                  |            |               |                   | public images   |
+|                  |            |               |                   |                 |
++------------------+------------+---------------+-------------------+-----------------+
+|virtual_network_name| true     | string        |virtual_network_name|                 |
++------------------+------------+---------------+-------------------+-----------------+
+| vm_username      | true       | string        | image             |                 |
++------------------+------------+---------------+-------------------+-----------------+
+| vm_password      | true       | string        | image             |                 |
 +------------------+------------+---------------+-------------------+-----------------+
 
+#If you declare both public and private image, only the private will be taken
 
 Credentials Management
 ----------------------

--- a/docs/source/azure.rst
+++ b/docs/source/azure.rst
@@ -27,7 +27,7 @@ definition, the following options are available.
 |                  |            |               |                   | '_' and other   |
 |                  |            |               |                   |special char     |
 +------------------+------------+---------------+-------------------+-----------------+
-| private_image    | false      | string        | image             |This para takes  |
+| private_image    | false      | string        | image             |This takes       |
 |                  |            |               |                   | private images  |
 |                  |            |               |                   |                 |
 +------------------+------------+---------------+-------------------+-----------------+
@@ -35,7 +35,7 @@ definition, the following options are available.
 +------------------+------------+---------------+-------------------+-----------------+
 | vm_size          | true       | string        | vm_size           |                 |
 +------------------+------------+---------------+-------------------+-----------------+
-| public_image     | false      | dict          | image             |This para takes  |
+| public_image     | false      | dict          | image             |This takes       |
 |                  |            |               |                   | public images   |
 |                  |            |               |                   |                 |
 +------------------+------------+---------------+-------------------+-----------------+
@@ -46,7 +46,7 @@ definition, the following options are available.
 | vm_password      | true       | string        | image             |                 |
 +------------------+------------+---------------+-------------------+-----------------+
 
-#If you declare both public and private image, only the private will be taken
+⚫ If you declare both public and private image, only the private will be taken
 
 Credentials Management
 ----------------------

--- a/docs/source/examples/workspaces/azure/PinFile
+++ b/docs/source/examples/workspaces/azure/PinFile
@@ -10,7 +10,14 @@ azure_vm:
             role: azure_vm
             resource_group: "ccit"
             vm_size: "Standard_DS1_v2"
-            image: "rhcostestimage"
+            private_image: "rhcostestimage"
+            # If you have both private and public images
+            # Linchpin will take the private one
+            public_image:
+              offer: CentOS
+              publisher: OpenLogic
+              sku: '7.1'
+              version: latest
             vm_username: linchpin
             vm_password: Asdfghjkl12345_
             virtual_network_name: linchpincreated

--- a/docs/source/examples/workspaces/azure/PinFile
+++ b/docs/source/examples/workspaces/azure/PinFile
@@ -34,6 +34,38 @@ azure_vm:
           host_groups:
             - example
 
+azure_vm_public_image:
+  topology:
+    topology_name: azure_vm_public_image
+    resource_groups:
+      - resource_group_name: "azure"
+        resource_group_type: "azure"
+        resource_definitions:
+          - vm_name: TEST-Azure
+            role: azure_vm
+            resource_group: "ccit"
+            vm_size: "Standard_DS1_v2"
+            public_image:
+              offer: CentOS
+              publisher: OpenLogic
+              sku: '7.1'
+              version: latest
+            vm_username: linchpin
+            vm_password: Asdfghjkl12345_
+            virtual_network_name: linchpincreated
+        credentials:
+          filename: azure.key
+          profile: key
+  layout:
+    inventory_layout:
+      vars:
+        hostname: __IP__
+      hosts:
+        example-node:
+          count: 1
+          host_groups:
+            - example
+
 azure_vn:
   topology:
     topology_name: azure_vn

--- a/linchpin/provision/roles/azure/files/schema.json
+++ b/linchpin/provision/roles/azure/files/schema.json
@@ -13,13 +13,35 @@
                                 "azure_vm"
                             ]
                         },
+                        "public_image": {
+                            "type": "dict",
+                            "required": false,
+                            "schema": {
+                                "offer": {
+                                    "type": "string",
+                                    "required": true
+                                },
+                                "publisher": {
+                                    "type": "string",
+                                    "required": true
+                                },
+                                "sku": {
+                                    "type": "string",
+                                    "required": true
+                                },
+                                "version": {
+                                    "type": "string",
+                                    "required": true
+                                }
+                            }
+                        },
                         "vm_name": {
                             "type": "string",
                             "required": true
                         },
                         "image": {
                             "type": "string",
-                            "required": true
+                            "required": false
                         },
                         "vm_username": {
                             "type": "string",
@@ -111,7 +133,7 @@
                         },
                         "subnet_name": {
                             "type": "string",
-                            "required":true
+                            "required": true
                         },
                         "resource_group": {
                             "type": "string",
@@ -119,7 +141,7 @@
                         },
                         "address_prefix": {
                             "type": "string",
-                            "required":false
+                            "required": false
                         }
                     }
                 }

--- a/linchpin/provision/roles/azure/files/schema.json
+++ b/linchpin/provision/roles/azure/files/schema.json
@@ -39,7 +39,7 @@
                             "type": "string",
                             "required": true
                         },
-                        "image": {
+                        "private_image": {
                             "type": "string",
                             "required": false
                         },

--- a/linchpin/provision/roles/azure/tasks/provision_azure_vm.yml
+++ b/linchpin/provision/roles/azure/tasks/provision_azure_vm.yml
@@ -20,12 +20,12 @@
 - name: Set image
   set_fact:
     image: "{{pub_img}}"
-    when: res_def[image] is not defined   
+    when: res_def[private_image] is not defined   
 
 - name: Set image
   set_fact: 
     image: "{{res_def[image]}}"
-  when: res_def[image] is defined     
+  when: res_def[private_image] is defined     
 
 - name: "Provisioning Azure VM when not async"
   azure_rm_virtualmachine:

--- a/linchpin/provision/roles/azure/tasks/provision_azure_vm.yml
+++ b/linchpin/provision/roles/azure/tasks/provision_azure_vm.yml
@@ -1,3 +1,32 @@
+---
+- name: Make a default image
+  set_fact: 
+    default_img:
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
+
+- name: "Set public images when public image is defined"
+  set_fact:
+    pub_img: "{{res_def['public_image']}}"
+  when: res_def['public_image'] is defined
+
+- name: "Set default public images"
+  set_fact:
+    pub_img: "{{default_img}}"
+  when: res_def['public_image'] is not defined  
+
+- name: Set image
+  set_fact:
+    image: "{{pub_img}}"
+    when: res_def[image] is not defined   
+
+- name: Set image
+  set_fact: 
+    image: "{{res_def[image]}}"
+  when: res_def[image] is defined     
+
 - name: "Provisioning Azure VM when not async"
   azure_rm_virtualmachine:
     client_id: "{{ auth_var['client_id'] | default(omit) }}"
@@ -10,13 +39,7 @@
     vm_size: "{{ res_def['vm_size'] | default(omit) }}"
     name: "{{ res_def['vm_name'] | default(omit) }}"
     virtual_network_name: "{{res_def['virtual_network_name']|default(omit)}}"
-    image: "{{ res_def['image'] | default(omit) }}"
-    #leave the code below here for now, implement later
-    # image: 
-    #   offer: CentOS
-    #   publisher: OpenLogic
-    #   sku: '7.1'
-    #   version: latest
+    image: "{{ image | default(omit) }}"
   register: res_def_output
   when: not _async
   no_log: "{{ not debug_mode }}"
@@ -37,13 +60,7 @@
     resource_group: "{{ res_def['resource_group'] | default(omit) }}"
     vm_size: "{{ res_def['vm_size'] | default(omit) }}"
     name: "{{ res_def['vm_name'] | default(omit) }}"
-    image: "{{ res_def['image'] | default(omit) }}"
-    #leave the code below here for now, implement later
-    # image: 
-    #   offer: CentOS
-    #   publisher: OpenLogic
-    #   sku: '7.1'
-    #   version: latest
+    image: "{{ image | default(omit) }}"
   async: "{{ async_timeout }}"
   poll: 0
   register: res_def_output


### PR DESCRIPTION
Enabled public image for Linchpin Azure
For current Azure support, we only support private image which means you can only create vm based on the user owned images. After enable the public image, user could create vm based on any online image