### PR TITLE
Suppress pymongo imports inside module_utils

### DIFF
--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -18,7 +18,6 @@ try:
     from ansible.parsing.dataloader import DataLoader
     from ansible.executor.playbook_executor import PlaybookExecutor
 except ImportError:
-    sys.path.insert(0, '/usr/lib/python2.6/site-packages/Jinja2-2.6-py2.6.egg')
     from .callbacks import PlaybookCallback
     from ansible.parsing.dataloader import DataLoader
     from ansible.executor.playbook_executor import PlaybookExecutor

--- a/linchpin/rundb/mongodb.py
+++ b/linchpin/rundb/mongodb.py
@@ -6,8 +6,11 @@ import sys
 from . import usedb
 from .basedb import BaseDB
 
-if sys.version_info[0] == 3:
-    from pymongo import MongoClient, DESCENDING
+try:
+    if sys.version_info[0] == 3:
+        from pymongo import MongoClient, DESCENDING
+except Exception:
+    pass
 
 
 
@@ -20,8 +23,11 @@ class MongoDB(BaseDB):
 
 
     def _opendb(self):
-        self.client = MongoClient(self.conn_str)
-        self.db = self.client['linchpin']
+        try:
+            self.client = MongoClient(self.conn_str)
+            self.db = self.client['linchpin']
+        except Exception:
+            pass
 
     def _closedb(self):
         # also flush the stored data to mongodb


### PR DESCRIPTION
Fixes #1504 
Ansible does not allow imports which are nonexistent in the python environment within module_utils
and causes JSON error as a side effect since module_utils are not loaded. 
 
The above fix is a hack for #1504 
I could not find any better solution at this point in time. 

Note:
Further, one should have a clean installation of linchpin. 
Since if we try installing linchpin again in existing virtualenv it wont work. 
existing linchpin should be uninstalled using 
```
pip3 uninstall linchpin
```

@Dannyb48 Let me know if it works
@abraverm  ^^^ this should work with both python3 and python2 envs 
