### PR TITLE
Ignore credentials in workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ duffy-ansible-module
 duffy.py
 docs/source/examples/workspace/dummy-data.yml
 
+# do not upload secure data
+docs/source/examples/workspaces/**/credentials


### PR DESCRIPTION
This just prevents people from accidentally uploading credentials when they submit a PR