### PR TITLE
Increase wait retry for shutdown state

### DIFF
--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -326,24 +326,8 @@
     uri: "{{ definition[1] }}"
   register: vmstatus
   until: vmstatus.status == 'shutdown'
-  retries: 5
-  delay: 10
-  with_nested:
-    - ["{{ libvirt_resource_name }}"]
-    - ["{{ res_def['uri'] }}"]
-    - "{{ res_count }}"
-    - ["{{ res_def['name_separator'] }}"]
-  loop_control:
-    loop_var: definition
-  when: node_exists['failed'] is defined and virt_type == "cloud-init" and cloud_init_used
-  ignore_errors: yes
-
-- name: "MSVMISD: Make sure vm is shutdown"
-  virt:
-    name: "{{ definition[0] }}{{ definition[3] }}{{ definition[2] }}"
-    state: shutdown
-    command: shutdown
-    uri: "{{ definition[1] }}"
+  retries: 20
+  delay: 15
   with_nested:
     - ["{{ libvirt_resource_name }}"]
     - ["{{ res_def['uri'] }}"]


### PR DESCRIPTION
50 seconds for VM to shutdown not always enough so it's increased to 5 minutes.

Task `MSVMISD: Make sure vm is shutdown` is dropped cause:
* > state and command are mutually exclusive except when command=list_vms.
*  > there may be some lag for state requests like `shutdown' since these refer only to VM states.