### PR TITLE
POC: Run CI testing using github actions

### DIFF
--- a/.github/install_dependencies.sh
+++ b/.github/install_dependencies.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+echo "Hello this is first attempt to run bash script on github actions"
+OS=$(cat /etc/*release | grep ^NAME | tr -d 'NAME="') 
+ID=$(cat /etc/*release | grep ^ID | tr -d 'ID="') 
+VERSION_ID=$(cat /etc/*release | grep ^VERSION_ID | tr -d 'VERSION_ID="') 
+
+echo $OS
+echo $ID
+echo $VERSION_ID
+
+if [ $VERSION_ID = "8" ]
+then
+    echo "This is centos8";
+    export LC_ALL=C.UTF-8;
+    export LANG=C.UTF-8;
+    yum install -y python3 epel-release which git;
+    yum install -y python3-pip python3-flake8 python3-devel gcc;
+    yum install -y python3-pytest;
+    mkdir -p /github/home/.ssh/;
+elif [ $VERSION_ID = "7" ]
+then
+    echo "This is centos7";
+    export LC_ALL="en_US";
+    export LANG="en_US";
+    yum install -y python3 epel-release which git;
+    yum install -y python-pip python3-pip python3-devel gcc;
+    pip install flake8;
+    yum install -y pytest;
+    mkdir -p /github/home/.ssh/;
+else
+    echo "This is fedora";
+    export LC_ALL=C.UTF-8;
+    export LANG=C.UTF-8;
+    dnf install -y --nogpgcheck python3 git python3-pip python3-flake8 python3-devel gcc which;
+    dnf install -y --nogpgcheck python3-pytest;
+    mkdir -p /github/home/.ssh/;
+
+fi
+

--- a/.github/runmocktests.sh
+++ b/.github/runmocktests.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+echo "Hello this is first attempt to run linchpin provisioning in github actions"
+
+
+VERSION_ID=$(cat /etc/*release | grep ^VERSION_ID | tr -d 'VERSION_ID="')
+
+echo $VERSION_ID
+
+if [ $VERSION_ID = "7" ]
+then
+    echo "This is centos7";
+    export LC_ALL="en_US";
+    export LANG="en_US";
+fi
+
+
+linchpin --version;
+
+mkdir /tmp/workspace/;
+
+cd /tmp/workspace/;
+
+echo $PWD;
+
+locale -a;
+
+echo $LC_ALL;
+export $LANG;
+
+echo "RUNNING AWS MOCK TESTS";
+
+linchpin init aws;
+cd aws;
+linchpin -vvvv up;
+linchpin -vvvv destroy;
+cd ..;
+linchpin init openstack;
+cd openstack;
+linchpin -vvvv up;
+linchpin -vvvv destroy;
+cd ..;
+
+linchpin init gcloud;
+cd gcloud;
+linchpin -vvvv up
+linchpin -vvvv destroy;
+cd ..;
+
+
+linchpin init beaker;
+cd beaker;
+linchpin -vvvv up
+linchpin -vvvv destroy;
+cd ..;

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,27 @@
+name: "Lint testing: Testing container matrix [centos7, centos8]"
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build on ${{matrix.container }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        container: ['fedora:31']
+    steps:
+    - uses: actions/checkout@v2
+    - run: cat /etc/os-release
+    - name: running a shell script file
+      run: |
+        chmod +x ./.github/install_dependencies.sh
+        ./.github/install_dependencies.sh
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        echo $PWD;
+        ls;
+        flake8 --exclude=\.eggs,tests,docs,config/Dockerfiles --ignore=E124,E303,W504 --max-line-length 80 .
+        #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics;
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/multicontainertesting.yml
+++ b/.github/workflows/multicontainertesting.yml
@@ -1,0 +1,37 @@
+name: "multicontainer testing: Testing container matrix"
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build on ${{matrix.container }}
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        container: ['centos:7', 'centos:8', 'fedora:30', 'fedora:31', 'fedora:32' ]
+    steps:
+    - uses: actions/checkout@v2
+    - run: cat /etc/os-release
+    - name: running a shell script file
+      run: |
+        chmod +x ./.github/install_dependencies.sh
+        ./.github/install_dependencies.sh
+    - name: Install dependencies
+      run: |
+        pip3 install -r requirements.txt
+        pip3 install pytest
+        pip3 install pytest-runner
+        pip3 install .[test]
+        pip3 install zipp>=0.5
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics;
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        python3 setup.py test
+    - name: RUN mock tests
+      run: |
+        chmod +x ./.github/runmocktests.sh
+        ./.github/runmocktests.sh    
+

--- a/.github/workflows/multicontainertesting.yml
+++ b/.github/workflows/multicontainertesting.yml
@@ -24,13 +24,10 @@ jobs:
         pip3 install pytest-runner
         pip3 install .[test]
         pip3 install zipp>=0.5
-    - name: Lint with flake8
+    - name: Run unit tests
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics;
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         python3 setup.py test
-    - name: RUN mock tests
+    - name: Run mock tests
       run: |
         chmod +x ./.github/runmocktests.sh
         ./.github/runmocktests.sh    

--- a/docs/source/examples/workspaces/dummy-python-hook/hooks/python/ex_hook/find_pinfile.py
+++ b/docs/source/examples/workspaces/dummy-python-hook/hooks/python/ex_hook/find_pinfile.py
@@ -17,6 +17,6 @@ for hook in prev_hooks:
         print('Found PinFile')
         sys.exit(0)
 
-error = {'error': 'could not find \'PinFile\'', 'files': files}
+error = {'error': 'could not find \'PinFile\''}
 print(error, file=respipe)
 sys.exit(1)

--- a/linchpin/tests/test_init_pass.py
+++ b/linchpin/tests/test_init_pass.py
@@ -240,7 +240,7 @@ def test_do_validation():
         for target, data in six.iteritems(results):
             if not data.startswith("valid"):
                 print(("Validation for target '{0}': has failed with"
-                      " error '{1}'".format(target, msg)))
+                      " error '{1}'".format(target, data)))
 
     assert not failed
 


### PR DESCRIPTION
The following PR uses GitHub actions to run all the CI related testing on
Centos7,8 and fedora 30,31,32 
To be merged after #1625 
fixes: #1626 