### PR TITLE
Fix ansible hooks hanging

### DIFF
--- a/linchpin/hooks/__init__.py
+++ b/linchpin/hooks/__init__.py
@@ -136,6 +136,8 @@ class LinchpinHooks(object):
         uhash = self.api.get_evar('uhash')
         uhash_enabled = self.api.get_evar('enable_uhash', False)
         ext = self.api.get_cfg('extensions', 'inventory')
+        # some applications need no_monitor disabled for ansible hooks
+        no_monitor = self.api.get_evar('no_monitor')
 
         inv_file = '{0}/{1}/{2}{3}'.format(workspace,
                                            inv_folder,
@@ -151,6 +153,7 @@ class LinchpinHooks(object):
         self.api.target_data['extra_vars'] = {}
         self.api.target_data['extra_vars']['inventory_dir'] = inv_folder
         self.api.target_data['extra_vars']['inventory_file'] = inv_file
+        self.api.target_data['extra_vars']['no_monitor'] = no_monitor
 
 
     def prepare_inv_params(self):

--- a/linchpin/hooks/action_managers/ansible_action_manager.py
+++ b/linchpin/hooks/action_managers/ansible_action_manager.py
@@ -106,6 +106,7 @@ class AnsibleActionManager(ActionManager):
         ctx_params["layout_file"] = self.target_data.get("layout_file", None)
         ctx_params["inventory_file"] = (
             self.target_data.get("inventory_file", None))
+        ctx_params['no_monitor'] = self.target_data.get("no_monitor", False)
 
         return ctx_params
 
@@ -140,6 +141,9 @@ class AnsibleActionManager(ActionManager):
             vault_pass_file = self.action_data.get("vault_password_file", None)
             extra_vars.update(e_vars)
             extra_vars['hook_data'] = results
+            # some applications need no_monitor disabled for ansible hooks
+            if 'no_monitor' in self.target_data:
+                extra_vars['no_monitor'] = self.target_data.get('no_monitor')
             verbosity = self.kwargs.get('verbosity', 1)
 
             if self.context:

--- a/linchpin/tests/hooks/action_managers/test_ansible_action_manager.py
+++ b/linchpin/tests/hooks/action_managers/test_ansible_action_manager.py
@@ -49,7 +49,8 @@ def test_get_ctx_params():
     params = manager.get_ctx_params()
     assert_equal(list(params.keys()), ['resource_file',
                                      'layout_file',
-                                     'inventory_file'])
+                                     'inventory_file',
+                                       'no_monitor'])
 
 @with_setup(setup_ansible_action_manager)
 def test_execute():


### PR DESCRIPTION
* Fix #1709 where no_monitor was not being propagated to the
  ansible action manager to disable the zmq multiprocess/progress bar code

* Fix an issue with the dummy action plugin causes hangs as well