### PR TITLE
fix openstack teardown bug remove missing filter

### DIFF
--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -19,11 +19,6 @@
   when: state == "absent"
 
 
-- name: set fact for instance ids
-  set_fact:
-    os_server_instance_ids: "{{ topo_output_resources | fetch_os_server_ids }}"
-  when: state == "absent"
-
 - name: "teardown os_server resources with provided auth"
   os_server:
     state: "absent"


### PR DESCRIPTION
Remove missing filter which is causing the failure in openstack instances deletion
