### PR TITLE
Added Azure doc and change name "Provediers" to Examples

### DIFF
--- a/docs/source/azure.rst
+++ b/docs/source/azure.rst
@@ -9,7 +9,7 @@ azure_vm
 Azure VM Instances can be provisioned using this resource.
 
 * Example <workspaces/azure/Pinfile>`
-* azure_vm module <https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachine_module.html#id4>_
+* azure_vm module <https://docs.ansible.com/ansible/latest/modules/azure_rm_virtualmachine_module.html#id4>`_
 
 Topology Schema
 ~~~~~~~~~~~~~~~
@@ -31,7 +31,7 @@ definition, the following options are available.
 |                  |            |               |                   | private images  |
 |                  |            |               |                   |                 |
 +------------------+------------+---------------+-------------------+-----------------+
-|virtual_network_name| false    | string        |virtual_network_name|                 |
+|virtual_network_name| false    | string        |virtual_network_name|                |
 +------------------+------------+---------------+-------------------+-----------------+
 | vm_username      | false      | string        | image             |                 |
 +------------------+------------+---------------+-------------------+-----------------+

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -1,4 +1,4 @@
-Providers
+Examples for all Providers
 =========
 
 LinchPin has many default providers. This choose-your-own-adventure page takes you through the basics to ensure success for each.


### PR DESCRIPTION
Add the examples by changing name of Providers, the name "Examples for Proveders" make more sense for user to find the examples fix #1199 