### PR TITLE
Initial converge tests for AWS

### DIFF
--- a/config/Dockerfiles/fedora30/Dockerfile
+++ b/config/Dockerfiles/fedora30/Dockerfile
@@ -41,6 +41,7 @@ COPY init_libvirt.sh $HOME/
 RUN pip install -U pip; \
     pip install -U setuptools; \
     pip install -U pygithub; \
+    pip install -U pyaml; \
     sed -i "/Service/a ExecStartPost=\/bin\/chmod 666 /dev/kvm" \
       /usr/lib/systemd/system/libvirtd.service
 

--- a/docs/source/examples/workspaces/dummy/PinFile
+++ b/docs/source/examples/workspaces/dummy/PinFile
@@ -4,7 +4,8 @@ dummy-new:
     topology_name: "dummy_cluster" # topology name
     resource_groups:
       - resource_group_name: "dummy"
-        resource_group_type: "14rcole.ansible_role_lp_dummy"
+#         resource_group_type: "14rcole.ansible_role_lp_dummy"
+        resource_group_type: dummy
         resource_definitions:
           - name: "{{ distro | default('') }}web"
             role: "dummy_node"

--- a/docs/source/examples/workspaces/linchpin-mock.conf
+++ b/docs/source/examples/workspaces/linchpin-mock.conf
@@ -38,8 +38,8 @@ pkg = linchpin
 # A common reason to move it is to use the rundb centrally across
 # the entire system, or in a central db on a shared filesystem.
 # System-wide RunDB: rundb_conn = ~/.config/linchpin/rundb-::mac::.json
-#rundb_conn = {{ workspace }}/.rundb/rundb-::mac::.json
-rundb_conn = ~/.config/linchpin/rundb-::mac::.json
+rundb_conn = {{ workspace }}/.rundb/rundb-::mac::.json
+#rundb_conn = ~/.config/linchpin/rundb-::mac::.json
 
 # name the type of Run database. Currently only TinyRunDB exists
 #rundb_type = TinyRunDB
@@ -82,8 +82,8 @@ use_rundb_for_actions = True
 # A user can request specific data distilled from the RunDB. This flag
 # enables the Context Distiller.
 # NOTE: This flag requires generate_resources = False.
-#distill_data = False
-distill_data = True
+distill_data = False
+#distill_data = True
 
 # If desired, enabling distill_on_error will distill any successfully (and
 # possibly failed) provisioned resources. This is predicated on the data
@@ -121,8 +121,8 @@ enable_uhash = True
 # in older versions of linchpin (<v1.0.4), a resources folder exists, which
 # dumped the data that is now stored in the RunDB. To disable the resources
 # output, set the value to False.
-#generate_resources = True
-generate_resources = False
+generate_resources = True
+#generate_resources = False
 
 # default paths in playbooks
 #
@@ -183,6 +183,7 @@ generate_resources = False
 # The location where default resources will be dumped. This path doesn't
 # automatically exist
 #default_resources_path = {{ workspace }}/%(resources_folder)s
+default_resources_path = {{ workspace }}/resources
 
 # If desired, one could overwrite the location of the generated inventory path
 #inventory_path = {{ workspace }}/{{inventories_folder}}/happy.inventory

--- a/linchpin/provision/roles/aws/action_plugins/aws_s3.py
+++ b/linchpin/provision/roles/aws/action_plugins/aws_s3.py
@@ -1,0 +1,1 @@
+../../../action_plugins/aws_s3.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_eip.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_eip.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_eip.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_elb_lb.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_elb_lb.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_elb_lb.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_group.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_group.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_group.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_key.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_key.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_key.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_endpoint.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_endpoint.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_endpoint.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_igw.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_igw.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_igw.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_nat_gateway.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_nat_gateway.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_nat_gateway.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_net.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_net.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_net.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_net_facts.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_net_facts.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_net_facts.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_route_table.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_route_table.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_route_table.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_route_table_facts.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_route_table_facts.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_route_table_facts.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_subnet.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_subnet.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_subnet.py

--- a/linchpin/provision/roles/aws/action_plugins/ec2_vpc_subnet_facts.py
+++ b/linchpin/provision/roles/aws/action_plugins/ec2_vpc_subnet_facts.py
@@ -1,0 +1,1 @@
+../../../action_plugins/ec2_vpc_subnet_facts.py

--- a/linchpin/provision/roles/aws/filter_plugins/write_to_file.py
+++ b/linchpin/provision/roles/aws/filter_plugins/write_to_file.py
@@ -1,0 +1,1 @@
+../../../filter_plugins/write_to_file.py

