### PR TITLE
Test Beaker with Linchpin RPM

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::set-output name=name::${rpm_name}"
       - uses: actions/upload-artifact@v1
         with:
-          name: ${{steps.result.outputs.name}}
+          name: linchpin.rpm
           path: ${{steps.result.outputs.name}}
       - name: Upload Release Asset
         if: github.event_name == 'release'
@@ -69,6 +69,31 @@ jobs:
           asset_path: ${{steps.result.outputs.name}}
           asset_name: ${{steps.result.outputs.name}}
           asset_content_type: application/rpm
+
+  test_rpm:
+    name: Test RPM package
+    container: fedora:31
+    runs-on: ubuntu-latest
+    needs: rpm
+    steps:
+      - name: Download RPM
+        uses: actions/download-artifact@v1
+        with:
+          name: linchpin.rpm
+          path: linchpin.rpm
+      - name: Install Linchpin
+        run: |
+          dnf install -y findutils
+          find . -name '*.rpm' -exec dnf install -y {} \; 
+      - name: Testing Beaker
+        run: |
+          cd /tmp
+          linchpin init beaker
+          pushd beaker
+          linchpin -vvvv up --env-vars linchpin_mock True
+          linchpin -vvvv destroy --env-vars  linchpin_mock True
+          popd
+
   appimage:
     name: Build AppImage
     runs-on: ubuntu-latest

--- a/linchpin/provision/linchpin.yml
+++ b/linchpin/provision/linchpin.yml
@@ -3,18 +3,21 @@
 
 - name:  "schema check and Pre Provisioning Activities on topology_file"
   hosts: localhost
+  connection: local
   gather_facts: False
   roles:
     - { role: 'common' }
 
 - name:  "Provisioning resources based on resource group type"
   hosts: localhost
+  connection: local
   gather_facts: True
   roles:
     - { role: "{{ resources['resource_group_type'] }}" }
 
 - name: "Writing contents to file"
   hosts: localhost
+  connection: local
   gather_facts: False
   roles:
     - { role: 'gather_resources' }


### PR DESCRIPTION
Linchpin RPM was failing on Beaker module import, and we found out by customer who tried to provision with it.  The import issue was fixed in RPM build PR, this PR adds RPM testing for Beaker. During test development, I found another bug - Linchpin fails to run on systems without SSH, the PR fixes that too.