### PR TITLE
Change generic yaml.load() references to use safe_load()

### DIFF
--- a/.github/install_dependencies.sh
+++ b/.github/install_dependencies.sh
@@ -19,12 +19,13 @@ then
     yum install -y openssl-devel;
     yum install libvirt-devel -y;
     yum install libguestfs-tools python-libguestfs -y;
+    pip3 install --upgrade pip 
     mkdir -p /github/home/.ssh/;
 elif [ $VERSION_ID = "7" ]
 then
     echo "This is centos7";
-    export LC_ALL="en_US";
-    export LANG="en_US";
+    export LC_ALL="en_US.UTF-8";
+    export LANG="en_US.UTF-8";
     yum install libvirt-devel -y;
     yum install -y openssl-devel;
     yum install libguestfs-tools python-libguestfs -y;
@@ -32,6 +33,7 @@ then
     yum install -y python-pip python3-pip python3-devel gcc;
     pip install flake8;
     yum install -y pytest;
+    pip3 install --upgrade pip
     mkdir -p /github/home/.ssh/;
 else
     echo "This is fedora";
@@ -42,6 +44,7 @@ else
     yum install libguestfs-tools python-libguestfs -y;
     dnf install -y --nogpgcheck python3 git python3-pip python3-flake8 python3-devel gcc which wget;
     dnf install -y --nogpgcheck python3-pytest;
+    pip3 install --upgrade pips
     mkdir -p /github/home/.ssh/;
 
 fi

--- a/.github/workflows/molecule-tests-centos7.yml
+++ b/.github/workflows/molecule-tests-centos7.yml
@@ -18,12 +18,15 @@ jobs:
           chmod +x ./.github/install_dependencies.sh
           ./.github/install_dependencies.sh
       - name: Install pip dependencies
+        env:
+          LC_ALL: en_US.utf8
+          LANG: en_US.utf8
         run: |
-          pip3 install -r requirements.txt
-          pip3 install .[tests]
-          pip3 install molecule[delegated]
-          pip3 install zipp>=0.5
-          pip3 install -r requirements-azure.txt
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install .[tests]
+          python3 -m pip install molecule[delegated]
+          python3 -m pip install zipp>=0.5
+          python3 -m pip install -r requirements-azure.txt
       - name: "Execute AWS molecule tests"
         env:
           LC_ALL: en_US.utf8

--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -19,11 +19,11 @@ jobs:
           ./.github/install_dependencies.sh
       - name: Install pip dependencies
         run: |
-          pip3 install -r requirements.txt
-          pip3 install .[tests]
-          pip3 install molecule[delegated]
-          pip3 install zipp>=0.5
-          pip3 install -r requirements-azure.txt
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install .[tests]
+          python3 -m pip install molecule[delegated]
+          python3 -m pip install zipp>=0.5
+          python3 -m pip install -r requirements-azure.txt
       - name: "Execute AWS molecule tests"
         env:
           LC_ALL: C.utf8

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -37,7 +37,7 @@ class Workspace(object):
         :param path: path to workspace directory
         """
 
-        self.pindict = yaml.load(open(path).read())
+        self.pindict = yaml.safe_load(open(path).read())
         return self.pindict
 
     def validate(self):

--- a/linchpin/hooks/action_managers/ansible_action_manager.py
+++ b/linchpin/hooks/action_managers/ansible_action_manager.py
@@ -133,7 +133,7 @@ class AnsibleActionManager(ActionManager):
                 extra_vars = open(var_file, "r").read()
 
                 if ("yaml" in ext) or ("yml" in ext):
-                    extra_vars = yaml.load(extra_vars)
+                    extra_vars = yaml.safe_load(extra_vars)
                 else:
                     extra_vars = json.loads(extra_vars)
 

--- a/linchpin/provision/library/auth_driver.py
+++ b/linchpin/provision/library/auth_driver.py
@@ -87,7 +87,7 @@ def parse_file(filename, vault_enc, vault_pass):
         out = json.loads(cred_str)
     except Exception:
         try:
-            out = yaml.load(cred_str)
+            out = yaml.safe_load(cred_str)
         except Exception:
             try:
                 config = ConfigDict()

--- a/linchpin/provision/library/output_parser.py
+++ b/linchpin/provision/library/output_parser.py
@@ -56,7 +56,7 @@ def main():
 
     check_file_paths(module, data_file_path)
     content = open(data_file_path, "r").read()
-    c = yaml.load(content)
+    c = yaml.safe_load(content)
     resp = {"path": data_file_path, "content": c}
     if resp["content"] or resp["content"] == []:
         changed = True

--- a/linchpin/provision/roles/azure/library/auth_driver.py
+++ b/linchpin/provision/roles/azure/library/auth_driver.py
@@ -87,7 +87,7 @@ def parse_file(filename, vault_enc, vault_pass):
         out = json.loads(cred_str)
     except Exception:
         try:
-            out = yaml.load(cred_str)
+            out = yaml.safe_load(cred_str)
         except Exception:
             try:
                 config = ConfigDict()

--- a/linchpin/provision/roles/azure/library/output_parser.py
+++ b/linchpin/provision/roles/azure/library/output_parser.py
@@ -56,7 +56,7 @@ def main():
 
     check_file_paths(module, data_file_path)
     content = open(data_file_path, "r").read()
-    c = yaml.load(content)
+    c = yaml.safe_load(content)
     resp = {"path": data_file_path, "content": c}
     if resp["content"] or resp["content"] == []:
         changed = True


### PR DESCRIPTION
This PR aims to update a few references in the code that used the `yaml.load()` function and didn't specify the `Loader` argument to use. Instead, the code has been changed to use the `yaml.safe_load()` function. The change is required because starting from PyYAML 6.0, the `Loader` argument is now mandatory for the `load()` call.

Here is an example of the output of running linchpin with PyYAML 6.0:

```
Error executing hook: 'load() missing 1 required positional argument: 'Loader''
```

The `safe_load()` function uses the `SafeLoader` loader, which is [considered to be safe](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning) for loading untrusted input. 

The PyYAML library has deprecated the `yaml.load()` without the `Loader` argument as it considers it insecure when [not specifying the loader argument](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

Note: there are references in the code that uses the `FullLoader` as the argument to the `yaml.load()` call. This loader is [not safe to use](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning). Let me know if the references should be changed to use the `SafeLoader` instead, so I can add them to this PR. For the time being, I will only change those that are not compatible with PyYAML 6.0 because of the deprecation.

Signed-off-by: Jordi Gil <jgil@redhat.com>