### PR TITLE
Fix install_selinux_venv.sh for RHEL8 environments

### DIFF
--- a/scripts/install_selinux_venv.sh
+++ b/scripts/install_selinux_venv.sh
@@ -2,6 +2,8 @@
 
 DNF='dnf'
 VERSION=$(python --version 2>&1 | cut -f 2 -d ' ' | sed 's/\.[0-9]*$//')
+VERSION_MAJOR=$(echo ${VERSION} | awk -F '.' {'print $1'})
+VERSION_MINOR=$(echo ${VERSION} | awk -F '.' {'print $2'})
 grep -i fedora /etc/os-release
 
 if [ "${?}" != 0 ]; then
@@ -19,7 +21,11 @@ if [ -n "${VIRTUAL_ENV}" ]; then
     fi
 
     ln -s ${LIBSELINUX_PATH}/selinux ${VIRTUAL_ENV}/${VENV_LIB_PATH} &> /dev/null
-    ln -s ${LIBSELINUX_PATH}/_selinux.so ${VIRTUAL_ENV}/${VENV_LIB_PATH} &> /dev/null
+    if [[ ${VERSION_MAJOR} -gt 2 ]]; then
+      ln -s ${LIBSELINUX_PATH}/_selinux.cpython-${VERSION_MAJOR}${VERSION_MINOR}m-x86_64-linux-gnu.so ${VIRTUAL_ENV}/${VENV_LIB_PATH} &> /dev/null
+    else
+      ln -s ${LIBSELINUX_PATH}/_selinux.so ${VIRTUAL_ENV}/${VENV_LIB_PATH} &> /dev/null
+    fi
 else
     echo "A virtual environment is required"
     exit 1


### PR DESCRIPTION
On RHEL8 _selinux.so file is not present. This change adjusts the symlinks in install_selinux_venv.sh to match python version present on RHEL8.