--- a/linchpin/provision/roles/aws/molecule/docker/molecule.yml
+++ b/linchpin/provision/roles/aws/molecule/docker/molecule.yml
@@ -9,8 +9,12 @@ lint:
   options:
     config-file: tests/yamllint.yml
 platforms:
-  - name: aws
-    image: centos:7
+  - name: aws-f31
+    image: lp_fedora31:latest
+    pull: false
+  - name: aws-f30
+    image: lp_fedora30
+    pull: false
     ## Remove 'image' above and uncomment the following to run systemd in Docker
     # image: centos/systemd
     # privileged: true

--- a/linchpin/provision/roles/aws/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/aws/molecule/shared/playbook.yml
@@ -1,4 +1,4 @@
-- name: Test EC2 Provision
+- name: Test AWS Provision
   hosts: all
   roles:
     - role: aws
@@ -14,6 +14,7 @@
     _async: false
     uhash: "111111"
     linchpin_mock: true
+    default_ssh_key_path: "~"
   post_tasks:
     - name: "Create topology_outputs var"
       set_fact:
@@ -29,7 +30,7 @@
         content: "{{ topology_outputs }}"
         dest: "/root/{{ topology_name }}.output"
 
-- name: Test EC2 Teardown
+- name: Test AWS Teardown
   hosts: all
   roles:
     - role: aws
@@ -45,4 +46,5 @@
     linchpin_mock: true
     generate_resources: true
     default_resources_path: "/root"
+    default_ssh_key_path: "~"
   post_tasks: []

--- a/linchpin/provision/roles/aws/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/aws/molecule/shared/playbook.yml
@@ -1,5 +1,48 @@
-- name: converge
+- name: Test EC2 Provision
   hosts: all
   roles:
     - role: aws
+  pre_tasks:
+    - include_vars:
+        file: topo_data.yml
+    - set_fact:
+        resources: "{{ topo_data.resource_groups }}"
+  vars:
+    state: "present"
+    debug_mode: true
+    auth_debug: true
+    _async: false
+    uhash: "111111"
+    linchpin_mock: true
+  post_tasks:
+    - name: "Create topology_outputs var"
+      set_fact:
+        topology_outputs: []
+        topology_name: "{{ topo_data.topology_name }}"
+    - name: "Aggregate topology outputs"
+      set_fact:
+        topology_outputs: "{{ topology_outputs }} + {{ lookup('vars', item) }}"
+      loop: "{{ lookup('varnames', '^topology_outputs_').split(',') }}"
+      when: item|length > 0
+    - name: "Generate resources file for destroy test"
+      copy:
+        content: "{{ topology_outputs }}"
+        dest: "/root/{{ topology_name }}.output"
+
+- name: Test EC2 Teardown
+  hosts: all
+  roles:
+    - role: aws
+  pre_tasks:
+    - include_vars:
+        file: topo_data.yml
+  vars:
+    state: "absent"
+    debug_mode: true
+    auth_debug: true
+    _async: false
+    uhash: "111111"
+    linchpin_mock: true
+    generate_resources: true
+    default_resources_path: "/root"
   post_tasks: []

--- a/linchpin/provision/roles/aws/molecule/shared/topo_data.yml
+++ b/linchpin/provision/roles/aws/molecule/shared/topo_data.yml
@@ -15,3 +15,84 @@ topo_data:
             shape: oval
           security_group:
             - default
