### PR TITLE
Fix bug preventing topology outputs from multiple sources from being collected

### DIFF
--- a/linchpin/provision/roles/gather_resources/tasks/main.yml
+++ b/linchpin/provision/roles/gather_resources/tasks/main.yml
@@ -6,14 +6,10 @@
 # NOTE: If there's async or not, lets just use topology_outputs_<resource> values
 # and do the updating after all data collection is complete.
 # ^^ I don't know what this comment means because it seems like the updating is done first
-- name: "Get names of variables storing topology outputs from each res_def"
-  set_fact:
-    topology_outputs_vars: "{{ lookup('varnames', '^topology_outputs_').split(',') }}"
-
 - name: "Aggregate topology outputs"
   set_fact:
-    topology_outputs: "{{ lookup('vars', item) }}"
-  loop: "{{ topology_outputs_vars }}"
+    topology_outputs: "{{ topology_outputs }} + {{ lookup('vars', item) }}"
+  loop: "{{ lookup('varnames', '^topology_outputs_').split(',') }}"
   when: item|length > 0
 
 - name: "set value"


### PR DESCRIPTION
I noticed this while I was working on something else.  #1607 didn't aggregate outputs into `topology_outputs`, it overwrote the outputs every time.  This fixes that bug