### PR TITLE
Fix error with beaker res data

### DIFF
--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -131,9 +131,6 @@
   when:
     - state == 'present'
 
-  # in the future, we may have to come up with a way of doing this that doesn't rely on the role for the first resource definition
-  # beaker only has one role currently and because of the recipeset syntax, there should never be more than one resource definition anyway
-  # But if either of these facts change, this will need to be reworked
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_beaker_server: "{{ topology_outputs_beaker_server | add_res_data(res_defs['resouce_group_type'], res_defs['resource_definitions'][0]['role']) }}"
+    topology_outputs_beaker_server: "{{ topology_outputs_beaker_server | add_res_data(vars['role_name'], res_defs['resource_definitions'][0]['role']) }}"


### PR DESCRIPTION
The resource group type was being read as an AnsibleUnsafeText, which was preventing the res data from being formatted correctly. This makes the resource group type a string

Resolves #1561 