### PR TITLE
Fix bug with aws ec2 mock & Breakdown GitHub actions into multiple steps 

### DIFF
--- a/.github/run_aws_mocktests.sh
+++ b/.github/run_aws_mocktests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+echo "Hello this is first attempt to run linchpin provisioning in github actions"
+
+
+VERSION_ID=$(cat /etc/*release | grep ^VERSION_ID | tr -d 'VERSION_ID="')
+
+echo $VERSION_ID
+
+if [ $VERSION_ID = "7" ]
+then
+    echo "This is centos7";
+    export LC_ALL="en_US";
+    export LANG="en_US";
+fi
+
+
+linchpin --version;
+
+mkdir /tmp/workspace/;
+
+cd /tmp/workspace/;
+
+echo $PWD;
+
+locale -a;
+
+echo $LC_ALL;
+export $LANG;
+
+echo "RUNNING AWS MOCK TESTS";
+
+linchpin init aws;
+cd aws;
+linchpin -vvvv up;
+linchpin -vvvv destroy;

--- a/.github/run_aws_mocktests.sh
+++ b/.github/run_aws_mocktests.sh
@@ -17,6 +17,7 @@ fi
 linchpin --version;
 
 mkdir /tmp/workspace/;
+mkdir /root/.ssh/;
 
 cd /tmp/workspace/;
 
@@ -31,5 +32,44 @@ echo "RUNNING AWS MOCK TESTS";
 
 linchpin init aws;
 cd aws;
-linchpin -vvvv up;
-linchpin -vvvv destroy;
+linchpin -vvvv up aws-ec2-new;
+linchpin -vvvv destroy aws-ec2-new;
+
+linchpin -vvvv up aws-ec2-new;
+linchpin -vvvv destroy aws-ec2-new;
+
+linchpin -vvvv up aws-ec2-key-new;
+linchpin -vvvv destroy aws-ec2--key-new;
+
+linchpin -vvvv up aws-sg-new;
+linchpin -vvvv destroy aws-sg-new;
+
+linchpin -vvvv up aws-s3-new;
+linchpin -vvvv destroy aws-s3-new;
+
+linchpin -vvvv up aws-ec2-eip;
+linchpin -vvvv destroy aws-ec2-eip;
+
+linchpin -vvvv up aws-ec2-vpc-net;
+linchpin -vvvv destroy aws-ec2-vpc-net;
+
+linchpin -vvvv up aws-ec2-vpc-subnet;
+linchpin -vvvv destroy aws-ec2-vpc-subnet;
+
+linchpin -vvvv up aws-ec2-vpc-routetable;
+linchpin -vvvv destroy aws-ec2-vpc-routetable;
+
+
+linchpin -vvvv up aws-ec2-elb-lb;
+linchpin -vvvv destroy aws-ec2-elb-lb;
+
+
+linchpin -vvvv up aws-ec2-template;
+linchpin -vvvv destroy aws-ec2-template;
+
+
+
+
+
+
+

--- a/.github/run_beaker_mocktests.sh
+++ b/.github/run_beaker_mocktests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+echo "Hello this is first attempt to run linchpin provisioning in github actions"
+
+
+VERSION_ID=$(cat /etc/*release | grep ^VERSION_ID | tr -d 'VERSION_ID="')
+
+echo $VERSION_ID
+
+if [ $VERSION_ID = "7" ]
+then
+    echo "This is centos7";
+    export LC_ALL="en_US";
+    export LANG="en_US";
+fi
+
+
+linchpin --version;
+
+mkdir /tmp/workspace/;
+
+cd /tmp/workspace/;
+
+echo $PWD;
+
+locale -a;
+
+echo $LC_ALL;
+export $LANG;
+
+echo "RUNNING beaker MOCK TESTS";
+
+linchpin init beaker;
+cd beaker;
+linchpin -vvvv up
+linchpin -vvvv destroy;
+cd ..;

--- a/.github/run_gcloud_mocktests.sh
+++ b/.github/run_gcloud_mocktests.sh
@@ -27,35 +27,10 @@ locale -a;
 echo $LC_ALL;
 export $LANG;
 
-echo "RUNNING AWS MOCK TESTS";
-
-linchpin init aws;
-cd aws;
-linchpin -vvvv up;
-linchpin -vvvv destroy;
-cd ..;
-linchpin init openstack;
-cd openstack;
-linchpin -vvvv up;
-linchpin -vvvv destroy;
-cd ..;
-
-echo "RUNNING Azure MOCK TESTS";
-linchpin init azure;
-cd azure;
-linchpin -vvvv up
-linchpin -vvvv destroy;
-cd ..;
+echo "RUNNING Gcloud MOCK TESTS";
 
 linchpin init gcloud;
 cd gcloud;
-linchpin -vvvv up
-linchpin -vvvv destroy;
-cd ..;
-
-
-linchpin init beaker;
-cd beaker;
 linchpin -vvvv up
 linchpin -vvvv destroy;
 cd ..;

--- a/.github/run_openstack_mocktests.sh
+++ b/.github/run_openstack_mocktests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+echo "Hello this is first attempt to run linchpin provisioning in github actions"
+
+
+VERSION_ID=$(cat /etc/*release | grep ^VERSION_ID | tr -d 'VERSION_ID="')
+
+echo $VERSION_ID
+
+if [ $VERSION_ID = "7" ]
+then
+    echo "This is centos7";
+    export LC_ALL="en_US";
+    export LANG="en_US";
+fi
+
+
+linchpin --version;
+
+mkdir /tmp/workspace/;
+
+cd /tmp/workspace/;
+
+echo $PWD;
+
+locale -a;
+
+echo $LC_ALL;
+export $LANG;
+
+echo "RUNNING Openstack MOCK TESTS";
+
+linchpin init openstack;
+cd openstack;
+linchpin -vvvv up;
+linchpin -vvvv destroy;
+cd ..;

--- a/.github/workflows/multicontainertesting.yml
+++ b/.github/workflows/multicontainertesting.yml
@@ -1,4 +1,4 @@
-name: "multicontainer testing: Testing container matrix"
+name: "multicontainer Testing on container matrix"
 
 on: [push, pull_request]
 
@@ -28,8 +28,23 @@ jobs:
     - name: Run unit tests
       run: |
         python3 setup.py test
-    - name: Run mock tests
+    - name: Run AWS mock tests
       run: |
-        chmod +x ./.github/runmocktests.sh
-        ./.github/runmocktests.sh    
+        chmod +x ./.github/run_aws_mocktests.sh
+        ./.github/run_aws_mocktests.sh
+    - name: Run Openstack mock tests
+      run: |
+        chmod +x ./.github/run_openstack_mocktests.sh
+        ./.github/run_openstack_mocktests.sh
+    - name: Run beaker mock tests
+      run: |
+         chmod +x ./.github/run_beaker_mocktests.sh
+         ./.github/run_beaker_mocktests.sh
+    - name: Run gcloud mock tests
+      run: |
+        chmod +x ./.github/run_gcloud_mocktests.sh
+        ./.github/run_gcloud_mocktests.sh
+
+
+
 

--- a/linchpin/provision/action_plugins/ec2.py
+++ b/linchpin/provision/action_plugins/ec2.py
@@ -23,6 +23,15 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
 
+        module_args = self._task.args.copy()
+        if task_vars is None:
+            task_vars = dict()
+        linchpin_mock = task_vars['vars'].get('linchpin_mock',
+                                              False)
+        if linchpin_mock:
+            return mock_utils.get_mock_data(module_args,
+                                            "ec2")
+
         vm = self._task.get_variable_manager()
         if vm.extra_vars.get('no_monitor', False):
             def get_dict(context, key):
@@ -108,15 +117,6 @@ class ActionModule(ActionBase):
                     socket.recv_string()
 
             return result
-        module_args = self._task.args.copy()
-        if task_vars is None:
-            task_vars = dict()
-        linchpin_mock = task_vars['vars'].get('linchpin_mock',
-                                              False)
-        if linchpin_mock:
-            return mock_utils.get_mock_data(module_args,
-                                            "ec2")
-
         module_return = self._execute_module(module_args=module_args,
                                              task_vars=task_vars,
                                              tmp=tmp)


### PR DESCRIPTION
In order to easily verify the logs we have to breakdown GitHub actions into multiple steps 
Further, a couple of tests were failing for aws-ec2 due to a bug on ec2.py action_plugin 
and also the mock data was missing. 
The following PR fixes the above situation. 