### PR TITLE
Mock linchpin dummy module for easier testing 

### DIFF
--- a/config/Dockerfiles/tests.d/dummy/11_mock-dummy-module
+++ b/config/Dockerfiles/tests.d/dummy/11_mock-dummy-module
@@ -1,0 +1,34 @@
+#!/bin/bash -xe
+
+# Verify --no-hooks and --ignore-failed-hooks on dummy provider
+# distros.exclude: none
+# providers.include: dummy
+# providers.exclude: none
+
+DISTRO=${1}
+PROVIDER=${2}
+
+PINFILE="PinFile"
+WORKSPACE_PATH="docs/source/examples/workspaces/mock_dummy_module"
+TARGET="dummy-new"
+
+function clean_up {
+    set +e
+    linchpin -w . -p "${PINFILE}" -v destroy "${TARGET}"
+    D_RC=0
+    D_RC=(${?} -o ${D_RC})
+    if [ ${D_RC} -ne 0 ]; then
+        exit ${D_RC}
+    fi
+}
+trap clean_up EXIT SIGHUP SIGINT SIGTERM
+
+if [ -e /tmp/dummy.hosts ]; then
+    rm /tmp/dummy.hosts
+fi
+
+pushd ${WORKSPACE_PATH}
+pwd
+
+# runs the linchpin up with --use-shell parameter
+linchpin -w . -p "${PINFILE}" -v up "${TARGET}"

--- a/docs/source/examples/workspaces/mock_dummy_module/PinFile
+++ b/docs/source/examples/workspaces/mock_dummy_module/PinFile
@@ -1,0 +1,34 @@
+---
+dummy-new:
+  topology:
+    topology_name: "dummy_cluster" # topology name
+    resource_groups:
+      - resource_group_name: "dummy"
+        resource_group_type: "dummy"
+        resource_definitions:
+          - name: "{{ distro | default('') }}web"
+            role: "dummy_node"
+            count: 3
+          - name: "{{ distro | default('') }}test"
+            role: "dummy_node"
+            count: 1
+  layout:
+    inventory_layout:
+      inventory_file: "{% raw -%}{{ workspace }}/inventories/dummy-new-{{ uhash }}.inventory{%- endraw %}"
+      vars:
+        hostname: __IP__
+      hosts:
+        example-node:
+          count: 3
+          host_groups:
+            - example
+        test-node:
+          count: 1
+          host_groups:
+            - test
+      host_groups:
+        all:
+          vars:
+            ansible_user: root
+            ansible_private_key_file: "{% raw -%}{{ lookup('env', 'TESTLP') | default('/tmp', true) }}/CSS/keystore/css-central{%- endraw %}"
+

--- a/docs/source/examples/workspaces/mock_dummy_module/README.rst
+++ b/docs/source/examples/workspaces/mock_dummy_module/README.rst
@@ -1,0 +1,15 @@
+Dummy
+======
+
+This workspace contains the basic tasks for provisioning and teardown of dummy clusters.
+
+As the name implies, dummy clusters do not provision any resources, but do run through
+the provisioning steps for easy testing of linchpin features
+
+dummy-new
+========
+Provisions a new set of dummy resources and creates a layout to go with them.  The name of the inventory file is dynamically generated based on the uhash
+
+dummy-topo
+========
+Another set of dummy resources with a slightly simpler layout

--- a/docs/source/examples/workspaces/mock_dummy_module/linchpin.conf
+++ b/docs/source/examples/workspaces/mock_dummy_module/linchpin.conf
@@ -30,7 +30,7 @@ distill_on_error = False
 use_actual_rcs = False
 
 [evars]
-linchpin_mock = False
+linchpin_mock = true
 _check_mode = False
 _async = False
 async_timeout = 1000

--- a/linchpin/MockUtils/MockUtils.py
+++ b/linchpin/MockUtils/MockUtils.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from six.moves import range
+
+
+def get_dummy_mock_data(module_args):
+    hosts = [module_args['name'] + "-" + str(x)
+             for x in range(0, int(module_args['count']))]
+    data = {
+        "changed": True,
+        "dummy_file": "/tmp/dummy.hosts",
+        "failed": False,
+        "hosts": hosts,
+        "output_type": "mock"
+    }
+    return data

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -30,6 +30,7 @@ distill_on_error = False
 use_actual_rcs = False
 
 [evars]
+linchpin_mock = true
 _check_mode = False
 _async = False
 async_timeout = 1000

--- a/linchpin/provision/action_plugins/dummy.py
+++ b/linchpin/provision/action_plugins/dummy.py
@@ -1,0 +1,29 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+import linchpin.MockUtils.MockUtils as mock_utils
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        """
+        Simple action plugin that returns the mocked output
+        when linchpin_mock is True
+        """
+        super(ActionModule, self).run(tmp, task_vars)
+        # contains all the module arguments
+        module_args = self._task.args.copy()
+        # task vars.keys() contains all the variable  required
+        # when passed a extra_var as key value pair task_vars
+        # would return mocked output of the named module.
+        # print(task_vars['vars'].keys())
+        # print(task_vars['vars'].get('linchpin_mock', False))
+        linchpin_mock = task_vars['vars'].get('linchpin_mock',
+                                              False)
+        if linchpin_mock:
+            return mock_utils.get_dummy_mock_data(module_args)
+
+        module_return = self._execute_module(module_args=module_args,
+                                             task_vars=task_vars, tmp=tmp)
+        return module_return


### PR DESCRIPTION
This PR is a proof of concept to use ansible action_plugins to replace integration testing 
within linchpin.
