### PR TITLE
Add transaction support for RunDb using Tinyrecords

### DIFF
--- a/linchpin/provision/module_utils/linchpin_rundb.py
+++ b/linchpin/provision/module_utils/linchpin_rundb.py
@@ -188,7 +188,7 @@ class TinyRunDB(BaseDB):
                     de = {"resources": de}
                     tx_rec[res_idx] = de
                     with transaction(t) as tr:
-                        res = tr.update(tinySet(key, [de]), doc_ids=[run_id])
+                        res = t.update({key: [de]}, doc_ids=[run_id])
                         return res
         with transaction(t) as tr:
             update_rec = t.update(add(key, value), doc_ids=[run_id])

--- a/linchpin/tests/test_init_pass.py
+++ b/linchpin/tests/test_init_pass.py
@@ -250,7 +250,7 @@ def test_lp_journal():
     x = lpa.lp_journal(targets=[provider])
     assert x.get(provider)
 
-
+"""
 @with_setup(setup_lp_api)
 def test_invoke_playbooks():
 
@@ -271,6 +271,8 @@ def test_invoke_playbooks():
                                                  console=True)
 
     assert return_code == 0
+
+"""
 
 """
 

--- a/linchpin/tests/test_init_pass.py
+++ b/linchpin/tests/test_init_pass.py
@@ -250,7 +250,6 @@ def test_lp_journal():
     x = lpa.lp_journal(targets=[provider])
     assert x.get(provider)
 
-"""
 @with_setup(setup_lp_api)
 def test_invoke_playbooks():
 
@@ -272,7 +271,6 @@ def test_invoke_playbooks():
 
     assert return_code == 0
 
-"""
 
 """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ configparser>=3.5.0
 pyasn1>=0.1.9
 gitpython==2.1.11
 future
+tinyrecord


### PR DESCRIPTION
fixes #1406 

With the help of TinyRecords package, we will be able to support ACID based transactions to RunDB

This should Solve any concurrency issue. 
@Dannyb48 @rujutashinde 
please let me know if this PR actually works.
It works as expected in my local environment.
