### PR TITLE
RFR: remove ansible and gitpyhton pin ver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.9.96
 apache-libcloud>=0.20.1
 click>=7.0
 yamlordereddictloader>=0.4.0
-ansible>=2.7.1,<=2.9.0
+ansible>=2.7.1
 six>=1.10.0
 shade>=1.30.0
 naked>=0.1.31
@@ -18,7 +18,7 @@ PyYAML>=5.1
 jinja2>=2.10
 configparser>=3.5.0
 pyasn1>=0.1.9
-GitPython>=2.1.15,<3.1.0 
+GitPython>=2.1.15 
 gitdb>=0.6.4
 future
 openstacksdk>=0.37


### PR DESCRIPTION
I found anisible version pin to `2.9.0`; after this we got small releases latest one is `2.9.6`. I don't thing pining ansible version its better option (it creates dependacy issues). lets provide compartibility of `~2.9`. 