### PR TITLE
Move python2-dnf dependency to pip

### DIFF
--- a/linchpin/provision/roles/dependencies/tasks/libvirt_deps.yml
+++ b/linchpin/provision/roles/dependencies/tasks/libvirt_deps.yml
@@ -3,7 +3,6 @@
     - name: Install package dependencies
       package:
         name:
-          - python2-dnf 
           - libvirt-devel
           - libguestfs-tools 
           - python-libguestfs
@@ -14,6 +13,7 @@
       with_items:
       - "libvirt-python>=3.0.0"
       - "lxml"
+      - "dnf"
       loop_control: 
         loop_var: libvirt_pypi
   rescue:


### PR DESCRIPTION
Move python2-dnf depedency from yum/dnf to pip since the package no
longer exists in fedora 30

Fixes #1340 