### PR TITLE
Run sync instead of sleep during libvirt provisioning

### DIFF
--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -295,10 +295,8 @@
       msg: 'Error running command qemu-img. Please make sure the dependencies are installed correctly. Try running `linchpin setup libvirt` to reinstall dependencies'
 
 
-- name: sleep for 60 seconds and continue with play
-  wait_for:
-    timeout: 60
-  delegate_to: localhost
+- name: sync memory data to disk
+  command: sync
 
 
 - name: "Start VM"
@@ -347,10 +345,8 @@
   when: node_exists['failed'] is defined and virt_type == "cloud-init" and cloud_config != {}
 
 
-- name: sleep for 60 seconds and continue with play
-  wait_for:
-    timeout: 60
-  delegate_to: localhost
+- name: sync memory data to disk
+  command: sync
 
 
 - name: "Start VM again (post cloud-init)"


### PR DESCRIPTION
Instead of wasting 2 minutes waiting let's run sync to write the memory data to disk, which should avoid failures caused by delayed write locks.