### PR TITLE
Update galaxy_runner get_role_paths function

### DIFF
--- a/linchpin/galaxy_runner.py
+++ b/linchpin/galaxy_runner.py
@@ -36,10 +36,10 @@ def get_role_paths():
     for line in proc.stderr:
         if line.strip().startswith(b'[WARNING]: - the configured path'):
             before = b'the configured path '
-            after = b' does not exist'
             start_idx = line.index(before) + len(before) - 1
-            end_idx = line.index(after)
-            path = line[start_idx:end_idx].strip()
+            path = line[start_idx:].strip()
+            end_idx = path.index(b' ')
+            path = path[:end_idx].strip()
             paths.append(path.decode('utf-8'))
 
     return paths


### PR DESCRIPTION
 testing develop branch with Carbon and The following errors are observed
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/e2e-openstack-linchpin-2/cbn/lib/python2.7/site-packages/blaster/engine/parallel.py", line 45, in run
    task_obj = task_cls(**task_def)
  File "/home/jenkins/workspace/e2e-openstack-linchpin-2/cbn/lib/python2.7/site-packages/carbon/tasks/provision.py", line 53, in __init__
    plugin = getattr(asset, 'provisioner_plugin')(asset)
  File "/home/jenkins/workspace/e2e-openstack-linchpin-2/cbn/lib/python2.7/site-packages/carbon/provisioners/ext/linchpin_wrapper_plugin.py", line 72, in __init__
    self.linchpin_api = LinchpinAPI(self._init_context())
  File "/home/jenkins/workspace/e2e-openstack-linchpin-2/cbn/lib/python2.7/site-packages/linchpin/__init__.py", line 92, in __init__
    for path in galaxy_runner.get_role_paths():
  File "/home/jenkins/workspace/e2e-openstack-linchpin-2/cbn/lib/python2.7/site-packages/linchpin/galaxy_runner.py", line 41, in get_role_paths
    end_idx = line.index(after)
ValueError: substring not found
```
the following is a fix for the same.