### PR TITLE
Add kernel panic ignore parameter for the beaker provider.

### DIFF
--- a/docs/source/beaker.rst
+++ b/docs/source/beaker.rst
@@ -120,6 +120,8 @@ describes the available recipesets options.
 |                     |            |          | fs        | false        | string       |
 |                     |            |          | type      | false        | string       |
 +---------------------+------------+----------+-----------------------------------------+
+| ignore_panic        | false      | boolean  | N/A                                     |
++---------------------+------------+----------+-----------------------------------------+
 
 Additional Dependencies
 -----------------------

--- a/linchpin/provision/library/bkr_server.py
+++ b/linchpin/provision/library/bkr_server.py
@@ -152,6 +152,11 @@ chmod go-w /root /root/.ssh /root/.ssh/authorized_keys
             # Create Base Recipe
             recipe_template = BeakerRecipe(*args, **kwargs)
 
+            # Add <watchdog panic="ignore"/> to the job XML
+            ignore_panic = kwargs.get("ignore_panic", False)
+            if ignore_panic:
+                recipe_template.add_ignore_panic()
+
             # Add Host Requirements
             for requirement in hostrequires:
                 if 'force' in requirement:

--- a/linchpin/provision/roles/beaker/files/schema.json
+++ b/linchpin/provision/roles/beaker/files/schema.json
@@ -40,6 +40,7 @@
                                 "kernel_options": { "type": "string", "required": false },
                                 "kernel_options_post": { "type": "string", "required": false },
                                 "reserve_duration": { "type": "integer", "required": false },
+                                "ignore_panic": { "type": "boolean", "required": false },
                                 "taskparam": {
                                     "type": "list",
                                     "required": false,


### PR DESCRIPTION
This PR adds a new field called `ignore_panic` in the `recipesets` schema for the beaker provider. Its default value is `False`.

Adding `ignore_panic: True` in the PinFile will call the `add_ignore_panic` method provided by the beaker client libraries and the resulting beaker XML will have a new line `<watchdog panic="ignore"/>` added to it.

Usage:
```
---
topology_name: "bkr-new"
resource_groups:
  - resource_group_name: "bkr-new"
    resource_group_type: beaker
    resource_definitions:
      - role: bkr_server
        whiteboard: Provisioned with linchpin
        recipesets:
          - distro: RHEL-8.5
            name: rheltest
            arch: x86_64
            count: 1
            ignore_panic: True
```
