### PR TITLE
Added Azure to examples(providers)

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -9,6 +9,7 @@ LinchPin has many default providers. This choose-your-own-adventure page takes y
    openstack
    libvirt
    aws
+   azure
    gcloud
    vmware
    beaker


### PR DESCRIPTION
Missed Azure for the linchpin documentation