### PR TITLE
Coala init

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,0 +1,47 @@
+[python]
+files = linchpin/**.py
+language = Python
+max_line_length = 80
+use_spaces = True
+
+[python.looks]
+# Patches may conflict with autopep8 so putting them in own section so they
+# will be executed sequentially; also we need the LineLengthBear to double
+# check the line length because PEP8Bear sometimes isn't able to correct the
+# linelength.
+bears = PyImportSortBear, SpaceConsistencyBear
+default_actions = *: ShowPatchAction
+preferred_quotation = '
+
+[python.unused]
+# Do not set default_action to ApplyPatchAction as it may lead to some
+# required imports being removed which might result in coala behaving weirdly.
+default_action = *: ShowPatchAction
+bears = PyUnusedCodeBear
+language = Python
+
+[docstring]
+bears = PyDocStyleBear
+files = linchpin/**/*.py
+
+[python.linting]
+bears = PEP8Bear, PycodestyleBear, PyLintBear
+default_actions = *: ShowPatchAction
+ylint_rcfile = .pylintrc
+
+[python.style]
+bear = YapfBear
+spaces_around_power_operator = False
+coalesce_brackets = True
+
+[python.lines]
+# Sometimes autopep8 makes too long lines, need to check after!
+bears = LineLengthBear, LineCountBear
+ignore_length_regex = ^.*https?://
+max_lines_per_file = 1000
+
+[python.security]
+bear = BanditBear
+
+[python.health]
+bear = MypyBear, RadonBear, VultureBear, CPDBear

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         [console_scripts]
         linchpin=linchpin.shell:runcli
     ''',
-    tests_require=["pytest<=4.4.0", "nose", "mock", "coverage", "flake8"],
+    tests_require=["pytest<=4.4.0", "nose", "mock", "coverage", "flake8",
+        "coala-bears"],
     extras_require={
         'krbV': ["python-krbV"],
         'beaker': ['beaker-client>=23.3', 'python-krbV'],


### PR DESCRIPTION
Centralized static analysis management tool for Linchpin.
To use Coala, install 'test' requirements or with pip `pip install coala-bears` and run `coala`. 
By default Coala will run in interactive mode and ask what to do with the issues found, this could be avoided by running with --ci option - `coala --ci`. Also, one can specifiy specific tests (Bears) to run and on which files to do it. General settings are stored in `.coafile`.