### PR TITLE
Fix an xmlrpc beaker error when count > 1

### DIFF
--- a/linchpin/FilterUtils/FilterUtils.py
+++ b/linchpin/FilterUtils/FilterUtils.py
@@ -271,7 +271,12 @@ def fetch_beaker_job_ids(topo_out):
     for entry in topo_out:
         entry_dict = {}
         entry_dict["ids"] = []
-        if "id" in list(entry):
+        # filter out if the resource's job id has already
+        # been added. Workaround for Beaker server xmlrpc
+        # issue on python2
+        if "id" in list(entry) and not \
+                [id for ed in output
+                 for id in ed.get("ids", []) if entry.get("id") == id[2:]]:
             entry_dict["ids"].append("J:" + entry["id"])
             output.append(entry_dict)
     return output

--- a/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
+++ b/linchpin/tests/InventoryFilters/test_FilterPlugins_pass.py
@@ -154,6 +154,13 @@ def test_fetch_beaker_job_ids():
     assert_equals(expected,
                   filter_utils.fetch_beaker_job_ids(test_input))
 
+
+def test_fetch_beaker_job_ids_count():
+    test_input = [{"id": "3124"}, {"id": "3124"}, {"id": "3214"}]
+    expected = [{'ids': ['J:3124']}, {'ids': ['J:3214']}]
+    assert_equals(expected,
+                  filter_utils.fetch_beaker_job_ids(test_input))
+
 def test_fetch_os_server_names():
     test_input = [ {"resource_group": "openstack",
                     "role": "os_server",


### PR DESCRIPTION
This should fix #1693 where two resources belong to the same
job are filtered to avoid xmlrpc condition