### PR TITLE
Make linchpin look in multiple locations for ansible galaxy roles

### DIFF
--- a/config/Dockerfiles/tests.d/azure/03_azure_virtual_subnet
+++ b/config/Dockerfiles/tests.d/azure/03_azure_virtual_subnet
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
   
 # Verify the azure vm provisioning
-# distros.exclude: none
+# distros.exclude: fedora29 fedora30 centos7
 # providers.include: azure
 # providers.exclude: none
 

--- a/config/Dockerfiles/tests.d/azure/04_azure_vm_public_image
+++ b/config/Dockerfiles/tests.d/azure/04_azure_vm_public_image
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
   
 # Verify the azure vm provisioning
-# distros.exclude: none
+# distros.exclude: fedora29 fedora30 centos7
 # providers.include: azure
 # providers.exclude: none
 

--- a/linchpin/InventoryFilters/GenericInventory.py
+++ b/linchpin/InventoryFilters/GenericInventory.py
@@ -9,9 +9,9 @@ from .InventoryProviders import get_inv_formatter
 
 class GenericInventory(InventoryFilter):
 
-    def __init__(self, inv_format="cfg", pb_path=None):
+    def __init__(self, inv_format="cfg", role_path=None):
         InventoryFilter.__init__(self)
-        self.pb_path = pb_path
+        self.role_path = role_path
         self.inv_formatter = get_inv_formatter(inv_format)()
 
     def get_host_data(self, res_output, config):
@@ -40,8 +40,8 @@ class GenericInventory(InventoryFilter):
         :params res_type: name of the role
         """
 
-        for path in self.pb_path:
-            p = '{0}/{1}/{2}'.format(path, 'roles', res_type)
+        for path in self.role_path:
+            p = '{0}/{1}'.format(path, res_type)
 
             if os.path.exists(os.path.expanduser(p)):
                 return p

--- a/linchpin/galaxy_runner.py
+++ b/linchpin/galaxy_runner.py
@@ -3,9 +3,43 @@ from __future__ import absolute_import
 import subprocess
 
 
-def galaxy_runner(package):
+def install(package):
     cmd = "ansible-galaxy install {0}".format(package)
     retcode = subprocess.call(cmd,
                               shell=True)
 
     return retcode == 0
+
+
+def get_role_paths():
+    """
+    Returns a list of all the roles paths which Ansible-galaxy uses when
+    searching for roles
+
+    In the future, we should read the ansible.cfg and combine it with
+    linchpin.conf, since this data is set in ansible.cfg.
+    """
+    paths = []
+
+    cmd = "ansible-galaxy list"
+    proc = subprocess.Popen(cmd,
+                            shell=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    proc.wait()
+
+    for line in proc.stdout:
+        if line.startswith(b'#'):
+            path = line[2:].strip()
+            paths.append(path.decode('utf-8'))
+
+    for line in proc.stderr:
+        if line.strip().startswith(b'[WARNING]: - the configured path'):
+            before = b'the configured path '
+            after = b' does not exist'
+            start_idx = line.index(before) + len(before) - 1
+            end_idx = line.index(after)
+            path = line[start_idx:end_idx].strip()
+            paths.append(path.decode('utf-8'))
+
+    return paths

--- a/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
+++ b/linchpin/tests/InventoryFilters/test_GenericInventory_pass.py
@@ -36,7 +36,7 @@ def setup_generic_inventory_filter():
     lpa = LinchpinAPI(lpc)
 
 
-    filter = GenericInventory.GenericInventory(pb_path=lpa.pb_path)
+    filter = GenericInventory.GenericInventory(role_path=lpa.role_path)
 
     provider = 'general-inventory'
     base_path = '{0}'.format(os.path.dirname(

--- a/linchpin/tests/validator/test_init_pass.py
+++ b/linchpin/tests/validator/test_init_pass.py
@@ -28,7 +28,7 @@ def setup_validator():
     lpc.load_config()
     lpc.load_global_evars()
     lpa = LinchpinAPI(lpc)
-    validator = Validator(lpa.ctx, lpa.pb_path, lpa.pb_ext)
+    validator = Validator(lpa.ctx, lpa.role_path, lpa.pb_ext)
 
     schema_file = 'schema.json'
     base_path = '{0}'.format(os.path.dirname(os.path.realpath(__file__)))\
@@ -100,9 +100,9 @@ def test_validate_cfgs():
 
 @with_setup(setup_validator)
 def test_find_role_path():
-    pb_path = validator._find_role_path('dummy')
+    role_path = validator._find_role_path('dummy')
 
-    assert os.path.exists(os.path.expanduser(pb_path))
+    assert os.path.exists(os.path.expanduser(role_path))
 
 
 def test_gen_error_msg():


### PR DESCRIPTION
Currently linchpin only looks in ~/.ansible/roles.  This expands the search area to all directories listed in `ansible-galaxy list`

Fixes #1408 