### PR TITLE
Fix validation return codes

### DIFF
--- a/linchpin/validator/__init__.py
+++ b/linchpin/validator/__init__.py
@@ -113,6 +113,7 @@ class Validator(object):
             except SchemaError as e:
                 error = self._format_error(err_prefix, e)
                 results['layout'] = error + '\n'
+                return_code += 1
             else:
                 results['layout'] = "valid"
 
@@ -123,6 +124,7 @@ class Validator(object):
             except SchemaError as e:
                 error = self._format_error(err_prefix, e)
                 results['cfgs'] = error + '\n'
+                return_code += 1
             else:
                 results['cfgs'] = "valid"
 


### PR DESCRIPTION
Fixes #1578 where validate_pretty was not returning a non zero return code if the layout or cfg of the schema was failed to validate. 