### PR TITLE
Add workflows to make PYPI releases

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,0 +1,15 @@
+name: "Autobump tag on develop branch when version changes"
+
+on: [push]
+
+jobs:
+  tag-new-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: salsify/action-detect-and-tag-new-version@v1
+        with:
+          version-command: |
+            grep -o "'.*'" ./linchpin/version.py | sed "s/'//g" | tail -n 1

--- a/.github/workflows/publishtopypi.yml
+++ b/.github/workflows/publishtopypi.yml
@@ -1,0 +1,32 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: "Upload Python Package to PYPI"
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'linchpin/version.py'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
Contains GitHub workflows that enable the following:
- Autobumps the version and tags the branches 
- Publish to PyPI based on the version changes

fixes #1633 