### PR TITLE
Auth debug variable

### DIFF
--- a/docs/source/examples/workspace/linchpin.conf
+++ b/docs/source/examples/workspace/linchpin.conf
@@ -113,9 +113,13 @@ distill_on_error = False
 #async_timeout = 1000
 
 # enables debug mode, which turns on debugging outputs for certain commands.
+#debug_mode = False
+
+# enable authentication debugging mode, where any task related to Linchpin
+# authentication will allow logging in verbose mode.
 # Note that this feature may cause secret keys to be leaked and therefore
 # should not be used in production.
-#debug_mode = False
+#auth_debug = True
 
 # the uhash value will still exist, but will not be added to
 # instances or the inventory_path

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -28,6 +28,7 @@ class Workspace(object):
         self.context.set_cfg('lp', 'workspace', self.workspace_path)
         self.context.set_evar('workspace', self.workspace_path)
         self.context.set_evar('debug_mode', True)
+        self.context.set_evar('auth_debug', True)
 
     def load_data(self, path):
         """
@@ -337,6 +338,7 @@ class Pinfile(Workspace):
         self.context.set_cfg('lp', 'workspace', self.workspace_path)
         self.context.set_evar('workspace', self.workspace_path)
         self.context.set_evar('debug_mode', True)
+        self.context.set_evar('auth_debug', True)
 
     def up(self):
         """

--- a/linchpin/linchpin.constants
+++ b/linchpin/linchpin.constants
@@ -35,6 +35,7 @@ _async = False
 async_timeout = 1000
 default_ssh_key_path = ~/.ssh
 debug_mode = False
+auth_debug = False
 vault_encryption = False
 vault_password = ''
 async_retries = 60

--- a/linchpin/provision/roles/aws/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_resource_group.yml
@@ -20,13 +20,13 @@
   register: auth_variable
   ignore_errors: true
   when: res_grp['credentials'] is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "Set auth_var"
   set_fact:
     auth_var: "{{ auth_variable['output'][cred_profile] | default('') }}"
   when: cred_profile is defined and auth_variable['changed']
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }} res_grp_type={{ res_item.2 }}

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -15,14 +15,14 @@
   register: auth_var
   ignore_errors: true
   when: res_grp['credentials'] is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "Set auth_var"
   set_fact:
     auth_var: "{{ auth_var['output'][cred_profile] | default('') }}"
   ignore_errors: true
   when: auth_var is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "Get topology output data from resources file"
   output_parser:

--- a/linchpin/provision/roles/azure/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/azure/tasks/provision_resource_group.yml
@@ -20,13 +20,13 @@
   register: auth_variable
   ignore_errors: true
   when: res_grp['credentials'] is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "Set auth_var"
   set_fact:
     auth_var: "{{ auth_variable['output'][cred_profile] | default('') }}"
   when: cred_profile is defined and auth_variable['changed']
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }} res_grp_type={{ res_item.2 }}

--- a/linchpin/provision/roles/azure/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/azure/tasks/teardown_resource_group.yml
@@ -15,14 +15,14 @@
   register: auth_var
   ignore_errors: true
   when: res_grp['credentials'] is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "Set auth_var"
   set_fact:
     auth_var: "{{ auth_var['output'][cred_profile] | default('') }}"
   ignore_errors: true
   when: auth_var is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "Get topology output data from resources file"
   output_parser:

--- a/linchpin/provision/roles/gcloud/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/gcloud/tasks/provision_resource_group.yml
@@ -19,14 +19,14 @@
   register: auth_variable
   ignore_errors: true
   when: res_grp['credentials'] is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "Set auth_var"
   set_fact:
     auth_var: "{{ auth_variable | default('') }}"
   ignore_errors: true
   when: auth_variable is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }} res_grp_type={{ res_item.2 }}

--- a/linchpin/provision/roles/nummy/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/nummy/tasks/provision_resource_group.yml
@@ -18,7 +18,7 @@
     vault_enc: "{{ vault_encryption }}"
     vault_pass: "{{ vault_pass }}"
   register: auth_var
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
   when: res_grp['credentials'] is defined
 
 - name: "Fail when auth_var is null"

--- a/linchpin/provision/roles/openshift/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openshift/tasks/provision_resource_group.yml
@@ -41,14 +41,14 @@
     driver: "file"
   register: auth_var_out
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
   when: res_grp['credentials'] is defined and res_grp['credentials']['filename'] is defined
 
 - name: "set auth_var"
   set_fact:
     auth_var: "{{ auth_var_out['output'][cred_profile] }}"
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
   when: auth_var_out['output'] is defined and res_grp['credentials'] is defined and res_grp['credentials']['filename'] is defined
 
 - name: "set auth_var when filename is not defined"

--- a/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -33,7 +33,7 @@
     vault_pass: "{{ vault_pass }}"
   register: auth_var_out
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
   when: res_grp['credentials'] is defined
 
 - name: "set auth_var"
@@ -41,7 +41,7 @@
     auth_var: "{{ auth_var_out['output']['clouds'][cred_profile]['auth'] }}"
   ignore_errors: true
   when: auth_var_out['output'] is defined
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }} res_grp_type={{ res_item.2 }}

--- a/linchpin/provision/roles/ovirt/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/ovirt/tasks/provision_resource_group.yml
@@ -17,13 +17,13 @@
     vault_pass: "{{ vault_pass }}"
   register: auth_var
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "set auth_var"
   set_fact:
     auth_var: "{{ auth_var['output'][cred_profile] }}"
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - block:
   - name: Obtain SSO token with using username/password credentials

--- a/linchpin/provision/roles/rackspace/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/rackspace/tasks/provision_resource_group.yml
@@ -18,13 +18,13 @@
     vault_pass: "{{ vault_pass }}"
   register: auth_var
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "set auth_var"
   set_fact:
     auth_var: "{{ auth_var['output'] }}"
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }} res_grp_type={{ res_item.2 }}

--- a/linchpin/provision/roles/vmware/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/vmware/tasks/provision_resource_group.yml
@@ -17,14 +17,14 @@
     vault_pass: "{{ vault_pass }}"
   register: auth_var
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
   when: res_grp['credentials'] is defined
 
 - name: "set auth_var"
   set_fact:
     auth_var: "{{ auth_var['output'][cred_profile] }}"
   ignore_errors: true
-  no_log: "{{ not debug_mode }}"
+  no_log: "{{ not auth_debug }}"
   when: res_grp['credentials'] is defined
 
 - name: "provisioning resource definitions of current group"


### PR DESCRIPTION
Debug mode is required for CI investigation (for linchpin project or user tests) and it could be needed by CI engineers (infra owners) or CI users (Quality engineers), but not everyone should able to see authentication credentials in that case. The change adds a new variable to Linchpin config to separate between general debug mode and credentials specific case.