### PR TITLE
Register a single address in libvirt 'wait up to 5 mins for dhcp' tasks

### DIFF
--- a/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/linchpin/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -489,7 +489,7 @@
 
 - name: "MAIP: mac_and_ip | wait up to 5 mins for dhcp ip address"
   shell: |
-    /usr/sbin/ip n | grep -F {{ mac }} | awk {'print $1'} | grep -v ^fe80
+    /usr/sbin/ip n | grep -F {{ mac }} | awk {'print $1'} | grep -v ^fe80 | head -1
   with_items:
     - "{{ macs }}"
   loop_control:
@@ -519,7 +519,7 @@
 
 - name: "mac_and_ip | wait up to 5 mins for dhcp ip address"
   shell: |
-    /usr/sbin/ip n | grep -F {{ mac }} | awk {'print $1'} | grep -v ^fe80
+    /usr/sbin/ip n | grep -F {{ mac }} | awk {'print $1'} | grep -v ^fe80 | head -1
   with_items:
     - "{{ macs }}"
   loop_control:


### PR DESCRIPTION
In case of dual stack environments the wait up to 5 mins for dhcp ip address tasks return 2 addresses which result in broken inventory files. This change filters the returned addresses to a single one.

```
TASK [libvirt : MAIP: mac_and_ip | wait up to 5 mins for dhcp ip address] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
libvirt_:_MAIP:_mac_and_ip_|_wait_up_to_5_mins_for_dhcp_ip_address
changed: [localhost] => (item=52:54:00:af:95:5a) => {"ansible_loop_var": "mac", "attempts": 1, "changed": true, "cmd": "/usr/sbin/ip n | grep -F 52:54:00:af:95:5a | awk {'print $1'} | grep -v ^fe80\n", "delta": "0:00:00.012793", "end": "2020-12-08 15:02:49.808213", "mac": "52:54:00:af:95:5a", "rc": 0, "start": "2020-12-08 15:02:49.795420", "stderr": "", "stderr_lines": [], "stdout": "192.168.123.110\nfd2e:6f44:5dd8::13a", "stdout_lines": ["192.168.123.110", "fd2e:6f44:5dd8::13a"]}

TASK [libvirt : fail when previous task fails] **********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [libvirt : Intialize ip_set variable] **************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {"ansible_facts": {"ip_set": []}, "changed": false}

TASK [libvirt : Intialize ip_set to ipaddress] **********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => (item=0) => {"ansible_facts": {"ip_set": ["192.168.123.110\nfd2e:6f44:5dd8::13a"]}, "ansible_loop_var": "num", "changed": false, "num": 0}

TASK [libvirt : mac_and_ip | wait up to 5 mins for dhcp ip address] *************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost] => (item=52:54:00:af:95:5a)  => {"ansible_loop_var": "mac", "changed": false, "mac": "52:54:00:af:95:5a", "skip_reason": "Conditional result was False"}

TASK [libvirt : remote: set ip_set] *********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost] => (item=0)  => {"ansible_loop_var": "num", "changed": false, "num": 0, "skip_reason": "Conditional result was False"}

TASK [Append ip_addresses and node_data to topology_outputs_libvirt_nodes] ******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => (item=0) => {"ansible_facts": {"topology_outputs_libvirt_nodes": [{"ip": "192.168.123.110\nfd2e:6f44:5dd8::13a", "ip_type": "private", "name": "provisionhost-0-0"}]}, "ansible_loop_var": "index", "changed": false, "index": 0}

```

Results in 

```
[provisionhost]
provisionhost-0-0 hostname=provisionhost-0-0 ansible_ssh_host=192.168.123.110
fd2e:6f44:5dd8::13a ansible_ssh_user=kni ansible_python_interpreter=/usr/libexec/platform-python ansible_ssh_common_args="-o StrictHostKeyChecking=no"

```