### PR TITLE
add readthedocs config yaml file to linchpin

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - method: pip
+        path: .
+        extra_requirements:
+            - docs
+   system_packages: true


### PR DESCRIPTION
$subject 
The recent updates in readthedoc environment needs sphinx-automodapi
to be added to the requirements.txt to pass builds. 
refer: 
https://readthedocs.org/projects/linchpin/builds/10204633/