### PR TITLE
Updated example for os-heat to make downstream tests pass.

### DIFF
--- a/docs/source/examples/workspaces/openstack-heat/os_stack.yml
+++ b/docs/source/examples/workspaces/openstack-heat/os_stack.yml
@@ -2,12 +2,24 @@ heat_template_version: 2013-05-23
 
 description: Simple template to deploy a single compute instance
 
+parameters:
+  flavor:
+    type: string
+    label: Instance Type
+    description: Flavor to be used
+    default: m1.small
+  tags:
+    type: string
+    label: metadata
+    description: test tags
+    default: testinstancelinchpin
+
 resources:
   my_instance:
     type: OS::Nova::Server
     properties:
       image: cirros
-      flavor: m1.small
+      flavor: { get_param: flavor }
       key_name: ci-factory
       networks:
         - network: provider_net_cci_6 


### PR DESCRIPTION
Need to update heat examples to make it. 
HOT templates are expected to specify the tags parameter. 