### PR TITLE
Add libvirt networks dual stack support

### DIFF
--- a/linchpin/provision/roles/libvirt/files/schema.json
+++ b/linchpin/provision/roles/libvirt/files/schema.json
@@ -123,11 +123,20 @@
                     "name": { "type": "string", "required": true },
                     "uri": { "type": "string", "required": false },
                     "remote_python_interpreter": { "type": "string", "required": false },
-                    "ip": { "type": "string", "required": false },
-                    "prefix": { "type": "integer", "required": false },
-                    "family": { "type": "string", "required": false },
-                    "dhcp_start": { "type": "string", "required": false, "dependencies": ["dhcp_end"] },
-                    "dhcp_end": { "type": "string", "required": false, "dependencies": ["dhcp_start"] },
+                    "ip": {
+                        "type": "list",
+                        "required": false,
+                        "schema": {
+                            "type": "dict",
+                            "schema": {
+                                "address": { "type": "string", "required": false },
+                                "prefix": { "type": "integer", "required": false },
+                                "family": { "type": "string", "required": false },
+                                "dhcp_start": { "type": "string", "required": false, "dependencies": ["dhcp_end"] },
+                                "dhcp_end": { "type": "string", "required": false, "dependencies": ["dhcp_start"] }
+                             }
+                         }
+                    },
                     "bridge": { "type": "string", "required": false },
                     "domain": { "type": "string", "required": false },
                     "forward_mode": { "type": "string", "required": false },

--- a/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
+++ b/linchpin/provision/roles/libvirt/templates/libvirt_network.xml.j2
@@ -53,12 +53,14 @@
   <domain name="{{ res_def['domain'] }}" localOnly="yes"/>
 {% endif %}
 {% if res_def['ip'] is defined %}
-  <ip address="{{ res_def['ip'] }}" {% if res_def['netmask'] is defined %} netmask="{{ res_def['netmask'] }}" {% endif %} {% if res_def['family'] is defined %}family="{{ res_def['family'] }}"{% endif %} {% if res_def['prefix'] is defined %}prefix="{{ res_def['prefix'] }}"{% endif %}>
-{% if res_def['dhcp_start'] is defined %}
+  {% for ip in res_def['ip'] %}
+  <ip address="{{ ip['address'] }}" {% if ip['netmask'] is defined %} netmask="{{ ip['netmask'] }}" {% endif %} {% if ip['family'] is defined %}family="{{ ip['family'] }}"{% endif %} {% if ip['prefix'] is defined %}prefix="{{ ip['prefix'] }}"{% endif %}>
+{% if ip['dhcp_start'] is defined %}
     <dhcp>
-      <range start="{{ res_def['dhcp_start'] }}" end="{{ res_def['dhcp_end'] }}"/>
+      <range start="{{ ip['dhcp_start'] }}" end="{{ ip['dhcp_end'] }}"/>
     </dhcp>
 {% endif %}
   </ip>
+  {% endfor %}
 {% endif %}
 </network>


### PR DESCRIPTION
This change adds support for allowing both ipv4 and ipv6 ip sections in the libvirt network definition hence enabling dual stack connectivity.