### PR TITLE
Fix remote provisioning of libvirt accross environments (except virtualenvs)

### DIFF
--- a/docs/source/examples/workspaces/libvirt/custom.xml
+++ b/docs/source/examples/workspaces/libvirt/custom.xml
@@ -1,7 +1,7 @@
-{% set vm = definition[1] %}
-{% set count = definition[2] %}
-{% set path = definition[3] %}
-{% set image_type = definition[4] %}
+{% set vm = definition[0] %}
+{% set count = definition[1] %}
+{% set path = definition[2] %}
+{% set image_type = definition[3] %}
 <domain type='{{ vm.driver | default('kvm') }}'>
   <name>{{ libvirt_resource_name }}_{{ count }}</name>
   <memory unit='KiB'>{{ vm.memory * 1024 | int }}</memory>

--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -17,6 +17,7 @@
                     "memory": { "type": "integer", "required": true },
                     "count": { "type": "integer", "required": false },
                     "uri": { "type": "string", "required": false },
+                    "remote_python_interpretor": { "type": "string", "required": false },
                     "driver": {
                         "type": "string",
                         "allowed": ["kvm", "qemu"],
@@ -121,6 +122,7 @@
                         "allowed": ["libvirt_network"] },
                     "name": { "type": "string", "required": true },
                     "uri": { "type": "string", "required": false },
+                    "remote_python_interpreter": { "type": "string", "required": false },
                     "ip": { "type": "string", "required": false },
                     "prefix": { "type": "integer", "required": false },
                     "family": { "type": "string", "required": false },
@@ -202,6 +204,7 @@
                         "allowed": ["libvirt_storage"] },
                     "name": { "type": "string", "required": true },
                     "uri": { "type": "string", "required": false },
+                    "remote_python_interpreter": { "type": "string", "required": false },
                     "size": { "type": "integer", "required": true },
                     "path": { "type": "integer", "required": true }
                 }

--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -23,6 +23,7 @@
 - name: set cloud config default
   set_fact:
     cloud_config: "{{ res_def['cloud_config'] }}"
+    cloud_config_used: true
 
 - name: "check cloud_config is used or not"
   set_fact:
@@ -87,6 +88,8 @@
   remote_user: "{{ res_def['remote_user'] }}"
   delegate_to: "{{ uri_hostname }}"
   when: uri_hostname != 'localhost'
+  vars:
+    ansible_python_interpreter: "{{ res_def['remote_python_interpreter'] | default('/usr/bin/python3') }}"
 
 - name: "local: Generate ssh keys when they don't exist"
   shell: "ssh-keygen -t rsa -f {{ ssh_key_path }} -N '';cat {{ ssh_key_path }}.pub >> ~/.ssh/authorized_keys"
@@ -301,7 +304,6 @@
 
 - name: sync memory data to disk
   command: sync
-
 
 - name: "Start VM"
   virt:


### PR DESCRIPTION
fixes #1228 
Fixes a couple of bugs with libvirt provisioning with cloud-init config.
1. Provisioning with cloud-config 
2. Remote provisioning  
Further, linchpin currently provisions successfully when we use linchpin-custom-xml topology. 
This PR also introduces remote_python_interpretor schema key resolve differences between python_interpretor of linchpin machine and remote_libvirt_host. 
Note:
As long as there is a ssh connection setup between both client machine and remote_libvirt_host, linchpin provisions libvirt instances. 
This does not work when the linchpin machine is running in a virtual machine. 