### PR TITLE
Specify file-mode for output file.

### DIFF
--- a/docs/source/credentials/libvirt.rst
+++ b/docs/source/credentials/libvirt.rst
@@ -14,11 +14,11 @@ on the target machine:
       $ getent group | grep libvirt
       $ groupadd -g 7777 libvirt
 
-#. Add user account to libvirt group
+#. Add user account to libvirt and qemu groups
 
    .. code-block:: bash
 
-      $ usermod -aG libvirt <user>
+      $ usermod -aG libvirt,qemu <user>
 
 #. Edit libvirtd configuration to add group
 

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -235,7 +235,7 @@
   when: node_exists['failed'] is defined and uri_hostname != 'localhost' and virt_type == "cloud-init" and cloud_config_used
 
 - name: "localhost: Generate ci data cd image for cloud-init when cloud config is defined"
-  command: mkisofs -o /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}.iso -V cidata -r -J --quiet /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/user-data /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/meta-data
+  command: mkisofs -file-mode 0666 -o /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}.iso -V cidata -r -J --quiet /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/user-data /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/meta-data
   with_nested:
     - ["{{ libvirt_resource_name }}"]
     - "{{ res_count }}"
@@ -245,7 +245,7 @@
   when: node_exists['failed'] is defined and uri_hostname == 'localhost' and virt_type == "cloud-init" and cloud_config_used
 
 - name: "remote_host: Generate ci data cd image for cloud-init when cloud config is defined"
-  command: mkisofs -o /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}.iso -V cidata -r -J --quiet /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/user-data /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/meta-data
+  command: mkisofs -file-mode 0666 -o /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}.iso -V cidata -r -J --quiet /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/user-data /tmp/vm-{{ definition[0] }}{{ definition[2] }}{{ definition[1] }}/meta-data
   with_nested:
     - ["{{ libvirt_resource_name }}"]
     - "{{ res_count }}"


### PR DESCRIPTION
Re-running provisioning as non-root user fails:

``` yaml
TASK [libvirt : localhost: Generate ci data cd image for cloud-init when cloud config is defined] ***

failed: [localhost] (item=['master', 0, '-']) => {"ansible_loop_var": "definition", "changed": true, "cmd": ["mkisofs", "-o", "/tmp/vm-master-0.iso", "-V", "cidata", "-r", "-J", "--quiet", "/tmp/vm-master-0/user-data", "/tmp/vm-master-0/meta-data"], "definition": ["master", 0, "-"], "delta": "0:00:00.003242", "end": "2020-01-28 16:54:42.858604", "msg": "non-zero return code", "rc": 13, "start": "2020-01-28 16:54:42.855362", "stderr": "genisoimage: Permission denied. Unable to open disc image file '/tmp/vm-master-0.iso'.", "stderr_lines": ["genisoimage: Permission denied. Unable to open disc image file '/tmp/vm-master-0.iso'."], "stdout": "", "stdout_lines": []}
```

Reason `/tmp/vm-master-0.iso` is owned by `qemu:qemu` and is writeable
just by owner.

One of possible solutions(in this pr) is:
  * speify file mode to be writeable by a group
  * add user to a `qemu` group

Fixes #1593 