### PR TITLE
Don't hardcode name_separator for remote task

### DIFF
--- a/linchpin/provision/roles/libvirt/tasks/copy_image_src_remote.yml
+++ b/linchpin/provision/roles/libvirt/tasks/copy_image_src_remote.yml
@@ -86,13 +86,14 @@
 - name: "cp img_src to match node name"
   copy:
     src: "{{ img_src }}"
-    dest: "{{ img_item[0] }}{{ img_item[1] }}_{{ img_item[2] }}.{{ img_item[3] }}"
+    dest: "{{ img_item[0] }}{{ img_item[1] }}{{img_item[4]}}{{ img_item[2] }}.{{ img_item[3] }}"
     remote_src: true
   with_nested:
     - ["{{ local_image_path }}"]
     - ["{{ libvirt_resource_name }}"]
     - "{{ res_count }}"
     - ["{{ img_src_ext }}"]
+    - ["{{ res_def['name_separator'] | default('_') }}"]
   loop_control:
     loop_var: img_item
   remote_user: "{{ res_def['remote_user'] }}"


### PR DESCRIPTION
Task `Add additional storage` in `libvirt/tasks/provision_libvirt_node.yml` uses `res_def['name_separator']` when composing path for **qemu-img resize** command

```yaml
  - name: "Add additional storage"
    command: "qemu-img resize {{ definition[1] }}/{{ definition[0] }}{{ definition[5] }}{{ definition[4] }}.{{ definition[2] }} +{{ definition[3] }}"
    with_nested:
      - ["{{ libvirt_resource_name }}"]
      - ["{{ libvirt_image_path | expanduser }}"]
      - ["{{ img_src_ext }}"]
      - ["{{ res_def['additional_storage'] }}"]
      - "{{ res_count }}"
      - ["{{ res_def['name_separator'] }}"]
    loop_control:
      loop_var: definition
    become: "{{ libvirt_become }}"
    remote_user: "{{ res_def['remote_user'] }}"
```

But in `copy_image_src_remote.yml` it's hardcoded to `_` causing task to fail