### PR TITLE
Allow roles to write to topology_outputs directly

### DIFF
--- a/linchpin/provision/roles/common/tasks/main.yml
+++ b/linchpin/provision/roles/common/tasks/main.yml
@@ -12,4 +12,4 @@
 
 - name: "output vars"
   set_fact:
-    topology_outputs: {}
+    topology_outputs: []

--- a/linchpin/provision/roles/gather_resources/tasks/main.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/main.yml
@@ -6,10 +6,6 @@
 # NOTE: If there's async or not, lets just use topology_outputs_<resource> values
 # and do the updating after all data collection is complete.
 # ^^ I don't know what this comment means because it seems like the updating is done first
-- name: "Declare topology_outputs"
-  set_fact:
-    topology_outputs: []
-
 - name: "Add dummy_res"
   set_fact:
     topology_outputs: "{{ topology_outputs_dummy }}"


### PR DESCRIPTION
This allows role developers to avoid the hard-coding in gather_resources while developing external roles