### PR TITLE
Revert "Added azure mock test to github action"

### DIFF
--- a/.github/runmocktests.sh
+++ b/.github/runmocktests.sh
@@ -40,13 +40,6 @@ linchpin -vvvv up;
 linchpin -vvvv destroy;
 cd ..;
 
-echo "RUNNING Azure MOCK TESTS";
-linchpin init azure;
-cd azure;
-linchpin -vvvv up
-linchpin -vvvv destroy;
-cd ..;
-
 linchpin init gcloud;
 cd gcloud;
 linchpin -vvvv up


### PR DESCRIPTION
Reverts CentOS-PaaS-SIG/linchpin#1648
Causing GitHub actions to hang. 
Since mock is not yet implemented. 
