### PR TITLE
Revert "Wrap IPv6 addresses on ansible_ssh_host fixes issue #1691"

### DIFF
--- a/linchpin/InventoryFilters/CFGInventoryFormatter.py
+++ b/linchpin/InventoryFilters/CFGInventoryFormatter.py
@@ -16,8 +16,6 @@ try:
 except ImportError:
     from six.moves.configparser import ConfigParser
 
-from ipaddress import ip_interface
-
 
 class CFGInventoryFormatter(InventoryFormatter):
 
@@ -32,15 +30,6 @@ class CFGInventoryFormatter(InventoryFormatter):
         # adding a default section all
         if "all" not in self.config.sections():
             self.config.add_section("all")
-
-    def is_ipv6(self, ipaddr):
-        try:
-            if ip_interface(ipaddr).ip.version == 6:
-                return True
-            return False
-        except Exception as e:
-            print(e)
-            return False
 
     def set_children(self, inv):
         if 'host_groups' not in list(inv.keys()):
@@ -105,32 +94,11 @@ class CFGInventoryFormatter(InventoryFormatter):
                             continue
                         if common_vars[var] in list(cfg_item[item].keys()):
                             value = common_vars[var]
-                            ip_addr = str(cfg_item[item][value])
-                            if ((var == "ansible_ssh_host") or
-                                    (var == "ansible_host"))\
-                                    and self.is_ipv6(ip_addr):
-                                host_string += " " + \
-                                               var + \
-                                               "=" + \
-                                               "[" + \
-                                               str(cfg_item[item][value]) + "]"
-                            else:
-                                host_string += " " + \
-                                               var + \
-                                               "=" + \
-                                               str(cfg_item[item][value])
+                            host_string += " " + var + "=" +\
+                                           str(cfg_item[item][value])
                         else:
-                            if ((var == "ansible_ssh_host") or
-                                    (var == "ansible_host")) and\
-                                    self.is_ipv6(str(common_vars[var])):
-                                host_string += " " + \
-                                               var + \
-                                               "=" + \
-                                               "[" + str(common_vars[var]) + "]"
-                            else:
-                                host_string += " " + \
-                                               var + \
-                                               "=" + str(common_vars[var])
+                            host_string += " " + var + "=" +\
+                                           str(common_vars[var])
                 self.config.set(group, host_string)
 
     def generate_inventory(self):

--- a/linchpin/provision/roles/aws/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/aws/molecule/shared/playbook.yml
@@ -31,6 +31,7 @@
       copy:
         content: "{{ topology_outputs }}"
         dest: "/tmp/{{ topology_name }}.output"
+        mode: 0644
 
 - name: Test AWS Teardown
   hosts: all

--- a/linchpin/provision/roles/azure/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/azure/molecule/shared/playbook.yml
@@ -29,6 +29,7 @@
       copy:
         content: "{{ topology_outputs }}"
         dest: "/tmp/{{ topology_name }}.output"
+        mode: 0644
 
 - name: Test Azure Teardown
   hosts: all

--- a/linchpin/provision/roles/beaker/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/beaker/molecule/shared/playbook.yml
@@ -35,6 +35,7 @@
       copy:
         content: "{{ topology_outputs }}"
         dest: "/tmp/{{ topology_name }}.output"
+        mode: 0644
 
 - name: Test Beaker Teardown
   hosts: all

--- a/linchpin/provision/roles/dummy/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/dummy/molecule/shared/playbook.yml
@@ -32,6 +32,7 @@
       copy:
         content: "{{ topology_outputs }}"
         dest: "/tmp/{{ topology_name }}.output"
+        mode: 0644
 
 - name: Test Dummy Teardown
   hosts: all

--- a/linchpin/provision/roles/gcloud/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/gcloud/molecule/shared/playbook.yml
@@ -33,6 +33,7 @@
       copy:
         content: "{{ topology_outputs }}"
         dest: "/tmp/{{ topology_name }}.output"
+        mode: 0644
 
 - name: Test Google Cloud Teardown
   hosts: all

--- a/linchpin/provision/roles/openstack/molecule/shared/playbook.yml
+++ b/linchpin/provision/roles/openstack/molecule/shared/playbook.yml
@@ -33,6 +33,7 @@
       copy:
         content: "{{ topology_outputs }}"
         dest: "/tmp/{{ topology_name }}.output"
+        mode: 0644
 
 - name: Test OpenStack Teardown
   hosts: all

--- a/linchpin/provision/roles/openstack/tasks/provision_os_keypair.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_keypair.yml
@@ -48,6 +48,7 @@
     content: "{{ job_result['key']['private_key'] }}"
     dest: "{{ default_ssh_key_path }}/{{ res_def['res_name'] |
               default(res_def['name']) }}.key"
+    mode: 0644
   when: state == "present" and
         res_def_output_async['changed'] and
         _async

--- a/linchpin/provision/roles/openstack/tasks/teardown_os_keypair.yml
+++ b/linchpin/provision/roles/openstack/tasks/teardown_os_keypair.yml
@@ -48,6 +48,7 @@
     content: "{{ job_result['key']['private_key'] }}"
     dest: "{{ default_ssh_key_path }}/{{ res_def['res_name'] |
               default(res_def['name']) }}.key"
+    mode: 0644
   when: state == "present" and
         res_def_output_async['changed']
         and _async


### PR DESCRIPTION
This reverts commit efeca3827cdb2c981c145114cd55c44019b70627.

Wrapping IPv6 address in inventory break connectivity to the nodes

```yaml
node-0-0 hostname=node-0-0 ansible_ssh_host=[fd2e:6f44:5dd8::12b] ...
```

fails like
```yaml
node-0-0 | UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to connect to the host via ssh: ssh: Could not resolve hostname [fd2e:6f44:5dd8::12b]: Name or service not known",
    "unreachable": true
}
```

Removing the quotes fixes the issue

```yaml
node-0-0 hostname=node-0-0 ansible_ssh_host=fd2e:6f44:5dd8::12b
```

```yaml
node-0-0 | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```

**Packages**
```
linchpin==2.0.3
ansible==2.9.13
```
