### PR TITLE
Make ansible hooks use proper verbosity

### DIFF
--- a/linchpin/ansible_runner.py
+++ b/linchpin/ansible_runner.py
@@ -265,6 +265,7 @@ def ansible_runner(playbook_path,
                                                   extra_vars,
                                                   vault_password_file,
                                                   inventory_src=inventory_src,
+                                                  verbosity=verbosity,
                                                   console=console)
         results = stdout
         return rc, results

--- a/linchpin/hooks/__init__.py
+++ b/linchpin/hooks/__init__.py
@@ -260,7 +260,7 @@ class LinchpinHooks(object):
 
 
     def run_action(self, state, block, tgt_data):
-        use_shell = self.api.get_cfg("ansible", "use_shell")
+        use_shell = ast.literal_eval(self.api.get_cfg("ansible", "use_shell"))
         if block['name'] in GLOBAL_HOOKS.keys():
             block = self.global_hooks_block(block)
         # currently built-ins support only ansible


### PR DESCRIPTION
Also, all ansible commands were running as shell commands because of a configuration issue.  This fixes that error as well