### PR TITLE
Update aws ec2 examples to reflect changes in account

### DIFF
--- a/docs/source/examples/workspaces/aws-simple/PinFile
+++ b/docs/source/examples/workspaces/aws-simple/PinFile
@@ -13,8 +13,8 @@ simple:
           - name: simple
             flavor: {{ flavor | default('t2.micro') }}
             role: aws_ec2
-            region: {{ region | default('us-east-1') }}
-            image: {{ image | default('ami-0c322300a1dd5dc79') }}
+            region: {{ region | default('ca-central-1') }}
+            image: {{ image | default('ami-0b85d4ff00de6a225') }}
             {% if security_groups is defined %}
             security_group:
               - default

--- a/docs/source/examples/workspaces/aws/PinFile
+++ b/docs/source/examples/workspaces/aws/PinFile
@@ -8,9 +8,9 @@ aws-ec2-new:
         resource_definitions:
           - name: demo-day
             role: aws_ec2
-            flavor: {{ flavor | default('m1.small') }}
-            region: {{ region | default('us-east-1') }}
-            image: {{ image | default('ami-984189e2') }}
+            flavor: {{ flavor | default('t2.micro') }}
+            region: {{ region | default('ca-central-1') }}
+            image: {{ image | default('ami-0b85d4ff00de6a225') }}
             count: 1
             {% if tags is defined %}
             instance_tags:
@@ -30,7 +30,6 @@ aws-ec2-new:
             {% else %}
             security_group:
               - default
-              - public
             {% endif %}
         {% if credentials is defined %}
         credentials:
@@ -462,7 +461,6 @@ aws-ec2-template:
             distro: "{{ distro }}"
           security_group:
           - default
-          - public
         {% if credentials is defined %}
         credentials:
           filename: {{ credentials.filename }}

--- a/docs/source/examples/workspaces/dummy-aws/PinFile.dummy-aws.yml
+++ b/docs/source/examples/workspaces/dummy-aws/PinFile.dummy-aws.yml
@@ -3,30 +3,29 @@ dummy-aws:
   topology:
     topology_name: dummy-aws
     resource_groups:
-      - resource_group_name: dummy-topology
-        resource_group_type: dummy
-        resource_definitions:
-          - name: "{{ distro | default('') }}test"
-            role: "dummy_node"
-            count: 1
       - resource_group_name: aws-topology
         resource_group_type: aws
         resource_definitions:
           - name: demo-day
-            flavor: m1.small
+            flavor: t2.micro
             role: aws_ec2
-            region: us-east-1
-            image: ami-984189e2
+            region: ca-central-1
+            image: ami-0b85d4ff00de6a225
             count: 1
             instance_tags:
               color: blue
               shape: oval
             security_group:
               - default
-              - public
         credentials:
           filename: aws.key
           profile: default
+      - resource_group_name: dummy-topology
+        resource_group_type: dummy
+        resource_definitions:
+          - name: "{{ distro | default('') }}test"
+            role: "dummy_node"
+            count: 1
   layout:
     inventory_layout:
       vars:


### PR DESCRIPTION
Update the default (or in some cases hard-coded) values for aws_ec2
resources to be compatible with our new ec2 region.  This will also fix the last failure in #1287 