+        - name: "ec2_linchpin_keypair"
+          role: "aws_ec2_key"
+          region: "ca-central-1"
+        - name: "aws_sg_test"
+          role: "aws_sg"
+          description: "aws ssh security group"
+          region: "ca-central-1"
+          rules:
+            - rule_type: "inbound"
+              from_port: "8"
+              to_port: -1
+              proto: "icmp"
+              cidr_ip: "0.0.0.0/0"
+            - rule_type: "inbound"
+              from_port: 22
+              to_port: 22
+              proto: "tcp"
+              cidr_ip: "0.0.0.0/0"
+            - rule_type: "outbound"
+              from_port: 0
+              to_port: 65535
+              proto: "all"
+              cidr_ip: "0.0.0.0/0"
+        - name: "linchpins3bucket"
+          role: "aws_s3"
+          region: "ca-central-1"
+        - name: demodaycilp
+          role: aws_ec2_eip
+          region: "ca-central-1"
+        - name: "demo_day_vpc"
+          role: aws_ec2_vpc_net
+          region: "ca-central-1"
+          cidr_block: "10.10.0.0/16"
+          tags:
+            module: "fedora-aws_ec2_vpc_net"
+            this: works
+          tenancy: dedicated
+        - name: demodayvpcsubnet
+          role: aws_ec2_vpc_subnet
+          region: "ca-central-1"
+          vpc_name: demovpcnetsubnet
+          cidr: "13.0.1.0/24"
+          tags:
+            module: "fedora-aws_ec2_vpc_subnet"
+            this: works
+        - name: demo_routetable
+          role: aws_ec2_vpc_routetable
+          region: ca-central-1
+          vpc_name: demo_vpc_net_r
+          tags:
+            module: "fedora-aws_ec2_vpc_routetable"
+            this: alsoworks
+          subnets:
+            - 'demo_vpc_subnet_r'
+#        - name: demo_ec2_vpc_ep
+#          role: aws_ec2_vpc_endpoint
+#          region: ca-central-1
+#          vpc_name: demo_vpc_net_ep
+#          service: com.amazonaws.ca-central-1.s3
+#          route_table_name: demo_routetable_ep
+#        - name: demo_vpc_nat_gateway_ci_lp
+#          role: aws_ec2_vpc_nat_gateway
+#          region: ca-central-1
+#          subnet_filters:
+#            "tag:module": ec2vpcnatgateway_demo
+#            "tag:distro": fedora
+        - name: "fedora-demoec2elblbcilp"
+          role: aws_ec2_elb_lb
+          region: "ca-central-1'"
+          zones:
+          - ca-central-1a
+          - ca-central-1b
+          listeners:
+          - protocol: http # options are http, https, ssl, tcp
+            load_balancer_port: 80
+            instance_port: 80
+            proxy_protocol: True
+        - name: demo_vpc_internet_gateway
+          role: aws_ec2_vpc_internet_gateway
+          region: ca-central-1
+          vpc_name: "fedora-vpc-test"

--- a/linchpin/provision/roles/aws/molecule/shared/topo_data.yml
+++ b/linchpin/provision/roles/aws/molecule/shared/topo_data.yml
@@ -1,0 +1,17 @@
+topo_data:
+  topology_name: "ec2-new"
+  resource_groups:
+    - resource_group_name: "aws"
+      resource_group_type: "aws"
+      resource_definitions:
+        - name: demo-day
+          role: aws_ec2
+          flavor: 't2.micro'
+          region: 'ca-central-1'
+          image: 'ami-0b85d4ff00de6a225'
+          count: 1
+          instance_tags:
+            color: blue
+            shape: oval
+          security_group:
+            - default

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_eip.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_eip.yml
@@ -27,6 +27,6 @@
 
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net |
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_elb_lb.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_elb_lb.yml
@@ -53,6 +53,6 @@
 
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net |
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_endpoint.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_endpoint.yml
@@ -74,9 +74,14 @@
     wait_timeout: 600
   register: new_vpc_endpoint
 
+- name: "Append outputitem to topology_outputs"
+  set_fact:
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net +
+                                  [new_vpc_endpoint] }}"
+
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net |
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"
   when: state == 'present'

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_internet_gateway.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_internet_gateway.yml
@@ -58,6 +58,6 @@
 
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_internet |
+    topology_outputs_aws_internet: "{{ topology_outputs_aws_internet |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_nat_gateway.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_nat_gateway.yml
@@ -71,6 +71,6 @@
 
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net |
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_net.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_net.yml
@@ -26,6 +26,6 @@
 
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net |
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_routetable.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_routetable.yml
@@ -69,6 +69,6 @@
 
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net |
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"

--- a/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
+++ b/linchpin/provision/roles/aws/tasks/provision_aws_ec2_vpc_subnet.yml
@@ -71,6 +71,6 @@
 
 - name: "Add type to resource"
   set_fact:
-    topology_outputs_aws_ec2: "{{ topology_outputs_aws_net |
+    topology_outputs_aws_net: "{{ topology_outputs_aws_net |
                                   add_res_data(lookup('vars', 'role_name'),
                                                res_def['role']) }}"

--- a/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
+++ b/linchpin/provision/roles/aws/tasks/teardown_resource_group.yml
@@ -55,6 +55,7 @@
 - name: setfact to variable
   set_fact:
     topo_out_json: "{{ topo_output_rundb.output | convert_to_json }}"
+  when: not generate_resources
 
 - name: "set topo_output_resources fact rundb"
   set_fact:


### PR DESCRIPTION
`molecule converge` tests the ansible roles to make sure they function correctly.  This PR can serve as the basis for convergence tests for all of the roles.

Given that we mock the test data, I feel like we can just have a a resource definition for each role within the provider (e.g. ec2, ec2_vpc_net, etc).  Any reason why this can't work?  If not I'll stack another commit on top of this that contains all of the AWS tests