### PR TITLE
Temporarily disable postup hook for azure_vm

### DIFF
--- a/docs/source/examples/workspaces/azure/PinFile
+++ b/docs/source/examples/workspaces/azure/PinFile
@@ -163,9 +163,9 @@ azure_vm:
           count: 1
           host_groups:
             - example
-  hooks:
-    postup:
-      - name: azure_boot_log
+  # hooks:
+  #   postup:
+  #     - name: azure_boot_log
 
 #This is the minimum viable input for azure_vm
 # Default setting use username and password, no public key


### PR DESCRIPTION
The hook is causing all PRs that test azure to fail.  Disabling until #1600 is resolved