### PR TITLE
WIP: Ping once the IP address provided by libvirt dnsmasq in order to late the ARP table

### DIFF
--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -479,6 +479,8 @@
 
 - name: "mac_and_ip | wait up to 5 mins for dhcp ip address"
   shell: |
+    #ping once the IP address provided by libvirt dnsmasq in order to populate the ARP table
+    ping -c1 $(virsh net-dhcp-leases baremetal | awk '/{{ mac }}/ {print $5}' | awk -F / {'print $1'}) -W1 || true
     /usr/sbin/ip n | grep -F {{ mac }} | awk {'print $1'} | grep -v ^fe80
   with_items:
     - "{{ macs }}"


### PR DESCRIPTION
There are use cases when the ARP table is not populated with the IP address assigned to
the VM so the output of 'ip n' doesn't include the MAC address. In order to populate the
ARP table send one ICMP packet to the address assgined by libvirt dnsmasq.