### PR TITLE
restrict version of openstacksdk to 0.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ configparser>=3.5.0
 pyasn1>=0.1.9
 gitpython==2.1.11
 future
+openstacksdk==0.26


### PR DESCRIPTION
Due to the recent changes in infrastructure, 
ansible no longer works with latest versions of OpenStack SDK 
Until the issue is fixed we are going to restrict version of openstacksdk to 0.26
fixes: #1427  for the time being