### PR TITLE
Add delegated driver support to molecule tests

### DIFF
--- a/linchpin/provision/roles/aws/molecule/delegated/create.yml
+++ b/linchpin/provision/roles/aws/molecule/delegated/create.yml
@@ -1,0 +1,6 @@
+- name: Create
+  hosts: all
+  tasks:
+    - name: "Create molecule instances"
+      debug:
+        msg: "Creating..."

--- a/linchpin/provision/roles/aws/molecule/delegated/destroy.yml
+++ b/linchpin/provision/roles/aws/molecule/delegated/destroy.yml
@@ -1,0 +1,7 @@
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - role: oasis_roles.molecule_docker_ci
+      molecule_docker_ci_state: absent

--- a/linchpin/provision/roles/aws/molecule/delegated/molecule.yml
+++ b/linchpin/provision/roles/aws/molecule/delegated/molecule.yml
@@ -1,0 +1,40 @@
+dependency:
+  name: galaxy
+  options:
+    role-file: molecule/shared/requirements.yml
+driver:
+  name: delegated
+  options:
+    managed: False
+    ansible_connection_options:
+      ansible_connection: local
+lint:
+  name: yamllint
+  options:
+    config-file: tests/yamllint.yml
+platforms:
+  - name: aws-delegated
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    prepare: ../shared/prepare.yml
+    converge: ../shared/playbook.yml
+    cleanup: ../shared/cleanup.yml
+  config_options:
+    defaults:
+      stdout_callback: yaml
+verifier:
+  name: testinfra
+  options:
+    # Add a -v so you see the individual test names,
+    # particularly useful with parameterized tests
+    v: true
+  lint:
+    name: flake8
+  # Using the shared directory is useful for sharing tests across scenarios,
+  # but is not a requirement. For scenario specific tests, add the appropriate
+  # file path to the test or test directory below
+  additional_files_or_dirs:
+    - ../../shared/tests

--- a/linchpin/provision/roles/aws/molecule/delegated/tests/test_null.py
+++ b/linchpin/provision/roles/aws/molecule/delegated/tests/test_null.py
@@ -1,0 +1,8 @@
+# Without at least a file here, tests in the additional directory will not
+# get picked up. If you add actual tests to this directory, then you can
+# safely eliminate this file. Otherwise, it exists only to cause the tests in
+# shared/tests to be discovered.
+#
+# Most tests should be written in the shared/tests directory so that they can
+# be captured by all the scenarios. Only add tests here if there are tests
+# only relevant to a particular scenario

--- a/linchpin/provision/roles/aws/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/aws/molecule/shared/playbook.yml
@@ -28,7 +28,7 @@
     - name: "Generate resources file for destroy test"
       copy:
         content: "{{ topology_outputs }}"
-        dest: "/root/{{ topology_name }}.output"
+        dest: "/tmp/{{ topology_name }}.output"
 
 - name: Test AWS Teardown
   hosts: all
@@ -45,6 +45,6 @@
     uhash: "111111"
     linchpin_mock: true
     generate_resources: true
-    default_resources_path: "/root"
+    default_resources_path: "/tmp"
     default_ssh_key_path: "~"
   post_tasks: []


### PR DESCRIPTION
Adds support for the delegated driver in molecule tests that that we don't have to use nested containers in github actions

To run the delegated driver locally, you may have to set `ansible_python_interpreter` to the python interpreter within your virtual environment.  This is set under `ansible_connection_options` in `molecule/delegated/molecule.yml`